### PR TITLE
Stateful testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,7 @@ repos:
       - id: mypy
         exclude: ^(docs/|test/).*$
         args: ["--ignore-missing-imports"]
+        additional_dependencies: [attrs~=19.3]
 
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.4.4

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Added
+~~~~~
+
+- Stateful testing by inferring endpoint's dependencies
+
 Changed
 ~~~~~~~
 

--- a/src/schemathesis/__init__.py
+++ b/src/schemathesis/__init__.py
@@ -4,5 +4,6 @@ from .cli import register_check
 from .constants import __version__
 from .loaders import from_dict, from_file, from_path, from_pytest_fixture, from_uri, from_wsgi
 from .models import Case
+from .runner.impl.core import update_state
 
 init_default_strategies()

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -18,7 +18,17 @@ from .models import Case, Endpoint, Requirement
 from .types import Hook
 
 PARAMETERS = frozenset(
-    ("path_parameters", "headers", "cookies", "query", "body", "form_data", "modified_path_parameters", "modified_body")
+    (
+        "path_parameters",
+        "headers",
+        "cookies",
+        "query",
+        "body",
+        "form_data",
+        "modified_path_parameters",
+        "modified_body",
+        "modified_form_data",
+    )
 )
 SCHEMA_DATATYPE = {"string": (str,), "number": (int, float), "object": (dict,), "array": (list,), "boolean": (bool,)}
 SLASH = "/"
@@ -111,14 +121,20 @@ def strategy_with_example(
             parameters["body"] = parameters["modified_body"]
         if "modified_path_parameters" in parameters:
             parameters["path_parameters"] = parameters["modified_path_parameters"]
+        if "modified_form_data" in parameters:
+            parameters["form_data"] = parameters["modified_form_data"]
         if "modified_body" in strategies:
             strategies["body"] = strategies["modified_body"]
         if "modified_path_parameters" in strategies:
             strategies["path_parameters"] = strategies["modified_path_parameters"]
+        if "modified_form_data" in strategies:
+            strategies["form_data"] = strategies["modified_form_data"]
     parameters.pop("modified_body", None)
     parameters.pop("modified_path_parameters", None)
+    parameters.pop("modified_form_data", None)
     strategies.pop("modified_body", None)
     strategies.pop("modified_path_parameters", None)
+    strategies.pop("modified_form_data", None)
     return _get_case_strategy(endpoint, parameters, strategies)
 
 

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -3,7 +3,7 @@ import asyncio
 import re
 from base64 import b64encode
 from functools import partial
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 from urllib.parse import quote_plus
 
 import hypothesis
@@ -14,19 +14,28 @@ from . import utils
 from ._compat import handle_warnings
 from .exceptions import InvalidSchema
 from .hooks import get_hook
-from .models import Case, Endpoint
+from .models import Case, Endpoint, Requirement
 from .types import Hook
 
-PARAMETERS = frozenset(("path_parameters", "headers", "cookies", "query", "body", "form_data"))
+PARAMETERS = frozenset(
+    ("path_parameters", "headers", "cookies", "query", "body", "form_data", "modified_path_parameters", "modified_body")
+)
+SCHEMA_DATATYPE = {"string": (str,), "number": (int, float), "object": (dict,), "array": (list,), "boolean": (bool,)}
 SLASH = "/"
 
 
 def create_test(
-    endpoint: Endpoint, test: Callable, settings: Optional[hypothesis.settings] = None, seed: Optional[int] = None,
+    endpoint: Endpoint,
+    test: Callable,
+    settings: Optional[hypothesis.settings] = None,
+    seed: Optional[int] = None,
+    stateful: bool = False,
 ) -> Callable:
     """Create a Hypothesis test."""
     hooks = getattr(test, "_schemathesis_hooks", None)
-    strategy = endpoint.as_strategy(hooks=hooks)
+    strategy = (  # pylint: disable=consider-using-ternary
+        stateful and _get_example_from_dependency(endpoint, True) or endpoint.as_strategy(hooks=hooks)
+    )
     wrapped_test = hypothesis.given(case=strategy)(test)
     if seed is not None:
         wrapped_test = hypothesis.seed(seed)(wrapped_test)
@@ -35,14 +44,21 @@ def create_test(
         wrapped_test.hypothesis.inner_test = make_async_test(original_test)  # type: ignore
     if settings is not None:
         wrapped_test = settings(wrapped_test)
-    return add_examples(wrapped_test, endpoint)
+    if stateful:
+        return wrapped_test
+    wrapped_test = add_examples(wrapped_test, endpoint, get_example)
+    return add_examples(wrapped_test, endpoint, get_example_from_dependency)
 
 
 def make_test_or_exception(
-    endpoint: Endpoint, func: Callable, settings: Optional[hypothesis.settings] = None, seed: Optional[int] = None
+    endpoint: Endpoint,
+    func: Callable,
+    settings: Optional[hypothesis.settings] = None,
+    seed: Optional[int] = None,
+    stateful: bool = False,
 ) -> Union[Callable, InvalidSchema]:
     try:
-        return create_test(endpoint, func, settings, seed=seed)
+        return create_test(endpoint, func, settings, seed=seed, stateful=stateful)
     except InvalidSchema as exc:
         return exc
 
@@ -70,26 +86,178 @@ def make_async_test(test: Callable) -> Callable:
     return async_run
 
 
-def get_example(endpoint: Endpoint) -> Optional[Case]:
+def get_example(endpoint: Endpoint, modify_schema: bool = False) -> Optional[Case]:
+    with handle_warnings():
+        example = _get_example(endpoint, modify_schema)
+        return example.example() if example else None
+
+
+def get_example_from_dependency(endpoint: Endpoint, modify_schema: bool = False) -> Optional[Case]:
+    with handle_warnings():
+        example = _get_example_from_dependency(endpoint, modify_schema)
+        return example.example() if example else None
+
+
+def strategy_with_example(
+    endpoint: Endpoint, parameters: Dict[str, Any], modify_schema: bool = False
+) -> Optional[st.SearchStrategy]:
+    strategies = {
+        other: from_schema(getattr(endpoint, other))
+        for other in PARAMETERS - set(parameters)
+        if getattr(endpoint, other) is not None
+    }
+    if modify_schema:
+        if "modified_body" in parameters:
+            parameters["body"] = parameters["modified_body"]
+        if "modified_path_parameters" in parameters:
+            parameters["path_parameters"] = parameters["modified_path_parameters"]
+        if "modified_body" in strategies:
+            strategies["body"] = strategies["modified_body"]
+        if "modified_path_parameters" in strategies:
+            strategies["path_parameters"] = strategies["modified_path_parameters"]
+    parameters.pop("modified_body", None)
+    parameters.pop("modified_path_parameters", None)
+    strategies.pop("modified_body", None)
+    strategies.pop("modified_path_parameters", None)
+    return _get_case_strategy(endpoint, parameters, strategies)
+
+
+def _get_example(endpoint: Endpoint, modify_schema: bool = False) -> Optional[st.SearchStrategy]:
     static_parameters = {}
+    body_example = False
     for name in PARAMETERS:
         parameter = getattr(endpoint, name)
         if parameter is not None and "example" in parameter:
             static_parameters[name] = parameter["example"]
-    if static_parameters:
-        with handle_warnings():
-            strategies = {
-                other: from_schema(getattr(endpoint, other))
-                for other in PARAMETERS - set(static_parameters)
-                if getattr(endpoint, other) is not None
-            }
-            return _get_case_strategy(endpoint, static_parameters, strategies).example()
+        elif modify_schema and name.startswith("modified") and parameter is not None and "properties" in parameter:
+            properties = parameter.get("properties", {})
+            for key, val in properties.items():
+                if "example" in val and "enum" not in val:
+                    properties[key]["enum"] = [properties[key]["example"]]
+                    body_example = True
+                if "items" in val and "example" in val["items"] and "enum" not in val["items"]:
+                    properties[key]["items"]["enum"] = [properties[key]["items"]["example"]]
+                    body_example = True
+
+    if static_parameters or body_example:
+        return strategy_with_example(endpoint, static_parameters, modify_schema)
     return None
 
 
-def add_examples(test: Callable, endpoint: Endpoint) -> Callable:
+def _get_example_from_dependency(endpoint: Endpoint, modify_schema: bool = False) -> Optional[st.SearchStrategy]:
+    static_parameters = {}
+    body = {}
+    if not endpoint.schema.state.requirements:
+        return _get_example(endpoint, modify_schema)
+    for param, endpoint_list in endpoint.dependencies.items():
+        requirement = endpoint.schema.state.requirements[param]
+        if requirement.values:
+            continue
+        _update_requirements(requirement, endpoint, param, endpoint_list)
+    for name in PARAMETERS:
+        parameter = getattr(endpoint, name)
+        for key, req in endpoint.schema.state.requirements.items():
+            if req.values and parameter is not None and key in parameter:
+                static_parameters[name] = req.values[-1]
+            if (
+                modify_schema
+                and name.startswith("modified")
+                and req.values
+                and parameter is not None
+                and key in parameter.get("properties", {})
+            ):
+                # inject example value in request body
+                body = parameter["properties"][key].get("items") or parameter["properties"][key]
+                if req.is_fuzzable:
+                    _inject_fuzzable(body, req.values)
+                else:
+                    _inject_non_fuzzable(body, req.values)
+                if (  # pylint: disable=unidiomatic-typecheck
+                    "type" in body
+                    and type(req.values[0]) not in SCHEMA_DATATYPE.get(body["type"], [])
+                    and "items" in parameter["properties"][key]
+                ):
+                    # if type of key param is different from dependency
+                    # and requested param is of type list (items),
+                    # iter the response from dependency and use first value
+                    body["enum"] = [next(iter(req.values[0]))]
+    if static_parameters or body:
+        return strategy_with_example(endpoint, static_parameters, modify_schema)
+    return _get_example(endpoint, modify_schema)
+
+
+def _update_requirements(
+    requirement: Requirement, target_endpoint: Endpoint, param: str, endpoint_list: List[Endpoint]
+) -> None:
+    if not target_endpoint.schema.state.requirements:
+        return
+    for dependency in endpoint_list:
+        if requirement.values:
+            break
+        example_st = _get_example(dependency)
+        random_st = get_case_strategy(dependency)
+        with handle_warnings():
+            example = (example_st or random_st).example()
+        try:
+            response = example.call()
+        except ValueError:
+            # missing base_url
+            response = None
+        if response and (response.status_code - 200) < 100 and response.json():
+            for key, value in utils.json_traverse(response.json()):
+                if value and key == param:
+                    target_endpoint.schema.state.requirements[key].append(value)
+                    break
+
+
+def _inject_non_fuzzable(body: dict, items: List) -> None:
+    if "type" in body or "enum" in body:
+        body["enum"] = items
+    if "oneOf" in body:
+        enum_in_body = any(["enum" in (x.get("items") or x) for x in body["oneOf"]])
+        for oneof in body["oneOf"]:
+            body_oneof = oneof.get("items") or oneof
+            if ("enum" in body_oneof) == enum_in_body:
+                body_oneof["enum"] = items
+            elif enum_in_body and "enum" not in body_oneof:
+                body["oneOf"].remove(oneof)
+
+
+def _inject_fuzzable(body: dict, items: List) -> None:
+    if "type" in body:
+        body["oneOf"] = [{"type": body["type"]}, {"enum": "NOT_SET"}]
+        del body["type"]
+        body["oneOf"][1]["enum"] = items
+        if "enum" in body:
+            del body["enum"]
+    elif "oneOf" in body:
+        if any(["enum" in (x.get("items") or x) for x in body["oneOf"]]):
+            # update enum
+            # make sure it is still fuzzable
+            type_present = False  # [{"type": type}, ...]
+            needed_type = None
+            for oneof in body["oneOf"]:
+                body_oneof = oneof.get("items") or oneof
+                if "enum" in body_oneof:
+                    body_oneof["enum"] = items
+                    needed_type = body_oneof.get("enum")
+                elif "type" in body_oneof:
+                    type_present = True
+            if not type_present:
+                body["oneOf"].append({"type": needed_type or "string"})
+        else:
+            for oneof in body["oneOf"]:
+                body_oneof = oneof.get("items") or oneof
+                if "enum" not in body_oneof:
+                    body_oneof["oneOf"] = [{"type": body_oneof["type"]}, {"enum": "NOT_SET"}]
+                    del body_oneof["type"]
+                    body_oneof = body_oneof["oneOf"][1]
+                body_oneof["enum"] = items
+
+
+def add_examples(test: Callable, endpoint: Endpoint, get_example_func: Callable) -> Callable:
     """Add examples to the Hypothesis test, if they are specified in the schema."""
-    example = get_example(endpoint)
+    example = get_example_func(endpoint)
     if example:
         test = hypothesis.example(case=example)(test)
     return test
@@ -129,6 +297,8 @@ def get_case_strategy(endpoint: Endpoint, hooks: Optional[Dict[str, Hook]] = Non
     static_kwargs: Dict[str, Any] = {"endpoint": endpoint}
     try:
         for parameter in PARAMETERS:
+            if parameter.startswith("modified"):
+                continue
             value = getattr(endpoint, parameter)
             if value is not None:
                 if parameter == "path_parameters":

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -144,6 +144,9 @@ def schemathesis(pre_run: Optional[str] = None) -> None:
     type=click.Choice([item.name for item in hypothesis.Verbosity]),
     callback=callbacks.convert_verbosity,
 )
+@click.option(
+    "--stateful", help="Create tests chaining endpoint's dependencies.", type=bool, default=False, is_flag=True,
+)
 def run(  # pylint: disable=too-many-arguments
     schema: str,
     auth: Optional[Tuple[str, str]],
@@ -168,6 +171,7 @@ def run(  # pylint: disable=too-many-arguments
     hypothesis_suppress_health_check: Optional[List[hypothesis.HealthCheck]] = None,
     hypothesis_seed: Optional[int] = None,
     hypothesis_verbosity: Optional[hypothesis.Verbosity] = None,
+    stateful: bool = False,
 ) -> None:
     """Perform schemathesis test against an API specified by SCHEMA.
 
@@ -196,6 +200,7 @@ def run(  # pylint: disable=too-many-arguments
         checks=selected_checks,
         workers_num=workers_num,
         validate_schema=validate_schema,
+        stateful=stateful,
         hypothesis_deadline=hypothesis_deadline,
         hypothesis_derandomize=hypothesis_derandomize,
         hypothesis_max_examples=hypothesis_max_examples,

--- a/src/schemathesis/loaders.py
+++ b/src/schemathesis/loaders.py
@@ -15,7 +15,7 @@ from .exceptions import HTTPError
 from .lazy import LazySchema
 from .schemas import BaseSchema, OpenApi30, SwaggerV20
 from .types import Filter, PathLike
-from .utils import NOT_SET, StringDatesYAMLLoader, WSGIResponse, get_base_url
+from .utils import NOT_SET, NotSet, StringDatesYAMLLoader, WSGIResponse, get_base_url
 
 
 def from_path(
@@ -27,6 +27,7 @@ def from_path(
     *,
     app: Any = None,
     validate_schema: bool = True,
+    stateful: bool = False,
 ) -> BaseSchema:
     """Load a file from OS path and parse to schema instance."""
     with open(path) as fd:
@@ -39,6 +40,7 @@ def from_path(
             tag=tag,
             app=app,
             validate_schema=validate_schema,
+            stateful=stateful,
         )
 
 
@@ -51,6 +53,7 @@ def from_uri(
     *,
     app: Any = None,
     validate_schema: bool = True,
+    stateful: bool = False,
     **kwargs: Any,
 ) -> BaseSchema:
     """Load a remote resource and parse to schema instance."""
@@ -71,6 +74,7 @@ def from_uri(
         tag=tag,
         app=app,
         validate_schema=validate_schema,
+        stateful=stateful,
     )
 
 
@@ -84,6 +88,7 @@ def from_file(
     *,
     app: Any = None,
     validate_schema: bool = True,
+    stateful: bool = False,
     **kwargs: Any,  # needed in runner to have compatible API across all loaders
 ) -> BaseSchema:
     """Load a file content and parse to schema instance.
@@ -100,6 +105,7 @@ def from_file(
         tag=tag,
         app=app,
         validate_schema=validate_schema,
+        stateful=stateful,
     )
 
 
@@ -113,6 +119,7 @@ def from_dict(
     *,
     app: Any = None,
     validate_schema: bool = True,
+    stateful: bool = False,
 ) -> BaseSchema:
     """Get a proper abstraction for the given raw schema."""
     if "swagger" in raw_schema:
@@ -126,6 +133,7 @@ def from_dict(
             tag=tag,
             app=app,
             validate_schema=validate_schema,
+            stateful=stateful,
         )
 
     if "openapi" in raw_schema:
@@ -139,6 +147,7 @@ def from_dict(
             tag=tag,
             app=app,
             validate_schema=validate_schema,
+            stateful=stateful,
         )
     raise ValueError("Unsupported schema type")
 
@@ -156,9 +165,10 @@ def from_pytest_fixture(
     method: Optional[Filter] = NOT_SET,
     endpoint: Optional[Filter] = NOT_SET,
     tag: Optional[Filter] = NOT_SET,
+    stateful: Union[bool, NotSet] = NOT_SET,
 ) -> LazySchema:
     """Needed for a consistent library API."""
-    return LazySchema(fixture_name, method=method, endpoint=endpoint, tag=tag)
+    return LazySchema(fixture_name, method=method, endpoint=endpoint, tag=tag, stateful=stateful)  # type: ignore
 
 
 def from_wsgi(
@@ -169,6 +179,7 @@ def from_wsgi(
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
     validate_schema: bool = True,
+    stateful: bool = False,
     **kwargs: Any,
 ) -> BaseSchema:
     kwargs.setdefault("headers", {}).setdefault("User-Agent", USER_AGENT)
@@ -187,6 +198,7 @@ def from_wsgi(
         tag=tag,
         app=app,
         validate_schema=validate_schema,
+        stateful=stateful,
     )
 
 
@@ -205,6 +217,7 @@ def from_aiohttp(
     tag: Optional[Filter] = None,
     *,
     validate_schema: bool = True,
+    stateful: bool = False,
     **kwargs: Any,
 ) -> BaseSchema:
     from .extra._aiohttp import run_server  # pylint: disable=import-outside-toplevel
@@ -215,5 +228,12 @@ def from_aiohttp(
     if not base_url:
         base_url = app_url
     return from_uri(
-        url, base_url=base_url, method=method, endpoint=endpoint, tag=tag, validate_schema=validate_schema, **kwargs
+        url,
+        base_url=base_url,
+        method=method,
+        endpoint=endpoint,
+        tag=tag,
+        validate_schema=validate_schema,
+        stateful=stateful,
+        **kwargs,
     )

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -33,6 +33,7 @@ def prepare(  # pylint: disable=too-many-arguments
     tag: Optional[Filter] = None,
     app: Optional[str] = None,
     validate_schema: bool = True,
+    stateful: bool = False,
     # Hypothesis-specific configuration
     hypothesis_deadline: Optional[Union[int, NotSet]] = None,
     hypothesis_derandomize: Optional[bool] = None,
@@ -68,6 +69,7 @@ def prepare(  # pylint: disable=too-many-arguments
         tag=tag,
         app=app,
         validate_schema=validate_schema,
+        stateful=stateful,
         checks=checks,
         hypothesis_options=hypothesis_options,
         seed=seed,
@@ -109,6 +111,7 @@ def execute_from_schema(
     tag: Optional[Filter] = None,
     app: Optional[str] = None,
     validate_schema: bool = True,
+    stateful: bool = False,
     checks: Iterable[CheckFunction],
     workers_num: int = 1,
     hypothesis_options: Dict[str, Any],
@@ -133,6 +136,7 @@ def execute_from_schema(
             loader=loader,
             app=app,
             validate_schema=validate_schema,
+            stateful=stateful,
             auth=auth,
             auth_type=auth_type,
             headers=headers,
@@ -203,6 +207,7 @@ def load_schema(
     loader: Callable = loaders.from_uri,
     app: Any = None,
     validate_schema: bool = True,
+    stateful: bool = False,
     # Network request parameters
     auth: Optional[Tuple[str, str]] = None,
     auth_type: Optional[str] = None,
@@ -230,7 +235,7 @@ def load_schema(
     if loader is loaders.from_uri and loader_options.get("auth"):
         loader_options["auth"] = get_requests_auth(loader_options["auth"], loader_options.pop("auth_type", None))
 
-    return loader(schema_uri, validate_schema=validate_schema, **loader_options)
+    return loader(schema_uri, validate_schema=validate_schema, **loader_options, stateful=stateful)
 
 
 def prepare_hypothesis_options(  # pylint: disable=too-many-arguments

--- a/src/schemathesis/runner/impl/solo.py
+++ b/src/schemathesis/runner/impl/solo.py
@@ -18,7 +18,13 @@ class SingleThreadRunner(BaseRunner):
         with get_session(auth, self.headers) as session:
             for endpoint, test in self.schema.get_all_tests(network_test, self.hypothesis_settings, self.seed):
                 for event in run_test(
-                    endpoint, test, self.checks, results, session=session, request_timeout=self.request_timeout,
+                    endpoint,
+                    test,
+                    self.checks,
+                    results,
+                    session=session,
+                    request_timeout=self.request_timeout,
+                    stateful=self.schema.stateful,
                 ):
                     yield event
                     if isinstance(event, events.Interrupted):
@@ -30,7 +36,14 @@ class SingleThreadWSGIRunner(SingleThreadRunner):
     def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
         for endpoint, test in self.schema.get_all_tests(wsgi_test, self.hypothesis_settings, self.seed):
             for event in run_test(
-                endpoint, test, self.checks, results, auth=self.auth, auth_type=self.auth_type, headers=self.headers,
+                endpoint,
+                test,
+                self.checks,
+                results,
+                auth=self.auth,
+                auth_type=self.auth_type,
+                headers=self.headers,
+                stateful=self.schema.stateful,
             ):
                 yield event
                 if isinstance(event, events.Interrupted):

--- a/src/schemathesis/runner/serialization.py
+++ b/src/schemathesis/runner/serialization.py
@@ -80,6 +80,7 @@ class SerializedTestResult:
     checks: List[SerializedCheck] = attr.ib()  # pragma: no mutate
     logs: List[str] = attr.ib()  # pragma: no mutate
     errors: List[SerializedError] = attr.ib()  # pragma: no mutate
+    dep_results: List = attr.ib(factory=list)  # pragma: no mutate
 
     @classmethod
     def from_test_result(cls, result: TestResult) -> "SerializedTestResult":
@@ -95,4 +96,5 @@ class SerializedTestResult:
             checks=[SerializedCheck.from_check(check) for check in result.checks],
             logs=[formatter.format(record) for record in result.logs],
             errors=[SerializedError.from_error(*error) for error in result.errors],
+            dep_results=[cls.from_test_result(result) for result in result.dep_results],
         )

--- a/test/cli/output/test_default.py
+++ b/test/cli/output/test_default.py
@@ -165,7 +165,9 @@ def test_display_single_failure(capsys, swagger_20, endpoint, body):
         endpoint, [success, success, success, failure, failure, models.Check("different_check", models.Status.success)]
     )
     # When this failure is displayed
-    default.display_failures_for_single_test(SerializedTestResult.from_test_result(test_statistic))
+    result = SerializedTestResult.from_test_result(test_statistic)
+    checks = default._get_unique_failures(result.checks)
+    default.display_failures_for_single_test(result, checks)
     out = capsys.readouterr().out
     lines = out.split("\n")
     # Then the endpoint name is displayed as a subsection

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -205,6 +205,7 @@ def test_commands_run_help(cli):
         "",
         "  --hypothesis-verbosity [quiet|normal|verbose|debug]",
         "                                  Verbosity level of Hypothesis messages.",
+        "  --stateful                      Create tests chaining endpoint's dependencies.",
         "  -h, --help                      Show this message and exit.",
     ]
 
@@ -262,6 +263,7 @@ def test_execute_arguments(cli, mocker, simple_schema, args, expected):
         "tag": (),
         "schema_uri": SCHEMA_URI,
         "validate_schema": True,
+        "stateful": False,
         "loader": from_uri,
         "hypothesis_options": {},
         "workers_num": 1,
@@ -309,6 +311,7 @@ def test_load_schema_arguments(cli, mocker, args, expected):
         "method": (),
         "tag": (),
         "validate_schema": True,
+        "stateful": False,
         **expected,
     }
 

--- a/test/cli/test_crashes.py
+++ b/test/cli/test_crashes.py
@@ -62,6 +62,7 @@ def csv_strategy(enum):
             "workers": st.integers(min_value=1, max_value=64),
             "request-timeout": st.integers(),
             "validate-schema": st.booleans(),
+            "stateful": st.booleans(),
             "hypothesis-deadline": st.integers() | st.none(),
             "hypothesis-max-examples": st.integers(),
             "hypothesis-report-multiple-bugs": st.booleans(),

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -134,6 +134,7 @@ def testdir(testdir):
         tag=None,
         pytest_plugins=("aiohttp.pytest_plugin",),
         validate_schema=True,
+        stateful=False,
         schema=None,
         schema_name="simple_swagger.yaml",
         **kwargs,
@@ -146,13 +147,14 @@ def testdir(testdir):
         from test.utils import *
         from hypothesis import given, settings, HealthCheck
         raw_schema = {schema}
-        schema = schemathesis.from_dict(raw_schema, method={method}, endpoint={endpoint}, tag={tag}, validate_schema={validate_schema})
+        schema = schemathesis.from_dict(raw_schema, method={method}, endpoint={endpoint}, tag={tag}, validate_schema={validate_schema}, stateful={stateful})
         """.format(
                 schema=schema,
                 method=repr(method),
                 endpoint=repr(endpoint),
                 tag=repr(tag),
                 validate_schema=repr(validate_schema),
+                stateful=repr(stateful),
             )
         )
         module = testdir.makepyfile(preparation, content)

--- a/test/data/stateful_v2.yaml
+++ b/test/data/stateful_v2.yaml
@@ -1,0 +1,96 @@
+swagger: '2.0'
+info:
+  title: REST API
+  version: 0.0.1
+paths:
+  /systems:
+    get:
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/systems'
+      description: Get systems
+    patch:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - description: Input json
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/system_request'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/updated'
+      description: Change system's name and fqdn
+  '/systems/{id}':
+    get:
+      produces:
+        - application/json
+      parameters:
+        - description: System id
+          in: path
+          name: id
+          required: true
+          type: string
+          x-example: 03708698-7921-11ea-b755-48a4720be785
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/systems_fqdn'
+      deprecated: true
+      description: Get fqdn of a system
+definitions:
+  system_request:
+    properties:
+      fqdn:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+    required:
+      - id
+      - name
+      - fqdn
+    type: object
+  systems:
+    properties:
+      data:
+        items:
+          properties:
+            attributes:
+              properties:
+                fqdn:
+                  type: string
+                name:
+                  type: string
+              type: object
+            id:
+              type: string
+          type: object
+        type: array
+    type: object
+  systems_fqdn:
+    properties:
+      fqdn:
+        type: string
+      id:
+        type: string
+    type: object
+  updated:
+    properties:
+      updated:
+        type: string
+    type: object
+x-components: {}

--- a/test/data/stateful_v3.yaml
+++ b/test/data/stateful_v3.yaml
@@ -1,0 +1,96 @@
+openapi: '3.0.0'
+
+info:
+  version: '0.0.1'
+  title: REST API
+
+paths:
+  /systems:
+    get:
+      description: Get systems
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/systems'
+    patch:
+      description: Change system's name and fqdn
+      requestBody:
+        description: Input json
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/system_request'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/updated'
+  '/systems/{id}':
+    get:
+      deprecated: true
+      description: Get fqdn of a system
+      parameters:
+        - name: id
+          description: System id
+          required: true
+          schema:
+            type: string
+          in: path
+          x-example: 03708698-7921-11ea-b755-48a4720be785
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/systems_fqdn'
+components:
+  schemas:
+    systems:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              attributes:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  fqdn:
+                    type: string
+    systems_fqdn:
+      type: object
+      properties:
+        id:
+          type: string
+        fqdn:
+          type: string
+    updated:
+      type: object
+      properties:
+        updated:
+          type: string
+    system_request:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        fqdn:
+          type: string
+      required:
+        - id
+        - name
+        - fqdn

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -14,7 +14,7 @@ def make_endpoint(schema, **kwargs) -> Endpoint:
     return Endpoint("/users", "POST", definition={}, schema=schema, **kwargs)
 
 
-@pytest.mark.parametrize("name", sorted(PARAMETERS))
+@pytest.mark.parametrize("name", sorted(PARAMETERS - {"modified_path_parameters", "modified_body"}))
 def test_get_examples(name, swagger_20):
     example = {"name": "John"}
     endpoint = make_endpoint(

--- a/test/test_parametrization.py
+++ b/test/test_parametrization.py
@@ -180,7 +180,7 @@ def test(request, case):
     result = testdir.runpytest("-v", "-s")
     # Then this example should be used in tests
     result.assert_outcomes(passed=1)
-    result.stdout.re_match_lines([r"Hypothesis calls: 1$"])
+    result.stdout.re_match_lines([r"Hypothesis calls: 2$"])
 
 
 @pytest.mark.parametrize(
@@ -242,7 +242,7 @@ def test(request, case):
     result = testdir.runpytest("-v", "-s")
     # Then this example should be used in tests
     result.assert_outcomes(passed=1)
-    result.stdout.re_match_lines([r"Hypothesis calls: 1$"])
+    result.stdout.re_match_lines([r"Hypothesis calls: 2$"])
 
 
 def test_specified_example_parameter_override(testdir):
@@ -282,7 +282,7 @@ def test(request, case):
     result = testdir.runpytest("-v", "-s")
     # Then this example should be used in tests
     result.assert_outcomes(passed=1)
-    result.stdout.re_match_lines([r"Hypothesis calls: 1$"])
+    result.stdout.re_match_lines([r"Hypothesis calls: 2$"])
 
 
 def test_specified_example_body_media_type_override(testdir):
@@ -326,7 +326,7 @@ def test(request, case):
     result = testdir.runpytest("-v", "-s")
     # Then this example should be used in tests, not the example from the schema
     result.assert_outcomes(passed=1)
-    result.stdout.re_match_lines([r"Hypothesis calls: 1$"])
+    result.stdout.re_match_lines([r"Hypothesis calls: 2$"])
 
 
 def test_multiple_examples_different_locations(testdir):
@@ -372,7 +372,7 @@ def test(request, case):
     result = testdir.runpytest("-v", "-s")
     # Then these examples should be used in tests as a part of a single request, i.e combined
     result.assert_outcomes(passed=1)
-    result.stdout.re_match_lines([r"Hypothesis calls: 1$"])
+    result.stdout.re_match_lines([r"Hypothesis calls: 2$"])
 
 
 def test_multiple_examples_same_location(testdir):
@@ -415,7 +415,7 @@ def test(request, case):
     result = testdir.runpytest("-v", "-s")
     # Then these examples should be used combined in tests
     result.assert_outcomes(passed=1)
-    result.stdout.re_match_lines([r"Hypothesis calls: 1$"])
+    result.stdout.re_match_lines([r"Hypothesis calls: 2$"])
 
 
 def test_deselecting(testdir):
@@ -483,7 +483,7 @@ def test_(request, case):
     result = testdir.runpytest()
     # Then collection phase should fail with error
     result.assert_outcomes(error=1)
-    result.stdout.re_match_lines([r".*Error during collection$"])
+    result.stdout.re_match_lines([r".*error during collection"])
 
 
 @pytest.mark.parametrize("as_kwarg", (True, False))

--- a/test/test_stateful.py
+++ b/test/test_stateful.py
@@ -1,0 +1,81 @@
+import pytest
+
+
+@pytest.fixture(params=["stateful_v2.yaml", "stateful_v3.yaml"])
+def testdir(request, testdir):
+    def make_stateful_test(*args, **kwargs):
+        kwargs["schema_name"] = request.param
+        testdir.make_test(*args, **kwargs)
+
+    testdir.make_stateful_test = make_stateful_test
+
+    def assert_stateful(stateful):
+        passed = 1
+        tests_num = 1
+        if stateful:
+            passed = 6
+            tests_num = 6
+
+        result = testdir.runpytest("-v", "-s")
+        result.assert_outcomes(passed=passed)
+        result.stdout.re_match_lines([rf"Hypothesis calls: {tests_num}"])
+
+    testdir.assert_stateful = assert_stateful
+    testdir.param = request.param  # `request.param` is not available in test for some reason
+
+    return testdir
+
+
+@pytest.mark.parametrize("stateful", (False, True))
+def test_no_dependencies(testdir, stateful):
+    """Test schema without dependent endpoints."""
+    testdir.make_test(
+        f"""
+@schema.parametrize()
+@settings(max_examples=1)
+def test_(request, case):
+    request.config.HYPOTHESIS_CASES += 1
+    assert case.endpoint.schema.stateful == {stateful}
+""",
+        stateful=stateful,
+    )
+    result = testdir.runpytest("-v", "-s")
+    result.assert_outcomes(passed=1)
+    result.stdout.re_match_lines([rf"Hypothesis calls: 1$"])
+
+
+@pytest.mark.parametrize("stateful", (False, True))
+def test_dependencies(testdir, stateful):
+    """Test schema with dependent endpoints."""
+    testdir.make_stateful_test(
+        f"""
+@schema.parametrize(method="PATCH")
+@settings(max_examples=1)
+def test_(request, case):
+    request.config.HYPOTHESIS_CASES += 1
+    assert case.endpoint.schema.stateful == {stateful}
+    if case.endpoint.method == "PATCH":
+        assert case.endpoint.dependency_count
+""",
+        stateful=stateful,
+    )
+    testdir.assert_stateful(stateful)
+
+
+@pytest.mark.parametrize("schema_stateful", (False, True))
+@pytest.mark.parametrize("stateful", (False, True))
+def test_parametrize(testdir, stateful, schema_stateful):
+    """Test schema with dependent endpoints, overwrite `stateful` parameter in schema."""
+    testdir.make_stateful_test(
+        f"""
+@schema.parametrize(method="PATCH", stateful={stateful})
+@settings(max_examples=1)
+def test_(request, case):
+    request.config.HYPOTHESIS_CASES += 1
+    assert case.endpoint.schema.stateful == {stateful}
+    if case.endpoint.method == "PATCH":
+        assert case.endpoint.dependency_count
+""",
+        stateful=schema_stateful,
+    )
+    testdir.assert_stateful(stateful)


### PR DESCRIPTION
Hi,
this PR adds an option to test REST application statefully.

Features:
- determine from schema which endpoints are required to call before the tested endpoint and endpoints that have the same required parameters
- minimize 404s by getting required body/path parameters for the tested endpoint, determine which parameters are really required and which could be fuzzed.
- find issues caused by incorrect modification of a resource e.g.:
  - `PATCH /systems/{id}` with a generated body will modify the resource incorrectly
  - `GET /systems/{id} ` fails because of the previous API call
- modify the schema of an endpoint to add values for required parameters:
  - if the parameter is required, add an enum to the endpoint's schema, e.g.:
    ```
    {
      "type": "string",
      "enum": ["red", "amber", "green"]
    }
    ```
  - if the endpoint is not required, add oneOf with an enum to the schema, e.g.:
    ```
    {
      "oneOf": [
        {"type": "string"},
        {"type": "string", "enum": ["red", "amber", "green"]}
    }
    ```
- hold state of previous tests - previous test results and update list of values for required parameters
- can be executed from CLI using `--stateful` or from pytest by adding `stateful=True` parameter while initializing the schema or by test parametrization.
- add an example from dependent endpoints while creating tests.
