### PR TITLE
chore: Set the default Hypothesis's `deadline` setting for tests with `schema.parametrize` to 500 ms for consistency with the CLI behaviour

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,12 @@ Changelog
 `Unreleased`_
 -------------
 
+Changed
+~~~~~~~
+
+- The default Hypothesis's ``deadline`` setting for tests with ``schema.parametrize`` is set to 500 ms for consistency with
+  the CLI behaviour. `#705`_
+
 `2.3.3`_ - 2020-08-04
 ---------------------
 
@@ -1303,6 +1309,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#705: https://github.com/kiwicom/schemathesis/issues/705
 .. _#692: https://github.com/kiwicom/schemathesis/issues/692
 .. _#684: https://github.com/kiwicom/schemathesis/issues/684
 .. _#675: https://github.com/kiwicom/schemathesis/issues/675

--- a/src/schemathesis/constants.py
+++ b/src/schemathesis/constants.py
@@ -8,3 +8,4 @@ except metadata.PackageNotFoundError:
 
 
 USER_AGENT = f"schemathesis/{__version__}"
+DEFAULT_DEADLINE = 500  # pragma: no mutate

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -10,7 +10,7 @@ from _pytest.logging import LogCaptureHandler, catching_logs
 from requests.auth import HTTPDigestAuth, _basic_auth_str
 
 from ..._hypothesis import make_test_or_exception
-from ...constants import USER_AGENT
+from ...constants import DEFAULT_DEADLINE, USER_AGENT
 from ...exceptions import CheckFailed, InvalidSchema, get_grouped_exception
 from ...hooks import HookContext, get_all_by_name
 from ...models import Case, CheckFunction, Endpoint, Status, TestResult, TestResultSet
@@ -21,7 +21,6 @@ from ...types import RawAuth
 from ...utils import GenericResponse, WSGIResponse, capture_hypothesis_output, format_exception
 from ..targeted import Target
 
-DEFAULT_DEADLINE = 500  # pragma: no mutate
 DEFAULT_STATEFUL_RECURSION_LIMIT = 5  # pragma: no mutate
 
 


### PR DESCRIPTION
Resolves #705 