### PR TITLE
fix: Possible `IndexError` when a user-defined check raises an exception without a message

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,11 @@ Changed
 - Hide ``Case.endpoint`` from representation. Its representation decreases the usability of pytest's output. `#719`_
 - Return registered functions from ``register_target`` and ``register_check`` decorators. `#721`_
 
+Fixed
+~~~~~
+
+- Possible ``IndexError`` when a user-defined check raises an exception without a message. `#718`_
+
 `2.4.0`_ - 2020-09-15
 ---------------------
 
@@ -1341,6 +1346,7 @@ Fixed
 
 .. _#721: https://github.com/schemathesis/schemathesis/issues/721
 .. _#719: https://github.com/schemathesis/schemathesis/issues/719
+.. _#718: https://github.com/schemathesis/schemathesis/issues/718
 .. _#708: https://github.com/schemathesis/schemathesis/issues/708
 .. _#705: https://github.com/schemathesis/schemathesis/issues/705
 .. _#692: https://github.com/schemathesis/schemathesis/issues/692

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -226,8 +226,12 @@ def run_checks(case: Case, checks: Iterable[CheckFunction], result: TestResult, 
             if not skip_check:
                 result.add_success(check_name, case)
         except AssertionError as exc:
+            message = str(exc)
+            if not message:
+                message = f"Check '{check_name}' failed"
+                exc.args = (message,)
             errors.append(exc)
-            result.add_failure(check_name, case, str(exc))
+            result.add_failure(check_name, case, message)
 
     if errors:
         raise get_grouped_exception(*errors)


### PR DESCRIPTION
Fixes #718 