### PR TITLE
refactor: Do not display the check name in the CLI

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,12 @@ Changelog
 `Unreleased`_
 -------------
 
+Changed
+~~~~~~~
+
+- Check name is no longer displayed in the CLI output, since its verbose message is already displayed. This change
+  also simplifies the internal structure of the runner events.
+
 `2.4.1`_ - 2020-09-17
 ---------------------
 

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -77,6 +77,27 @@ class Case:
             return urlunsplit(("http", "localhost", path or "", "", ""))
         return self.base_url
 
+    def as_text_lines(self) -> List[str]:
+        """Textual representation.
+
+        Each component is a separate line.
+        """
+        output = {
+            "Path parameters": self.path_parameters,
+            "Headers": self.headers,
+            "Cookies": self.cookies,
+            "Query": self.query,
+            "Body": self.body,
+            "Form data": self.form_data,
+        }
+        max_length = max(map(len, output))
+        template = f"{{:<{max_length}}} : {{}}"
+        return [
+            template.format(key, value)
+            for key, value in output.items()
+            if (key == "Body" and value is not None) or value not in (None, {})
+        ]
+
     def get_code_to_reproduce(self, headers: Optional[Dict[str, Any]] = None) -> str:
         """Construct a Python code to reproduce this case with `requests`."""
         base_url = self.get_full_base_url()

--- a/src/schemathesis/runner/serialization.py
+++ b/src/schemathesis/runner/serialization.py
@@ -9,29 +9,18 @@ from typing import Any, Dict, List, Optional
 import attr
 
 from ..models import Case, Check, Interaction, Status, TestResult
-from ..types import Body, Cookies, FormData, Headers, PathParameters, Query
 from ..utils import format_exception
 
 
 @attr.s(slots=True)  # pragma: no mutate
 class SerializedCase:
-    requests_code: str = attr.ib()  # pragma: no mutate
-    path_parameters: Optional[PathParameters] = attr.ib(default=None)  # pragma: no mutate
-    headers: Optional[Headers] = attr.ib(default=None)  # pragma: no mutate
-    cookies: Optional[Cookies] = attr.ib(default=None)  # pragma: no mutate
-    query: Optional[Query] = attr.ib(default=None)  # pragma: no mutate
-    body: Optional[Body] = attr.ib(default=None)  # pragma: no mutate
-    form_data: Optional[FormData] = attr.ib(default=None)  # pragma: no mutate
+    text_lines: List[str] = attr.ib()  # pragma: no mutate
+    requests_code: str = attr.ib()
 
     @classmethod
     def from_case(cls, case: Case, headers: Optional[Dict[str, Any]]) -> "SerializedCase":
         return cls(
-            path_parameters=case.path_parameters,
-            headers=case.headers,
-            cookies=case.cookies,
-            query=case.query,
-            body=case.body,
-            form_data=case.form_data,
+            text_lines=case.as_text_lines(),
             requests_code=case.get_code_to_reproduce(headers),
         )
 

--- a/test/cli/output/test_default.py
+++ b/test/cli/output/test_default.py
@@ -181,8 +181,6 @@ def test_display_single_failure(capsys, swagger_20, execution_context, endpoint,
     lines = out.split("\n")
     # Then the endpoint name is displayed as a subsection
     assert " GET: /v1/success " in lines[0]
-    # And check name is displayed in red
-    assert lines[1] == strip_style_win32(click.style("Check           : not_a_server_error", fg="red"))
     # And body should be displayed if it is not None
     if body is None:
         assert "Body" not in out
@@ -274,8 +272,6 @@ def test_display_failures(swagger_20, capsys, execution_context, results_set):
     # And endpoint with a failure is displayed as a subsection
     assert " GET: /v1/api/failure " in out
     assert "Message" in out
-    # And check name is displayed
-    assert "Check           : test" in out
     assert "Run this Python code to reproduce this failure: " in out
     assert "requests.get('http://127.0.0.1:8080/api/failure')" in out
 
@@ -322,11 +318,6 @@ def test_display_internal_error(capsys, execution_context, show_errors_traceback
         out = capsys.readouterr().out.strip()
         assert ("Traceback (most recent call last):" in out) is show_errors_tracebacks
         assert "ZeroDivisionError: division by zero" in out
-
-
-@pytest.mark.parametrize("attribute, expected", (("cookies", "Cookies"), ("path_parameters", "Path parameters")))
-def test_make_verbose_name(attribute, expected):
-    assert default.make_verbose_name(attribute) == expected
 
 
 def test_display_summary(capsys, results_set, swagger_20):

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -1218,7 +1218,7 @@ def test_wsgi_app_missing(testdir, cli):
     assert "Can not import application from the given module" in lines
 
 
-def test_wsgi_app_internal_exception(testdir, cli, caplog):
+def test_wsgi_app_internal_exception(testdir, cli):
     module = testdir.make_importable_pyfile(
         location="""
         from test.apps._flask import create_openapi_app
@@ -1230,13 +1230,13 @@ def test_wsgi_app_internal_exception(testdir, cli, caplog):
     result = cli.run("/schema.yaml", "--app", f"{module.purebasename}:app")
     assert result.exit_code == ExitCode.TESTS_FAILED, result.stdout
     lines = result.stdout.strip().split("\n")
-    assert "== APPLICATION LOGS ==" in lines[34]
-    assert "ERROR in app: Exception on /api/success [GET]" in lines[36]
-    assert lines[52] == "ZeroDivisionError: division by zero"
+    assert "== APPLICATION LOGS ==" in lines[30]
+    assert "ERROR in app: Exception on /api/success [GET]" in lines[32]
+    assert lines[48] == "ZeroDivisionError: division by zero"
 
 
 @pytest.mark.parametrize("args", ((), ("--base-url",)))
-def test_aiohttp_app(openapi_version, request, testdir, cli, loadable_aiohttp_app, args):
+def test_aiohttp_app(openapi_version, request, cli, loadable_aiohttp_app, args):
     # When an URL is passed together with app
     if args:
         args += (request.getfixturevalue("base_url"),)
@@ -1246,7 +1246,7 @@ def test_aiohttp_app(openapi_version, request, testdir, cli, loadable_aiohttp_ap
     assert "1 passed, 1 failed in" in result.stdout
 
 
-def test_wsgi_app_remote_schema(testdir, cli, schema_url, loadable_flask_app):
+def test_wsgi_app_remote_schema(cli, schema_url, loadable_flask_app):
     # When an URL is passed together with app
     result = cli.run(schema_url, "--app", loadable_flask_app)
     # Then the schema should be loaded from that URL
@@ -1254,7 +1254,7 @@ def test_wsgi_app_remote_schema(testdir, cli, schema_url, loadable_flask_app):
     assert "1 passed, 1 failed in" in result.stdout
 
 
-def test_wsgi_app_path_schema(testdir, cli, loadable_flask_app):
+def test_wsgi_app_path_schema(cli, loadable_flask_app):
     # When an existing path to schema is passed together with app
     result = cli.run(SIMPLE_PATH, "--app", loadable_flask_app)
     # Then the schema should be loaded from that path


### PR DESCRIPTION
This change will simplify the typing of protocols in the future and eventually allow us to make more generic structures and accommodate other specs easier