### PR TITLE
feat: Support for stateful testing, using only explicit examples from the schema

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Added
 ~~~~~
 
 - Stateful testing via Open API links for the ``pytest`` runner. `#616`_
+- Support for stateful testing, using only explicit examples from the schema. `#638`_
 
 Changed
 ~~~~~~~
@@ -1369,6 +1370,7 @@ Fixed
 .. _#647: https://github.com/schemathesis/schemathesis/issues/647
 .. _#641: https://github.com/schemathesis/schemathesis/issues/641
 .. _#640: https://github.com/schemathesis/schemathesis/issues/640
+.. _#638: https://github.com/schemathesis/schemathesis/issues/638
 .. _#631: https://github.com/schemathesis/schemathesis/issues/631
 .. _#629: https://github.com/schemathesis/schemathesis/issues/629
 .. _#622: https://github.com/schemathesis/schemathesis/issues/622

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -45,7 +45,7 @@ class Case:
     body: Optional[Body] = attr.ib(default=None)  # pragma: no mutate
     form_data: Optional[FormData] = attr.ib(default=None)  # pragma: no mutate
 
-    feedback: "Feedback" = attr.ib(repr=False, default=None)
+    feedback: Optional["Feedback"] = attr.ib(repr=False, default=None)
 
     @property
     def path(self) -> str:

--- a/test/apps/utils.py
+++ b/test/apps/utils.py
@@ -459,7 +459,7 @@ def _make_openapi_3_schema(endpoints: Tuple[str, ...]) -> Dict:
                         "application/json": {
                             "schema": {
                                 "type": "object",
-                                "properties": {"username": {"type": "string", "minLength": 3}},
+                                "properties": {"username": {"type": "string", "minLength": 3, "example": "John"}},
                                 "required": ["username"],
                             }
                         }


### PR DESCRIPTION
Resolves #638

TODO:
- [ ] Control hypothesis settings for generated tests. Otherwise, if the new test has no examples - nothing will be executed