### PR TITLE
fix: Show a more precise percentage value for tests executed via `from_pytest_fixture`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,11 @@ Added
 
 - Stateful testing via Open API links for the ``pytest`` runner. `#616`_
 
+Fixed
+~~~~~
+
+- Progress percentage in the terminal output for "lazy" schemas. `#636`_
+
 Changed
 ~~~~~~~
 
@@ -1369,6 +1374,7 @@ Fixed
 .. _#647: https://github.com/schemathesis/schemathesis/issues/647
 .. _#641: https://github.com/schemathesis/schemathesis/issues/641
 .. _#640: https://github.com/schemathesis/schemathesis/issues/640
+.. _#636: https://github.com/schemathesis/schemathesis/issues/636
 .. _#631: https://github.com/schemathesis/schemathesis/issues/631
 .. _#629: https://github.com/schemathesis/schemathesis/issues/629
 .. _#622: https://github.com/schemathesis/schemathesis/issues/622

--- a/src/schemathesis/lazy.py
+++ b/src/schemathesis/lazy.py
@@ -61,7 +61,9 @@ class LazySchema:
                 # Changing the node id is required for better reporting - the method and endpoint will appear there
                 node_id = subtests.item._nodeid
                 settings = getattr(test, "_hypothesis_internal_use_settings", None)
-                for _endpoint, sub_test in schema.get_all_tests(func, settings):
+                tests = list(schema.get_all_tests(func, settings))
+                request.session.testscollected += len(tests)
+                for _endpoint, sub_test in tests:
                     actual_test = get_test(sub_test)
                     subtests.item._nodeid = _get_node_name(node_id, _endpoint)
                     run_subtest(_endpoint, fixtures, actual_test, subtests)

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -83,10 +83,9 @@ def test_(request, case):
     result.assert_outcomes(passed=1, failed=1)
     result.stdout.re_match_lines(
         [
-            # Percentage is weird, due to subtest behavior
-            r"test_invalid_endpoint.py::test_[GET:/v1/valid] PASSED                    [100%]",
-            r"test_invalid_endpoint.py::test_[GET:/v1/invalid] FAILED                  [200%]",
-            r"test_invalid_endpoint.py::test_[GET:/v1/users] PASSED                    [300%]",
+            r"test_invalid_endpoint.py::test_[GET:/v1/valid] PASSED                    [ 25%]",
+            r"test_invalid_endpoint.py::test_[GET:/v1/invalid] FAILED                  [ 50%]",
+            r"test_invalid_endpoint.py::test_[GET:/v1/users] PASSED                    [ 75%]",
             r".*1 passed",
         ]
     )


### PR DESCRIPTION
Ref: #636 

It is not a complete solution for that issue but improves the behavior at least partially