### PR TITLE
fix(uri): allows specifying port for base_url

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Changelog
 - New hook to pre-commit, rstcheck, as well as updates to documentation based on rstcheck `#734`_
 - New check for maximum response time and corresponding CLI option ``--max-response-time`` `#716`_
 - New field with information about executed checks in cassettes. `#702`_
+- New ``port`` parameter added to ``from_uri()`` method. `#706`_
 
 **Fixed**
 
@@ -1389,6 +1390,7 @@ Deprecated
 .. _#718: https://github.com/schemathesis/schemathesis/issues/718
 .. _#716: https://github.com/schemathesis/schemathesis/issues/716
 .. _#708: https://github.com/schemathesis/schemathesis/issues/708
+.. _#706: https://github.com/schemathesis/schemathesis/issues/706
 .. _#705: https://github.com/schemathesis/schemathesis/issues/705
 .. _#702: https://github.com/schemathesis/schemathesis/issues/702
 .. _#695: https://github.com/schemathesis/schemathesis/issues/695

--- a/poetry.lock
+++ b/poetry.lock
@@ -263,6 +263,7 @@ webob = ["webob (>=1.8.6,<2)"]
 reference = "e8f3a89a64d75e8668f5f4762b87d34a1840d926"
 type = "git"
 url = "https://github.com/graphql-python/graphql-server-core.git"
+
 [[package]]
 category = "main"
 description = "A library for property-based testing"
@@ -426,7 +427,7 @@ python-versions = ">=3.5"
 version = "8.4.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "multidict implementation"
 name = "multidict"
 optional = false
@@ -780,7 +781,7 @@ version = "0.13.4"
 full = ["aiofiles", "graphene", "itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests", "ujson"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 name = "typing-extensions"
 optional = false
@@ -821,17 +822,20 @@ dev = ["pytest", "pytest-timeout", "coverage", "tox", "sphinx", "pallets-sphinx-
 watchdog = ["watchdog"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Yet another URL library"
 name = "yarl"
 optional = false
 python-versions = ">=3.5"
-version = "1.5.0"
+version = "1.6.0"
 
 [package.dependencies]
 idna = ">=2.0"
 multidict = ">=4.0"
-typing-extensions = ">=3.7.4"
+
+[package.dependencies.typing-extensions]
+python = "<3.8"
+version = ">=3.7.4"
 
 [[package]]
 category = "main"
@@ -847,7 +851,8 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "5f20f362fcd5a079c78125af78b1e7dd60ed46ebc0bb048550667717854cf88a"
+content-hash = "447f1292fdfdfa1193e0c49bd255e289d2d2f4211e1ec98991fbd5c8c56f16d3"
+lock-version = "1.0"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1227,23 +1232,23 @@ werkzeug = [
     {file = "Werkzeug-1.0.1.tar.gz", hash = "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"},
 ]
 yarl = [
-    {file = "yarl-1.5.0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:2657716c1fc998f5f2675c0ee6ce91282e0da0ea9e4a94b584bb1917e11c1559"},
-    {file = "yarl-1.5.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:cf5eb664910d759bbae0b76d060d6e21f8af5098242d66c448bbebaf2a7bfa70"},
-    {file = "yarl-1.5.0-cp35-cp35m-win32.whl", hash = "sha256:875b2a741ce0208f3b818008a859ab5d0f461e98a32bbdc6af82231a9e761c55"},
-    {file = "yarl-1.5.0-cp35-cp35m-win_amd64.whl", hash = "sha256:1707230e1ea48ea06a3e20acb4ce05a38d2465bd9566c21f48f6212a88e47536"},
-    {file = "yarl-1.5.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:9a592c4aa642249e9bdaf76897d90feeb08118626b363a6be8788a9b300274b5"},
-    {file = "yarl-1.5.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:f058b6541477022c7b54db37229f87dacf3b565de4f901ff5a0a78556a174fea"},
-    {file = "yarl-1.5.0-cp36-cp36m-win32.whl", hash = "sha256:5d410f69b4f92c5e1e2a8ffb73337cd8a274388c6975091735795588a538e605"},
-    {file = "yarl-1.5.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5bbcb195da7de57f4508b7508c33f7593e9516e27732d08b9aad8586c7b8c384"},
-    {file = "yarl-1.5.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:a1772068401d425e803999dada29a6babf041786e08be5e79ef63c9ecc4c9575"},
-    {file = "yarl-1.5.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1f269e8e6676193a94635399a77c9059e1826fb6265c9204c9e5a8ccd36006e1"},
-    {file = "yarl-1.5.0-cp37-cp37m-win32.whl", hash = "sha256:431faa6858f0ea323714d8b7b4a7da1db2eeb9403607f0eaa3800ab2c5a4b627"},
-    {file = "yarl-1.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:b325fefd574ebef50e391a1072d1712a60348ca29c183e1d546c9d87fec2cd32"},
-    {file = "yarl-1.5.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:b065a5c3e050395ae563019253cc6c769a50fd82d7fa92d07476273521d56b7c"},
-    {file = "yarl-1.5.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:66b4f345e9573e004b1af184bc00431145cf5e089a4dcc1351505c1f5750192c"},
-    {file = "yarl-1.5.0-cp38-cp38-win32.whl", hash = "sha256:9a3266b047d15e78bba38c8455bf68b391c040231ca5965ef867f7cbbc60bde5"},
-    {file = "yarl-1.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:f5cfed0766837303f688196aa7002730d62c5cc802d98c6395ea1feb87252727"},
-    {file = "yarl-1.5.0.tar.gz", hash = "sha256:5c82f5b1499342339f22c83b97dbe2b8a09e47163fab86cd934a8dd46620e0fb"},
+    {file = "yarl-1.6.0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:db9eb8307219d7e09b33bcb43287222ef35cbcf1586ba9472b0a4b833666ada1"},
+    {file = "yarl-1.6.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:e31fef4e7b68184545c3d68baec7074532e077bd1906b040ecfba659737df188"},
+    {file = "yarl-1.6.0-cp35-cp35m-win32.whl", hash = "sha256:5d84cc36981eb5a8533be79d6c43454c8e6a39ee3118ceaadbd3c029ab2ee580"},
+    {file = "yarl-1.6.0-cp35-cp35m-win_amd64.whl", hash = "sha256:5e447e7f3780f44f890360ea973418025e8c0cdcd7d6a1b221d952600fd945dc"},
+    {file = "yarl-1.6.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:6f6898429ec3c4cfbef12907047136fd7b9e81a6ee9f105b45505e633427330a"},
+    {file = "yarl-1.6.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d088ea9319e49273f25b1c96a3763bf19a882cff774d1792ae6fba34bd40550a"},
+    {file = "yarl-1.6.0-cp36-cp36m-win32.whl", hash = "sha256:b7c199d2cbaf892ba0f91ed36d12ff41ecd0dde46cbf64ff4bfe997a3ebc925e"},
+    {file = "yarl-1.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:67c5ea0970da882eaf9efcf65b66792557c526f8e55f752194eff8ec722c75c2"},
+    {file = "yarl-1.6.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:04a54f126a0732af75e5edc9addeaa2113e2ca7c6fce8974a63549a70a25e50e"},
+    {file = "yarl-1.6.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:fcbe419805c9b20db9a51d33b942feddbf6e7fb468cb20686fd7089d4164c12a"},
+    {file = "yarl-1.6.0-cp37-cp37m-win32.whl", hash = "sha256:c604998ab8115db802cc55cb1b91619b2831a6128a62ca7eea577fc8ea4d3131"},
+    {file = "yarl-1.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c22607421f49c0cb6ff3ed593a49b6a99c6ffdeaaa6c944cdda83c2393c8864d"},
+    {file = "yarl-1.6.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:7ce35944e8e61927a8f4eb78f5bc5d1e6da6d40eadd77e3f79d4e9399e263921"},
+    {file = "yarl-1.6.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:c15d71a640fb1f8e98a1423f9c64d7f1f6a3a168f803042eaf3a5b5022fde0c1"},
+    {file = "yarl-1.6.0-cp38-cp38-win32.whl", hash = "sha256:3cc860d72ed989f3b1f3abbd6ecf38e412de722fb38b8f1b1a086315cf0d69c5"},
+    {file = "yarl-1.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:e32f0fb443afcfe7f01f95172b66f279938fbc6bdaebe294b0ff6747fb6db020"},
+    {file = "yarl-1.6.0.tar.gz", hash = "sha256:61d3ea3c175fe45f1498af868879c6ffeb989d4143ac542163c45538ba5ec21b"},
 ]
 zipp = [
     {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ importlib_metadata = { version = "^1.1", python = "<3.8" }
 werkzeug = ">0.16.0"
 junit-xml = "^1.9"
 starlette = "^0.13.2"
+yarl = "^1.6.0"
 
 [tool.poetry.dev-dependencies]
 coverage = "^5"
@@ -75,7 +76,7 @@ multi_line_output = 3
 default_section = "THIRDPARTY"
 include_trailing_comma = true
 known_first_party = "schemathesis"
-known_third_party = ["_pytest", "aiohttp", "attr", "click", "fastapi", "flask", "graphene", "graphql", "graphql_server", "hypothesis", "hypothesis_graphql", "hypothesis_jsonschema", "jsonschema", "junit_xml", "packaging", "pytest", "pytest_subtests", "requests", "schemathesis", "starlette", "urllib3", "werkzeug", "yaml"]
+known_third_party = ["_pytest", "aiohttp", "attr", "click", "fastapi", "flask", "graphene", "graphql", "graphql_server", "hypothesis", "hypothesis_graphql", "hypothesis_jsonschema", "jsonschema", "junit_xml", "packaging", "pytest", "pytest_subtests", "requests", "schemathesis", "starlette", "urllib3", "werkzeug", "yaml", "yarl"]
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/src/schemathesis/loaders.py
+++ b/src/schemathesis/loaders.py
@@ -10,6 +10,7 @@ from jsonschema import ValidationError
 from starlette.applications import Starlette
 from starlette.testclient import TestClient as ASGIClient
 from werkzeug.test import Client
+from yarl import URL
 
 from .constants import USER_AGENT
 from .exceptions import HTTPError
@@ -54,6 +55,7 @@ def from_uri(
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
     operation_id: Optional[Filter] = None,
+    port: Optional[int] = None,
     *,
     app: Any = None,
     validate_schema: bool = True,
@@ -63,6 +65,8 @@ def from_uri(
     headers = kwargs.setdefault("headers", {})
     if "user-agent" not in {header.lower() for header in headers}:
         kwargs["headers"]["User-Agent"] = USER_AGENT
+    if not base_url and port:
+        base_url = str(URL(uri).with_port(port))
     response = requests.get(uri, **kwargs)
     try:
         response.raise_for_status()

--- a/test/test_loaders.py
+++ b/test/test_loaders.py
@@ -1,6 +1,8 @@
 import json
 
 import pytest
+from requests.models import Response
+from yarl import URL
 
 import schemathesis
 from schemathesis.constants import USER_AGENT
@@ -36,6 +38,27 @@ def test_base_url_override(openapi3_schema_url, url):
     schema = schemathesis.from_uri(openapi3_schema_url, base_url=url)
     endpoint = next(schema.get_all_endpoints())
     assert endpoint.base_url == "http://example.com"
+
+
+def test_port_override(openapi3_schema_url):
+    schema = schemathesis.from_uri(openapi3_schema_url, port=8081)
+    endpoint = next(schema.get_all_endpoints())
+    assert endpoint.base_url == "http://127.0.0.1:8081/schema.yaml"
+
+
+def test_port_override_with_ipv6(openapi3_schema_url, simple_openapi, mocker):
+    resp = Response()
+    resp.status_code = 200
+    resp._content = json.dumps(simple_openapi).encode("utf-8")
+    mocker.patch("requests.get", return_value=resp)
+
+    url = URL(openapi3_schema_url)
+    parts = list(map(int, url.host.split(".")))
+    ipv6_host = "2002:{:02x}{:02x}:{:02x}{:02x}::".format(*parts)
+    ipv6 = url.with_host("[%s]" % ipv6_host)
+    schema = schemathesis.from_uri(str(ipv6), validate_schema=False, port=8081)
+    endpoint = next(schema.get_all_endpoints())
+    assert endpoint.base_url == "http://[2002:7f00:1::]:8081/schema.yaml"
 
 
 def test_unsupported_type():


### PR DESCRIPTION
This patch set adds a new port parameter to .from_uri() when a base_url
is not specified but a port is, it will take the original URL and adjust
the port to the specified one.

Closes: #706

🚨Please review the [guidelines for contributing](https://github.com/schemathesis/schemathesis/blob/master/CONTRIBUTING.rst) to this repository.

### Description
Please explain the changes you made here.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Added a changelog entry
- [ ] Extended the README / documentation, if necessary
