### PR TITLE
fix: `GraphQLCase.call_and_validate` using wrong defaults

### DIFF
--- a/src/schemathesis/specs/graphql/schemas.py
+++ b/src/schemathesis/specs/graphql/schemas.py
@@ -37,8 +37,9 @@ class GraphQLCase(Case):
     def validate_response(
         self,
         response: GenericResponse,
-        checks: Tuple[CheckFunction, ...] = (not_a_server_error,),
+        checks: Tuple[CheckFunction, ...] = (),
     ) -> None:
+        checks = checks or (not_a_server_error,)
         return super().validate_response(response, checks)
 
 

--- a/test/specs/graphql/test_pytest.py
+++ b/test/specs/graphql/test_pytest.py
@@ -12,6 +12,7 @@ def test_(request, case):
     response = case.call()
     assert response.status_code == 200
     case.validate_response(response)
+    case.call_and_validate()
 """,
     )
     result = testdir.runpytest("-v", "-s")


### PR DESCRIPTION
Introduced in d66336ad147f9bdcd724a65e14a967307ed70cad

No changelog entry, because this version wasn't released yet