### PR TITLE
fix: Reusing `case` strategy if additional Hypothesis strategies are used

### DIFF
--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -33,7 +33,7 @@ def create_test(
     else:
         feedback = None
     strategy = endpoint.as_strategy(hooks=hook_dispatcher, feedback=feedback)
-    _given_kwargs = _given_kwargs or {}
+    _given_kwargs = (_given_kwargs or {}).copy()
     _given_kwargs.setdefault("case", strategy)
     wrapped_test = hypothesis.given(*_given_args, **_given_kwargs)(test)
     if seed is not None:

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -151,16 +151,29 @@ def test_schema_given(testdir):
         """
 from hypothesis.strategies._internal.core import DataObject
 
+ENDPOINTS = []
+
 @schema.parametrize()
 @schema.given(data=st.data())
 def test(data, case):
     assert isinstance(data, DataObject)
+    ENDPOINTS.append(f"{case.method} {case.path}")
+
+
+def test_endpoints():
+    assert ENDPOINTS == ['GET /users', 'POST /users']
     """,
+        paths={
+            "/users": {
+                "get": {"responses": {"200": {"description": "OK"}}},
+                "post": {"responses": {"200": {"description": "OK"}}},
+            }
+        },
     )
     # Then its arguments should be proxied to the `hypothesis.given`
     # And be available in the test
     result = testdir.runpytest()
-    result.assert_outcomes(passed=1)
+    result.assert_outcomes(passed=3)
 
 
 def test_invalid_test(testdir):


### PR DESCRIPTION
Otherwise `case.endpoint` will be the same for all tests generated for a test function
