### PR TITLE
Store more information about executed checks in cassettes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Changelog
 - Shortcut for calling & validation. `#738`_
 - New hook to pre-commit, rstcheck, as well as updates to documentation based on rstcheck `#734`_
 - New check for maximum response time and corresponding CLI option ``--max-response-time`` `#716`_
+- New field with information about executed checks in cassettes. `#702`_
 
 **Fixed**
 
@@ -1385,6 +1386,7 @@ Deprecated
 .. _#716: https://github.com/schemathesis/schemathesis/issues/716
 .. _#708: https://github.com/schemathesis/schemathesis/issues/708
 .. _#705: https://github.com/schemathesis/schemathesis/issues/705
+.. _#702: https://github.com/schemathesis/schemathesis/issues/702
 .. _#692: https://github.com/schemathesis/schemathesis/issues/692
 .. _#686: https://github.com/schemathesis/schemathesis/issues/686
 .. _#684: https://github.com/schemathesis/schemathesis/issues/684

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -233,6 +233,10 @@ It might look like this:
       seed: '1'
       elapsed: '0.00123'
       recorded_at: '2020-04-22T17:52:51.275318'
+      checks:
+        - name: 'not_a_server_error'
+          status: 'FAILURE'
+          message: 'Received a response with 5xx status code: 500'
       request:
         uri: 'http://127.0.0.1/api/failure'
         method: 'GET'
@@ -259,6 +263,7 @@ Schemathesis provides the following extra fields:
 - ``http_interactions.status``. Type of test outcome is one of ``SUCCESS``, ``FAILURE``, ``ERROR``.
 - ``http_interactions.seed``. The Hypothesis seed used in that particular case could be used as an argument to ``--hypothesis-seed`` CLI option to reproduce this request.
 - ``http_interactions.elapsed``. Time in seconds that a request took.
+- ``http_interactions.checks``. A list of executed checks and and their status.
 
 To work with the cassette, you could use `yq <https://github.com/mikefarah/yq>`_ or any similar tool.
 Show response body content of first failed interaction:

--- a/test/cli/test_cassettes.py
+++ b/test/cli/test_cassettes.py
@@ -37,6 +37,11 @@ def test_store_cassette(cli, schema_url, cassette_path):
     assert float(cassette["http_interactions"][0]["elapsed"]) >= 0
     data = base64.b64decode(cassette["http_interactions"][0]["response"]["body"]["base64_string"])
     assert data == b'{"success": true}'
+    assert all("checks" in interaction for interaction in cassette["http_interactions"])
+    assert len(cassette["http_interactions"][0]["checks"]) == 1
+    assert cassette["http_interactions"][0]["checks"][0]["name"] == "not_a_server_error"
+    assert cassette["http_interactions"][0]["checks"][0]["status"] == "SUCCESS"
+    assert cassette["http_interactions"][0]["checks"][0]["message"] is None
 
 
 def test_encoding_error(testdir, cli, cassette_path, openapi3_base_url):


### PR DESCRIPTION
🚨Please review the [guidelines for contributing](https://github.com/schemathesis/schemathesis/blob/master/CONTRIBUTING.rst) to this repository.

### Description
Added new field to cassettes that stores information about executed checks.
Related to #702 

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Added a changelog entry
- [x] Extended the README / documentation, if necessary
