### PR TITLE
refactor: Make ``as_requests_kwargs`` and ``as_werkzeug_kwargs`` reuse the same code for headers handling.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,11 @@ Changelog
 
 - Default ``User-Agent`` header in ``Case.call``. `#717`_
 
+**Changed**
+
+- ``Case.as_requests_kwargs`` and ``Case.as_werkzeug_kwargs`` now return the ``User-Agent`` header.
+  This change also affects code snippets for failure reproduction - all snippets will include the ``User-Agent`` header.
+
 `2.5.1`_ - 2020-09-30
 ---------------------
 

--- a/src/schemathesis/specs/graphql/schemas.py
+++ b/src/schemathesis/specs/graphql/schemas.py
@@ -18,14 +18,15 @@ from ...utils import GenericResponse
 
 @attr.s()  # pragma: no mutate
 class GraphQLCase(Case):
-    def as_requests_kwargs(self, base_url: Optional[str] = None) -> Dict[str, Any]:
+    def as_requests_kwargs(
+        self, base_url: Optional[str] = None, headers: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]:
+        final_headers = self._get_headers(headers)
         base_url = self._get_base_url(base_url)
-        return {"method": self.method, "url": base_url, "json": {"query": self.body}, "headers": self.headers}
+        return {"method": self.method, "url": base_url, "json": {"query": self.body}, "headers": final_headers}
 
     def as_werkzeug_kwargs(self, headers: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
-        final_headers = self.headers.copy() if self.headers is not None else {}
-        if headers:
-            final_headers.update(headers)
+        final_headers = self._get_headers(headers)
         return {
             "method": self.method,
             "path": self.endpoint.schema.get_full_path(self.formatted_path),

--- a/test/cli/output/test_default.py
+++ b/test/cli/output/test_default.py
@@ -10,6 +10,7 @@ import schemathesis.cli.context
 from schemathesis import models, runner, utils
 from schemathesis.cli.output import default
 from schemathesis.cli.output.default import display_internal_error
+from schemathesis.constants import USER_AGENT
 from schemathesis.runner.events import Finished, InternalError
 from schemathesis.runner.serialization import SerializedTestResult
 
@@ -273,7 +274,7 @@ def test_display_failures(swagger_20, capsys, execution_context, results_set):
     assert " GET: /v1/api/failure " in out
     assert "Message" in out
     assert "Run this Python code to reproduce this failure: " in out
-    assert "requests.get('http://127.0.0.1:8080/api/failure')" in out
+    assert f"requests.get('http://127.0.0.1:8080/api/failure', headers={{'User-Agent': '{USER_AGENT}'}})" in out
 
 
 @pytest.mark.parametrize("verbosity", (0, 1))

--- a/test/specs/graphql/test_basic.py
+++ b/test/specs/graphql/test_basic.py
@@ -2,6 +2,7 @@ import pytest
 from hypothesis import given, settings
 
 import schemathesis
+from schemathesis.constants import USER_AGENT
 
 
 @pytest.fixture()
@@ -62,7 +63,11 @@ def test_query_strategy(graphql_strategy):
 @pytest.mark.filterwarnings("ignore:.*method is good for exploring strategies.*")
 def test_get_code_to_reproduce(graphql_endpoint, graphql_strategy):
     case = graphql_strategy.example()
-    assert case.get_code_to_reproduce() == f"requests.post('{graphql_endpoint}', json={{'query': {repr(case.body)}}})"
+    assert (
+        case.get_code_to_reproduce() == f"requests.post('{graphql_endpoint}', "
+        f"json={{'query': {repr(case.body)}}}, "
+        f"headers={{'User-Agent': '{USER_AGENT}'}})"
+    )
 
 
 @pytest.mark.filterwarnings("ignore:.*method is good for exploring strategies.*")
@@ -73,5 +78,5 @@ def test_as_werkzeug_kwargs(graphql_strategy):
         "path": "/graphql",
         "query_string": None,
         "json": {"query": case.body},
-        "headers": {},
+        "headers": {"User-Agent": USER_AGENT},
     }


### PR DESCRIPTION
It will also make them return the `User-Agent` header value.