### PR TITLE
fix: Status of individual interactions in VCR cassettes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,8 @@ Changelog
 **Fixed**
 
 - Default ``User-Agent`` header in ``Case.call``. `#717`_
+- Status of individual interactions in VCR cassettes. Before this change, all statuses were taken from the overall test outcome,
+  rather than from the check results for a particular response. `#695`_
 
 **Changed**
 
@@ -1387,6 +1389,7 @@ Deprecated
 .. _#708: https://github.com/schemathesis/schemathesis/issues/708
 .. _#705: https://github.com/schemathesis/schemathesis/issues/705
 .. _#702: https://github.com/schemathesis/schemathesis/issues/702
+.. _#695: https://github.com/schemathesis/schemathesis/issues/695
 .. _#692: https://github.com/schemathesis/schemathesis/issues/692
 .. _#686: https://github.com/schemathesis/schemathesis/issues/686
 .. _#684: https://github.com/schemathesis/schemathesis/issues/684

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -260,7 +260,7 @@ Schemathesis provides the following extra fields:
 
 - ``command``. Full CLI command used to run Schemathesis.
 - ``http_interactions.id``. A numeric interaction ID within the current cassette.
-- ``http_interactions.status``. Type of test outcome is one of ``SUCCESS``, ``FAILURE``, ``ERROR``.
+- ``http_interactions.status``. Type of test outcome is one of ``SUCCESS``, ``FAILURE``. The status value is calculated from individual checks statuses - if any check failed, then the final status is ``FAILURE``.
 - ``http_interactions.seed``. The Hypothesis seed used in that particular case could be used as an argument to ``--hypothesis-seed`` CLI option to reproduce this request.
 - ``http_interactions.elapsed``. Time in seconds that a request took.
 - ``http_interactions.checks``. A list of executed checks and and their status.
@@ -288,7 +288,7 @@ Saved cassettes can be replayed with ``schemathesis replay`` command. Additional
 replay by these parameters:
 
 - ``id``. Specific, unique ID;
-- ``status``. Replay only interactions with this status (``SUCCESS``, ``FAILURE`` or ``ERROR``);
+- ``status``. Replay only interactions with this status (``SUCCESS`` or ``FAILURE``);
 - ``uri``. A regular expression for request URI;
 - ``method``. A regular expression for request method;
 

--- a/src/schemathesis/cli/cassettes.py
+++ b/src/schemathesis/cli/cassettes.py
@@ -48,7 +48,6 @@ class CassetteWriter(EventHandler):
             seed = cast(int, event.result.seed)
             self.queue.put(
                 Process(
-                    status=event.status.name.upper(),
                     seed=seed,
                     interactions=event.result.interactions,
                     checks=event.result.checks,
@@ -74,7 +73,6 @@ class Initialize:
 class Process:
     """A new chunk of data should be processed."""
 
-    status: str = attr.ib()  # pragma: no mutate
     seed: int = attr.ib()  # pragma: no mutate
     interactions: List[Interaction] = attr.ib()  # pragma: no mutate
     checks: List[SerializedCheck] = attr.ib()  # pragma: no mutate
@@ -132,9 +130,10 @@ http_interactions:"""
             )
         elif isinstance(item, Process):
             for interaction in item.interactions:
+                status = interaction.status.name.upper()
                 stream.write(
                     f"""\n- id: '{current_id}'
-  status: '{item.status}'
+  status: '{status}'
   seed: '{item.seed}'
   elapsed: '{interaction.response.elapsed}'
   recorded_at: '{interaction.recorded_at}'


### PR DESCRIPTION
Before this change, all statuses were taken from the overall test outcome, rather than from the check results for a particular response.

Resolves #695