### PR TITLE
fix: Escaping header values in VCR cassettes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,10 +15,11 @@ Changelog
 
 **Fixed**
 
-- Fix ``User-Agent`` header overriding the passed one. `#757`_
+- ``User-Agent`` header overriding the passed one. `#757`_
 - Default ``User-Agent`` header in ``Case.call``. `#717`_
 - Status of individual interactions in VCR cassettes. Before this change, all statuses were taken from the overall test outcome,
   rather than from the check results for a particular response. `#695`_
+- Escaping header values in VCR cassettes. `#783`_
 
 **Changed**
 
@@ -1378,6 +1379,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#783: https://github.com/schemathesis/schemathesis/issues/783
 .. _#768: https://github.com/schemathesis/schemathesis/issues/768
 .. _#757: https://github.com/schemathesis/schemathesis/issues/757
 .. _#748: https://github.com/schemathesis/schemathesis/issues/748

--- a/src/schemathesis/cli/cassettes.py
+++ b/src/schemathesis/cli/cassettes.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import re
 import sys
 import threading
@@ -103,7 +104,7 @@ def worker(file_handle: click.utils.LazyFile, queue: Queue) -> None:
     stream = file_handle.open()
 
     def format_header_values(values: List[str]) -> str:
-        return "\n".join(f"      - '{v}'" for v in values)
+        return "\n".join(f"      - {json.dumps(v)}" for v in values)
 
     def format_headers(headers: Dict[str, List[str]]) -> str:
         return "\n".join(f"      {name}:\n{format_header_values(values)}" for name, values in headers.items())

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -110,6 +110,12 @@ def schema_url(server, app):
 
 
 @pytest.fixture()
+def openapi2_schema_url(server, openapi_2_app):
+    """URL of the schema of the running application."""
+    return f"http://127.0.0.1:{server['port']}/schema.yaml"
+
+
+@pytest.fixture()
 def openapi3_schema_url(server, openapi_3_app):
     """URL of the schema of the running application."""
     return f"http://127.0.0.1:{server['port']}/schema.yaml"


### PR DESCRIPTION
Fixes #783
