### PR TITLE
chore(ci): publish image under schemathesis org using kaniko

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,29 +5,30 @@ on:
     types: [published]
 
 jobs:
-  release_image:
-    name: Build and publish to Docker Hub
+  container:
+    name: Container image
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
+      - uses: actions/checkout@v2
 
-    - name: Build the image
-      run: docker build -f "Dockerfile" -t "kiwicom/schemathesis:${GITHUB_REF##*/}" -t "kiwicom/schemathesis:stable" .
+      - name: GitHub Package Registry
+        uses: aevea/action-kaniko@master
+        with:
+          registry: docker.pkg.github.com
+          password: ${{ secrets.GITHUB_TOKEN }}
+          image: server
+          cache: true
+          cache_registry: cache
 
-    - name: Login to registry
-      run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-    - name: Publish tag image
-      run: docker push kiwicom/schemathesis:${GITHUB_REF##*/}
-
-    - name: Publish stable image
-      run: docker push kiwicom/schemathesis:stable
-
+      - name: Dockerhub
+        uses: aevea/action-kaniko@master
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          image: schemathesis/schemathesis
+          cache: true
+          cache_registry: schemathesis/cache
 
   release_package:
     name: Build and publish package to pypi.org


### PR DESCRIPTION
🚨Please review the [guidelines for contributing](https://github.com/schemathesis/schemathesis/blob/master/CONTRIBUTING.rst) to this repository.

### Description
I've updated the release action so it uses the more efficient [kaniko](https://github.com/GoogleContainerTools/kaniko) builder, and I've also changed the image organization target to the newly created `schemathesis` org and also GitHub docker registry.