### PR TITLE
feat: Stateful testing via Hypothesis's RuleBasedStateMachine

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,12 +4,22 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Added**
+
+- New approach to stateful testing, based on the Hypothesis's ``RuleBasedStateMachine``. `#737`_
+
+**Deprecated**
+
+- Using ``stateful=Stateful.links`` in schema loaders and ``parametrize``. Use ``schema.as_state_machine().TestCase`` instead.
+  The old approach to stateful testing will be removed in ``3.0``.
+  See the ``Stateful testing`` section of our documentation for more information.
+
 `2.6.1`_ - 2020-10-19
 ---------------------
 
 **Added**
 
-- New method ``as_curl_command`` added to the Case class `#689`_
+- New method ``as_curl_command`` added to the ``Case`` class. `#689`_
 
 `2.6.0`_ - 2020-10-06
 ---------------------
@@ -1410,6 +1420,7 @@ Deprecated
 .. _#748: https://github.com/schemathesis/schemathesis/issues/748
 .. _#742: https://github.com/schemathesis/schemathesis/issues/742
 .. _#738: https://github.com/schemathesis/schemathesis/issues/738
+.. _#737: https://github.com/schemathesis/schemathesis/issues/737
 .. _#734: https://github.com/schemathesis/schemathesis/issues/734
 .. _#731: https://github.com/schemathesis/schemathesis/issues/731
 .. _#721: https://github.com/schemathesis/schemathesis/issues/721

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,9 +51,9 @@ User's Guide
    introduction
    cli
    python
+   stateful
    compatibility
    examples
-   stateful
    graphql
    targeted
    extending

--- a/docs/stateful.rst
+++ b/docs/stateful.rst
@@ -1,22 +1,30 @@
+****************
 Stateful testing
-================
+****************
 
-By default, Schemathesis generates random data for all endpoints in your schema. With stateful testing,
-Schemathesis will try to reuse data from requests sent and responses received for generating requests to
-other endpoints.
+By default, Schemathesis takes all endpoints from your API and tests them separately by passing random input data and validating responses.
+It works great when you need to quickly verify that your endpoints properly validate input and respond in conformance with the API schema.
 
-Open API Links
---------------
+With stateful testing, Schemathesis combines multiple API calls into a single test scenario and tries to find call sequences that fail.
 
-The `official documentation <https://swagger.io/docs/specification/links/>`_ describes this feature like this:
+Why is it useful?
+-----------------
 
-    Using links, you can describe how various values returned by one operation can be used as input for other operations
+This approach allows your tests to reach deeper into your application logic and cover scenarios that are impossible to cover with independent tests.
+You may compare Schemathesis's stateful and non-stateful testing the same way you would compare integration and unit tests.
+Stateful testing checks how multiple API endpoints work in combination.
 
-Schemathesis uses this data to generate additional requests and send them to their respective endpoints.
-It enables Schemathesis to reach much deeper into your codebase that it is possible with randomly generated data.
-Let's take the example from the docs:
+It solves the problem when your application produces a high number of "404 Not Found" responses during testing due to randomness in the input data.
 
-.. code:: yaml
+How to specify connections?
+---------------------------
+
+To specify how different endpoints depend on each other, we use a special syntax from the Open API specification - `Open API links <https://swagger.io/docs/specification/links/>`_.
+It describes how the output from one operation can be used as input for other operations.
+To define such connections, you need to extend your API schema with the ``links`` keyword:
+
+.. code-block::
+   :emphasize-lines: 16-20
 
     paths:
       /users:
@@ -35,7 +43,7 @@ Let's take the example from the docs:
               ...
               links:
                 GetUserByUserId:
-                  operationId: getUser
+                  operationId: getUser  # The target operation
                   parameters:
                     userId: '$response.body#/id'
       /users/{userId}:
@@ -50,19 +58,393 @@ Let's take the example from the docs:
                 type: integer
                 format: int64
 
-Based on this definition, Schemathesis will:
+In this schema, you define that the ``id`` value returned by the ``POST /users`` call can be used as a path parameter in the ``GET /users/{userId}`` call.
 
-- Test ``POST /users`` endpoint as usual;
-- Each response with 201 code will be parsed and used for additional tests of ``GET /users/{user_id}`` endpoint;
-- All data that is not filled from responses will be generated as usual;
+Schemathesis will use this connection during ``GET /users/{userId}`` parameters generation - everything that is not defined by links will be generated randomly.
 
-In this case, it is much more likely that instead of a 404 response for a randomly-generated ``user_id``, we'll receive
-something else - for example, HTTP codes 200 or 500.
+If you don't want to modify your schema source, :func:`add_link <schemathesis.specs.openapi.schemas.BaseOpenAPISchema.add_link>`
+allows you to define links between a pair of endpoints programmatically.
 
-By default, stateful testing is disabled. You can add it via the ``--stateful=links`` CLI option or with the ``stateful=Stateful.links`` argument to ``parametrize``.
+.. automethod:: schemathesis.specs.openapi.schemas.BaseOpenAPISchema.add_link(source, target, status_code, parameters=None, request_body=None) -> None
+
+With some `minor limitations <#open-api-links-limitations>`_, Schemathesis fully supports Open API links, including the `runtime expressions <https://swagger.io/docs/specification/links/#runtime-expressions>`_ syntax.
+
+Minimal example
+---------------
+
+Stateful tests could be added to your test suite by defining a test class:
+
+.. code-block:: python
+
+    import schemathesis
+
+    schema = schemathesis.from_uri("http://0.0.0.0/schema.yaml")
+
+    APIWorkflow = schema.as_state_machine()
+    TestAPI = APIWorkflow.TestCase
+
+Besides loading an API schema, the example above contains two basic components:
+
+- ``APIWorkflow``. A state machine that allows you to `customize behavior <#how-to-customize-tests>`_ on each test scenario.
+- ``TestAPI``. A ``unittest``-style test case where you can add your ``pytest`` fixtures that will be applied to the whole set of scenarios.
+
+Stateful tests work seamlessly with WSGI / ASGI applications - the state machine will automatically pick up the right way to make an API call.
+
+The implementation is based on Hypothesis's `Rule-based state machines <https://hypothesis.readthedocs.io/en/latest/stateful.html>`_, and you can apply its features if you want to extend the default behavior.
+
+.. note::
+
+   Schemathesis's stateful testing uses `Swarm testing <https://www.cs.utah.edu/~regehr/papers/swarm12.pdf>`_ (via Hypothesis), which makes defect discovery much more effective.
+
+Lazy schema loading
+-------------------
+
+It is also possible to use stateful testing without loading the API schema during test collection. For example, if your
+application depends on some test fixtures, you might want to avoid loading the schema too early.
+
+To do so, you need to create the state machine inside a ``pytest`` fixture and run it via :func:`run_state_machine_as_test` inside a test function:
+
+.. code-block:: python
+
+    from hypothesis.stateful import run_state_machine_as_test
+
+    @pytest.fixture
+    def state_machine():
+        # You may use any schema loader here
+        # or use any pytest fixtures
+        schema = schemathesis.from_uri(
+            "http://0.0.0.0:8081/schema.yaml"
+        )
+        return schema.as_state_machine()
+
+    def test_statefully(state_machine):
+        run_state_machine_as_test(
+            state_machine,
+        )
+
+How it works behind the scenes?
+-------------------------------
+
+The whole concept consists of two important stages.
+
+- State machine creation:
+    - Each endpoint has a separate bundle where Schemathesis put all responses received from that endpoint;
+    - All links represent transitions of the state machine. Each one has a pre-condition - there should already be a response
+      with the proper status code;
+    - If an endpoint has no links, then Schemathesis creates a transition without a pre-condition and generates random
+      data as input.
+- Running scenarios:
+    - Each scenario step accepts a freshly generated random test case and randomly chosen data from the dependent endpoint.
+      This data might be missing if there are no links to the current endpoint;
+    - If there is data, then the generated case is updated according to the defined link rules;
+    - The resulting test case is sent to the current endpoint then its response is validated and stored for future use.
+
+As a result, Schemathesis can run arbitrary API call sequences and combine data generation with reusing responses.
+
+How to customize tests
+----------------------
+
+If you want to change a single scenario's behavior, you need to extend the state machine. Each scenario
+gets a freshly created state machine instance that runs a sequence of steps.
+
+.. autoclass:: schemathesis.stateful.APIStateMachine
+
+    The following methods are executed only once per test scenario.
+
+    .. automethod:: setup
+
+    |
+
+    .. automethod:: teardown
+
+    These methods might be called multiple times per test scenario.
+
+    .. automethod:: step
+
+    |
+
+    .. automethod:: before_call
+
+    |
+
+    .. automethod:: call
+
+    |
+
+    .. automethod:: after_call
+
+    |
+
+    .. automethod:: validate_response
+
+If you load your schema lazily, you can extend the state machine inside the ``pytest`` fixture:
+
+.. code-block:: python
+
+    @pytest.fixture
+    def state_machine():
+        schema = schemathesis.from_uri(
+            "http://0.0.0.0:8081/schema.yaml"
+        )
+
+        class APIWorkflow(schema.as_state_machine()):
+
+            def setup(self):
+                # your scenario setup
+                ...
+
+        return APIWorkflow
+
+Using pytest fixtures
+---------------------
+
+In case if you need to customize the whole test run, then you can extend the test class:
+
+.. code-block:: python
+
+    APIWorkflow = schema.as_state_machine()
+
+    class TestAPI(APIWorkflow.TestCase):
+
+        def setUp(self):
+            # create a database
+
+        def tearDown(self):
+            # drop the database
+
+Or with explicit fixtures:
+
+.. code-block:: python
+
+    import pytest
+
+    APIWorkflow = schema.as_state_machine()
+
+    @pytest.fixture()
+    def database():
+        # create tables & data
+        yield
+        # drop tables
+
+    @pytest.mark.usefixtures("database")
+    class TestAPI(APIWorkflow.TestCase):
+        pass
+
+Note that for ``pytest`` or ``unittest``, there is a single test case, which is parametrized on the Hypothesis side.
+Therefore, it will run only once, not for each test scenario.
+
+Hypothesis configuration
+------------------------
+
+Hypothesis settings can be changed via the settings object on the ``TestCase`` class:
+
+.. code-block:: python
+
+    from hypothesis import settings
+
+    TestCase = schema.as_state_machine().TestCase
+    TestCase.settings = settings(
+        max_examples=200, stateful_step_count=5
+    )
+
+If you load your schema lazily:
+
+.. code-block:: python
+
+    from hypothesis.stateful import run_state_machine_as_test
+    from hypothesis import settings
+
+    @pytest.fixture
+    def state_machine():
+        ...
+
+    def test_statefully(state_machine):
+        run_state_machine_as_test(
+            state_machine,
+            settings=settings(
+                max_examples=200,
+                stateful_step_count=5,
+            )
+        )
+
+With this configuration, there will be twice more test cases with a maximum of five steps in each one.
+
+How to provide initial data for test scenarios?
+-----------------------------------------------
+
+Often you might want to always make some API calls as a preparation for the test. For example, to create some
+test data, like users in the system or items in the e-shop stock. It can provide good starting points for scenarios, which is
+especially useful if your API expects specific input, which is hard to generate randomly.
+
+The best way to do so is by using the Hypothesis's ``initialize`` decorator:
+
+.. code-block:: python
+
+    from hypothesis.stateful import initialize
+
+    BaseAPIWorkflow = schema.as_state_machine()
+
+    class APIWorkflow(BaseAPIWorkflow):
+
+        @initialize(
+            target=BaseAPIWorkflow.bundles["/users/"]["POST"],
+            case=schema["/users/"]["POST"].as_strategy(),
+        )
+        def init_user(self, case):
+            return self.step(case)
+
+This rule will use the ``POST /users/`` endpoint strategy and generate random data as input and store the result in
+a special bundle, where it will be used for dependent API calls. The state machine will run this rule at the beginning of any test scenario.
+Note that if you have multiple rules, they will run in arbitrary order.
+
+If you need more control and you'd like to provide the whole payload to your endpoint, then you can do it either by modifying
+the generated case manually or by creating a new one via the :func:`Endpoint.make_case` function:
+
+.. code-block:: python
+
+    from hypothesis.stateful import initialize
+
+    BaseAPIWorkflow = schema.as_state_machine()
+
+    class APIWorkflow(BaseAPIWorkflow):
+
+        @initialize(
+            target=BaseAPIWorkflow.bundles["/users/"]["POST"],
+        )
+        def init_user(self):
+            case = schema["/users/"]["POST"].make_case(
+                body={"username": "Test"}
+            )
+            return self.step(case)
+
+Loading multiple entries of the same type is more verbose but still possible:
+
+.. code-block:: python
+
+    from hypothesis.stateful import initialize, multiple
+
+    BaseAPIWorkflow = schema.as_state_machine()
+    # These users will be created at the beginning of each scenario
+    USERS = [
+        {"is_admin": True, "username": "Admin"},
+        {"is_admin": False, "username": "Customer"},
+    ]
+
+    class APIWorkflow(BaseAPIWorkflow):
+
+        @initialize(
+            target=BaseAPIWorkflow.bundles["/users/"]["POST"],
+        )
+        def init_users(self):
+            result = []
+            # Create each user via the API
+            for user in USERS:
+                case = schema["/users/"]["POST"].make_case(
+                    body=user
+                )
+                result.append(self.step(case))
+            # Store them in the `POST /users/` bundle
+            return multiple(*result)
+
+Examples
+--------
+
+Here are more verbose examples of how you can adapt Schemathesis's stateful testing to some typical workflows.
+
+API authorization
+~~~~~~~~~~~~~~~~~
+
+Login to an app and use its API token with each call:
+
+.. code:: python
+
+    import requests
+
+    class APIWorkflow(schema.as_state_machine()):
+        headers: dict
+
+        def __init__(self):
+            super().__init__()
+            # Make a login request
+            response = requests.post(
+                "http://0.0.0.0/api/login",
+                json={
+                    "login": "test",
+                    "password": "password"
+                }
+            )
+            # Parse the response and store the token in headers
+            token = response.json()["auth_token"]
+            self.headers = {
+                "Authorization": f"Bearer {token}"
+            }
+
+        def call(self, case):
+            # Use stored headers
+            return case.call(headers=self.headers)
+
+Conditional validation
+~~~~~~~~~~~~~~~~~~~~~~
+
+Run different checks, depending on the result of the previous call:
+
+.. code:: python
+
+    def check_condition(response, case):
+        if case.source is not None:
+            # Run this check only for `GET /items/{id}`
+            if case.method == "GET" and case.path == "/items/{id}":
+                value = response.json()
+                if case.source.response.status_code == 201:
+                    assert value in ("IN_PROGRESS", "COMPLETE")
+                if case.source.response.status_code == 400:
+                    assert value == "REJECTED"
+
+    class APIWorkflow(schema.as_state_machine()):
+
+        def validate_response(self, response, case):
+            case.validate_response(
+                response,
+                (check_condition, )
+            )
+
+Reproducing failures
+--------------------
+
+When Schemathesis finds an erroneous API call sequence, it will provide executable Python code that reproduces the error.
+It might look like this:
+
+.. code-block:: python
+
+    state = APIWorkflow()
+    v1 = state.step(
+        case=state.schema["/users/"]["POST"].make_case(
+            body={"username": "000"}
+        ),
+        previous=None,
+    )
+    state.step(
+        case=state.schema["/users/{user_id}"]["PATCH"].make_case(
+            path_parameters={"user_id": 0},
+            query={"common": 0},
+            body={"username": ""},
+        ),
+        previous=(
+            v1,
+            schema["/users/"]["POST"].links["201"]["UpdateUserById"],
+        ),
+    )
+    state.teardown()
+
+The ``APIWorkflow`` class in the example is your state machine class - change it accordingly if your state machine
+class has a different name, or change it to ``state = schema.as_state_machine()()``. Besides the class naming, this code
+is supposed to run without changes.
+
+Command Line Interface
+----------------------
+
+By default, stateful testing is disabled. You can add it via the ``--stateful=links`` CLI option.
 Please, note that we plan to implement more different algorithms for stateful testing in the future.
-
-CLI:
 
 .. code:: bash
 
@@ -80,32 +462,68 @@ CLI:
 
     ...
 
-Python tests:
-
-.. code:: python
-
-    from schemathesis import Stateful
-
-    @schema.parametrize(stateful=Stateful.links)
-    def test_api(case):
-        case.call_and_validate()
-        ...
 
 Each additional test will be indented and prefixed with ``->`` in the CLI output.
 You can specify recursive links if you want. The default recursion depth limit is **5** and can be changed with the
-``--stateful-recursion-limit=<N>`` CLI option or with the ``stateful_recursion_limit=<N>`` argument to ``parametrize``.
+``--stateful-recursion-limit=<N>`` CLI option.
 
-**NOTE**. If you use stateful testing in Python tests, make sure you use the ``case.call_and_validate`` or ``case.call`` methods that automatically store the response for further usage.
-Alternatively, you could use ``case.store_response`` and store the received response by hand:
+Schemathesis's CLI currently uses the old approach to stateful testing, not based on state machines.
+We plan to use the new approach in CLI, beginning from Schemathesis 2.8. It may include slight changes to the visual
+appearance and the way to configure it. It also means that using stateful testing in CLI is not yet as customizable
+as in the in-code approach.
 
-.. code:: python
+Migration from the previous stateful testing approach
+-----------------------------------------------------
+
+Initially, stateful testing was introduced to the in-code testing in version 2.5 and used a much less effective way
+of generating scenarios. Using it is discouraged, and here is a migration guide to the new approach.
+
+.. warning::
+
+    The previous approach is deprecated since 2.7 and planned for removal in Schemathesis 3.0.
+
+The previous approach assumed test logic in the test function body, and now it could be moved to extension points in the
+state machine class.
+
+Before:
+
+.. code-block:: python
 
     @schema.parametrize(stateful=Stateful.links)
     def test_api(case):
-        response = case.call()  # stores the response automatically
-        # OR, store it manually
-        response = requests.request(**case.as_requests_kwargs())
-        case.store_response(response)
+        response = case.call()
+        case.validate_response(response)
+        # A custom conditional check
+        if case.path == "/items":
+            assert "X-Item-Id" in response.headers
+
+After:
+
+.. code-block:: python
+
+    class APIWorkflow(schema.as_state_machine()):
+
+        def validate_response(self, response, case):
+            super().validate_response(response, case)
+            # A custom conditional check
+            if case.path == "/items":
+                assert "X-Item-Id" in response.headers
+
+    TestCase = APIWorkflow.TestCase
+
+From the usage point of view, the main difference is that you need to work with the state machine class instead of creating a test function.
+These two approaches are significantly different in the test quality aspects. Specifically, the new one:
+
+- Can execute an arbitrary sequence of API calls, when the old one always run then in a particular order;
+- Provides the :py:attr:`Case.source` attribute, that allows you to use responses from previous steps;
+- Doesn't mix different components of responses when generating new ones;
+- Has a better distribution of generated calls in a sequence. With the old one, the deeper an endpoint is in the links
+  tree, the fewer examples will be executed, and the less chance to have it executed at all;
+- About 40% faster in data generation;
+- Much more flexible for adding additional ways of connecting endpoints in the future.
+
+Open API links limitations
+--------------------------
 
 Even though this feature appears only in Open API 3.0 specification, under Open API 2.0, you can use it
 via the ``x-links`` extension, the syntax is the same, but you need to use the ``x-links`` keyword instead of ``links``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ multi_line_output = 3
 default_section = "THIRDPARTY"
 include_trailing_comma = true
 known_first_party = "schemathesis"
-known_third_party = ["_pytest", "aiohttp", "attr", "click", "curlify", "fastapi", "flask", "graphene", "graphql", "graphql_server", "hypothesis", "hypothesis_graphql", "hypothesis_jsonschema", "jsonschema", "junit_xml", "packaging", "pytest", "pytest_subtests", "requests", "schemathesis", "starlette", "urllib3", "werkzeug", "yaml", "yarl"]
+known_third_party = ["_pytest", "aiohttp", "attr", "click", "curlify", "fastapi", "flask", "graphene", "graphql", "graphql_server", "hypothesis", "hypothesis_graphql", "hypothesis_jsonschema", "jsonschema", "junit_xml", "packaging", "pydantic", "pytest", "pytest_subtests", "requests", "schemathesis", "starlette", "urllib3", "werkzeug", "yaml", "yarl"]
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/src/schemathesis/__init__.py
+++ b/src/schemathesis/__init__.py
@@ -6,5 +6,6 @@ from .models import Case
 from .specs import graphql
 from .specs.openapi._hypothesis import init_default_strategies, register_string_format
 from .stateful import Stateful
+from .utils import GenericResponse
 
 init_default_strategies()

--- a/src/schemathesis/extra/pytest_plugin.py
+++ b/src/schemathesis/extra/pytest_plugin.py
@@ -36,7 +36,7 @@ class SchemathesisCase(PyCollector):
         super().__init__(*args, **kwargs)
 
     def _get_test_name(self, endpoint: Endpoint) -> str:
-        return f"{self.name}[{endpoint.method}:{endpoint.full_path}]"
+        return f"{self.name}[{endpoint.method.upper()}:{endpoint.full_path}]"
 
     def _gen_items(self, endpoint: Endpoint) -> Generator[Function, None, None]:
         """Generate all items for the given endpoint.
@@ -157,12 +157,12 @@ class SchemathesisFunction(Function):  # pylint: disable=too-many-ancestors
         recursion_level = self.recursion_level
         if feedback is None or recursion_level >= feedback.endpoint.schema.stateful_recursion_limit:
             return []
-        previous_test_name = self.test_name or f"{feedback.endpoint.method}:{feedback.endpoint.full_path}"
+        previous_test_name = self.test_name or f"{feedback.endpoint.method.upper()}:{feedback.endpoint.full_path}"
 
         def make_test(
             endpoint: Endpoint, test: Union[Callable, InvalidSchema], previous_tests: str
         ) -> SchemathesisFunction:
-            test_name = f"{previous_tests} -> {endpoint.method}:{endpoint.full_path}"
+            test_name = f"{previous_tests} -> {endpoint.method.upper()}:{endpoint.full_path}"
             return create(
                 self.__class__,
                 name=f"{self.originalname}[{test_name}]",

--- a/src/schemathesis/lazy.py
+++ b/src/schemathesis/lazy.py
@@ -95,12 +95,12 @@ def get_test(test: Union[Callable, InvalidSchema]) -> Callable:
 
 def _get_node_name(node_id: str, endpoint: Endpoint) -> str:
     """Make a test node name. For example: test_api[GET:/users]."""
-    return f"{node_id}[{endpoint.method}:{endpoint.full_path}]"
+    return f"{node_id}[{endpoint.method.upper()}:{endpoint.full_path}]"
 
 
 def run_subtest(endpoint: Endpoint, fixtures: Dict[str, Any], sub_test: Callable, subtests: SubTests) -> None:
     """Run the given subtest with pytest fixtures."""
-    with subtests.test(method=endpoint.method, path=endpoint.path):
+    with subtests.test(method=endpoint.method.upper(), path=endpoint.path):
         sub_test(**fixtures)
 
 

--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -53,7 +53,7 @@ class BeforeExecution(ExecutionEvent):
 
     @classmethod
     def from_endpoint(cls, endpoint: Endpoint, recursion_level: int) -> "BeforeExecution":
-        return cls(method=endpoint.method, path=endpoint.full_path, recursion_level=recursion_level)
+        return cls(method=endpoint.method.upper(), path=endpoint.full_path, recursion_level=recursion_level)
 
 
 @attr.s(slots=True)  # pragma: no mutate
@@ -76,7 +76,7 @@ class AfterExecution(ExecutionEvent):
         cls, result: TestResult, status: Status, elapsed_time: float, hypothesis_output: List[str], endpoint: Endpoint
     ) -> "AfterExecution":
         return cls(
-            method=endpoint.method,
+            method=endpoint.method.upper(),
             path=endpoint.full_path,
             result=SerializedTestResult.from_test_result(result),
             status=status,

--- a/src/schemathesis/runner/serialization.py
+++ b/src/schemathesis/runner/serialization.py
@@ -96,7 +96,7 @@ class SerializedTestResult:
     def from_test_result(cls, result: TestResult) -> "SerializedTestResult":
         formatter = logging.Formatter("[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
         return SerializedTestResult(
-            method=result.endpoint.method,
+            method=result.endpoint.method.upper(),
             path=result.endpoint.full_path,
             has_failures=result.has_failures,
             has_errors=result.has_errors,

--- a/src/schemathesis/specs/openapi/_hypothesis.py
+++ b/src/schemathesis/specs/openapi/_hypothesis.py
@@ -167,7 +167,7 @@ def _get_case_strategy(
     hook_dispatcher: Optional[HookDispatcher] = None,
 ) -> st.SearchStrategy[Case]:
     static_parameters: Dict[str, Any] = {"endpoint": endpoint, **extra_static_parameters}
-    if endpoint.schema.validate_schema and endpoint.method == "GET":
+    if endpoint.schema.validate_schema and endpoint.method.upper() == "GET":
         if endpoint.body is not None:
             raise InvalidSchema("Body parameters are defined for GET request.")
         static_parameters["body"] = None

--- a/src/schemathesis/specs/openapi/checks.py
+++ b/src/schemathesis/specs/openapi/checks.py
@@ -1,6 +1,4 @@
-import string
 from contextlib import ExitStack, contextmanager
-from itertools import product
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Union
 
 import jsonschema
@@ -9,6 +7,7 @@ import requests
 from ...exceptions import get_headers_error, get_response_type_error, get_schema_validation_error, get_status_code_error
 from ...utils import GenericResponse, are_content_types_equal, parse_content_type
 from .schemas import BaseOpenAPISchema
+from .utils import expand_status_code
 
 if TYPE_CHECKING:
     from ...models import Case
@@ -35,9 +34,7 @@ def status_code_conformance(response: GenericResponse, case: "Case") -> Optional
 
 def _expand_responses(responses: Dict[Union[str, int], Any]) -> Generator[int, None, None]:
     for code in responses:
-        chars = [list(string.digits) if digit == "X" else [digit] for digit in str(code).upper()]
-        for expanded in product(*chars):
-            yield int("".join(expanded))
+        yield from expand_status_code(code)
 
 
 def content_type_conformance(response: GenericResponse, case: "Case") -> Optional[bool]:

--- a/src/schemathesis/specs/openapi/expressions/nodes.py
+++ b/src/schemathesis/specs/openapi/expressions/nodes.py
@@ -58,7 +58,7 @@ class Method(Node):
     """A node for `$method` expression."""
 
     def evaluate(self, context: ExpressionContext) -> str:
-        return context.case.endpoint.method
+        return context.case.endpoint.method.upper()
 
 
 @attr.s(slots=True)  # pragma: no mutate

--- a/src/schemathesis/specs/openapi/stateful/__init__.py
+++ b/src/schemathesis/specs/openapi/stateful/__init__.py
@@ -1,0 +1,85 @@
+import functools
+import operator
+from collections import defaultdict
+from typing import TYPE_CHECKING, Dict, List, Tuple, Type
+
+from hypothesis.stateful import Bundle, Rule, rule
+from hypothesis.strategies import SearchStrategy, none
+from requests.structures import CaseInsensitiveDict
+
+from ....stateful import APIStateMachine, Direction, StepResult
+from .. import expressions
+from ..links import OpenAPILink
+from . import links
+
+if TYPE_CHECKING:
+    from ....models import Case, Endpoint
+    from ..schemas import BaseOpenAPISchema
+
+
+EndpointConnections = Dict[str, List[SearchStrategy[Tuple[StepResult, OpenAPILink]]]]
+
+
+class OpenAPIStateMachine(APIStateMachine):
+    def transform(self, result: StepResult, direction: Direction, case: "Case") -> "Case":
+        context = expressions.ExpressionContext(case=result.case, response=result.response)
+        direction.set_data(case, context=context)
+        return case
+
+
+def create_state_machine(schema: "BaseOpenAPISchema") -> Type[APIStateMachine]:
+    """Create a state machine class.
+
+    This state machine will contain transitions that connect some endpoints' outputs with other endpoints' inputs.
+    """
+    bundles = init_bundles(schema)
+    connections: EndpointConnections = defaultdict(list)
+    for endpoint in schema.get_all_endpoints():
+        links.apply(endpoint, bundles, connections)
+
+    rules = make_all_rules(schema, bundles, connections)
+
+    return type("APIWorkflow", (OpenAPIStateMachine,), {"bundles": bundles, "schema": schema, **rules})
+
+
+def init_bundles(schema: "BaseOpenAPISchema") -> Dict[str, CaseInsensitiveDict]:
+    """Create bundles for all endpoints in the given schema.
+
+    Each endpoint has a bundle that stores all responses from that endpoint.
+    We need to create bundles first, so they can be referred when building connections between endpoints.
+    """
+    output: Dict[str, CaseInsensitiveDict] = {}
+    for endpoint in schema.get_all_endpoints():
+        output.setdefault(endpoint.path, CaseInsensitiveDict())
+        output[endpoint.path][endpoint.method.upper()] = Bundle(endpoint.verbose_name)
+    return output
+
+
+def make_all_rules(
+    schema: "BaseOpenAPISchema", bundles: Dict[str, CaseInsensitiveDict], connections: EndpointConnections
+) -> Dict[str, Rule]:
+    """Create rules for all endpoints, based on the provided connections."""
+    return {
+        f"rule {endpoint.verbose_name}": make_rule(
+            endpoint, bundles[endpoint.path][endpoint.method.upper()], connections
+        )
+        for endpoint in schema.get_all_endpoints()
+    }
+
+
+def make_rule(endpoint: "Endpoint", bundle: Bundle, connections: EndpointConnections) -> Rule:
+    """Create a rule for an endpoint."""
+    previous_strategies = connections.get(endpoint.verbose_name)
+    if previous_strategies is not None:
+        previous = _combine_strategies(previous_strategies)
+    else:
+        previous = none()
+    return rule(target=bundle, previous=previous, case=endpoint.as_strategy())(APIStateMachine.step)
+
+
+def _combine_strategies(strategies: List[SearchStrategy]) -> SearchStrategy:
+    """Combine a list of strategies into a single one.
+
+    If the input is `[a, b, c]`, then the result is equivalent to `a | b | c`.
+    """
+    return functools.reduce(operator.or_, strategies[1:], strategies[0])

--- a/src/schemathesis/specs/openapi/stateful/links.py
+++ b/src/schemathesis/specs/openapi/stateful/links.py
@@ -1,0 +1,80 @@
+from typing import TYPE_CHECKING, Callable, Dict, List, Tuple
+
+import hypothesis.strategies as st
+from requests.structures import CaseInsensitiveDict
+
+from ....stateful import StepResult
+from ..links import OpenAPILink, get_all_links
+from ..utils import expand_status_code
+
+if TYPE_CHECKING:
+    from ....models import Endpoint
+
+FilterFunction = Callable[[StepResult], bool]
+
+
+def apply(
+    endpoint: "Endpoint",
+    bundles: Dict[str, CaseInsensitiveDict],
+    connections: Dict[str, List[st.SearchStrategy[Tuple[StepResult, OpenAPILink]]]],
+) -> None:
+    """Gather all connections based on Open API links definitions."""
+    all_status_codes = list(endpoint.definition.resolved["responses"])
+    for status_code, link in get_all_links(endpoint):
+        target_endpoint = link.get_target_endpoint()
+        strategy = bundles[endpoint.path][endpoint.method.upper()].filter(
+            make_response_filter(status_code, all_status_codes)
+        )
+        connections[target_endpoint.verbose_name].append(_convert_strategy(strategy, link))
+
+
+def _convert_strategy(
+    strategy: st.SearchStrategy[StepResult], link: OpenAPILink
+) -> st.SearchStrategy[Tuple[StepResult, OpenAPILink]]:
+    # This function is required to capture values properly (it won't work properly when lambda is defined in a loop)
+    return strategy.map(lambda out: (out, link))
+
+
+def make_response_filter(status_code: str, all_status_codes: List[str]) -> FilterFunction:
+    """Create a filter for stored responses.
+
+    This filter will decide whether some response is suitable to use as a source for requesting some endpoint.
+    """
+    if status_code == "default":
+        return default_status_code(all_status_codes)
+    return match_status_code(status_code)
+
+
+def match_status_code(status_code: str) -> FilterFunction:
+    """Create a filter function that matches all responses with the given status code.
+
+    Note that the status code can contain "X", which means any digit.
+    For example, 50X will match all status codes from 500 to 509.
+    """
+    status_codes = set(expand_status_code(status_code))
+
+    def compare(result: StepResult) -> bool:
+        return result.response.status_code in status_codes
+
+    # This name is displayed in the resulting strategy representation. For example, if you run your tests with
+    # `--hypothesis-show-statistics`, then you can see `Bundle(name='GET /users/{user_id}').filter(match_200_response)`
+    # which gives you information about the particularly used filter.
+    compare.__name__ = f"match_{status_code}_response"
+
+    return compare
+
+
+def default_status_code(status_codes: List[str]) -> FilterFunction:
+    """Create a filter that matches all "default" responses.
+
+    In Open API, the "default" response is the one that is used if no other options were matched.
+    Therefore we need to match only responses that were not matched by other listed status codes.
+    """
+    expanded_status_codes = {
+        status_code for value in status_codes if value != "default" for status_code in expand_status_code(value)
+    }
+
+    def match_default_response(result: StepResult) -> bool:
+        return result.response.status_code not in expanded_status_codes
+
+    return match_default_response

--- a/src/schemathesis/specs/openapi/utils.py
+++ b/src/schemathesis/specs/openapi/utils.py
@@ -1,0 +1,9 @@
+import string
+from itertools import product
+from typing import Generator, Union
+
+
+def expand_status_code(status_code: Union[str, int]) -> Generator[int, None, None]:
+    chars = [list(string.digits) if digit == "X" else [digit] for digit in str(status_code).upper()]
+    for expanded in product(*chars):
+        yield int("".join(expanded))

--- a/src/schemathesis/stateful.py
+++ b/src/schemathesis/stateful.py
@@ -1,13 +1,19 @@
 import enum
 import json
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
 import attr
 import hypothesis
+from hypothesis.stateful import RuleBasedStateMachine
+from requests.structures import CaseInsensitiveDict
+from starlette.applications import Starlette
 
 from .exceptions import InvalidSchema
 from .models import Case, Endpoint
 from .utils import NOT_SET, GenericResponse
+
+if TYPE_CHECKING:
+    from .schemas import BaseSchema
 
 
 class Stateful(enum.Enum):
@@ -92,3 +98,212 @@ class Feedback:
         for data in self.stateful_tests.values():
             endpoint = data.make_endpoint()
             yield endpoint, make_test_or_exception(endpoint, test, settings, seed)
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class StepResult:
+    response: GenericResponse = attr.ib()  # pragma: no mutate
+    case: Case = attr.ib()  # pragma: no mutate
+
+
+class Direction:
+    name: str
+    status_code: str
+    endpoint: Endpoint
+
+    def set_data(self, case: Case, **kwargs: Any) -> None:
+        raise NotImplementedError
+
+
+def _print_case(case: Case) -> str:
+    endpoint = f"state.schema['{case.endpoint.path}']['{case.endpoint.method.upper()}']"
+    data = [
+        f"{name}={getattr(case, name)}"
+        for name in ("path_parameters", "headers", "cookies", "query", "body", "form_data")
+        if getattr(case, name) is not None
+    ]
+    return f"{endpoint}.make_case({', '.join(data)})"
+
+
+@attr.s(slots=True, repr=False)  # pragma: no mutate
+class _DirectionWrapper:
+    """Purely to avoid modification of `Direction.__repr__`."""
+
+    direction: Direction = attr.ib()  # pragma: no mutate
+
+    def __repr__(self) -> str:
+        path = self.direction.endpoint.path
+        method = self.direction.endpoint.method.upper()
+        return f"state.schema['{path}']['{method}'].links['{self.direction.status_code}']['{self.direction.name}']"
+
+
+class APIStateMachine(RuleBasedStateMachine):
+    """The base class for state machines generated from API schemas.
+
+    Exposes additional extension points in the testing process.
+    """
+
+    bundles: Dict[str, CaseInsensitiveDict]
+    schema: "BaseSchema"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setup()
+
+    def _pretty_print(self, value: Any) -> str:
+        if isinstance(value, Case):
+            return _print_case(value)
+        if isinstance(value, tuple) and len(value) == 2:
+            result, direction = value
+            wrapper = _DirectionWrapper(direction)
+            return super()._pretty_print((result, wrapper))
+        return super()._pretty_print(value)
+
+    def setup(self) -> None:
+        """Hook method that runs unconditionally in the beginning of each test scenario.
+
+        Does nothing by default.
+        """
+
+    def teardown(self) -> None:
+        pass
+
+    # To provide the return type in the rendered documentation
+    teardown.__doc__ = RuleBasedStateMachine.teardown.__doc__
+
+    def transform(self, result: StepResult, direction: Direction, case: Case) -> Case:
+        raise NotImplementedError
+
+    def step(self, previous: Optional[Tuple[StepResult, Direction]], case: Case) -> StepResult:
+        """A single state machine step.
+
+        :param previous: Optional result from the previous step and the direction in which this step should be done.
+        :param Case case: Generated test case data that should be sent in an API call to the tested endpoint.
+
+        Schemathesis prepares data, makes a call and validates the received response.
+        It is the most high-level point to extend the testing process. You probably don't need it in most cases.
+        """
+        if previous is not None:
+            result, direction = previous
+            case = self.transform(result, direction, case)
+        self.before_call(case)
+        response = self.call(case)
+        self.after_call(response, case)
+        self.validate_response(response, case)
+        return self.store_result(response, case)
+
+    def before_call(self, case: Case) -> None:
+        """Hook method for modifying the case data before making a request.
+
+        :param Case case: Generated test case data that should be sent in an API call to the tested endpoint.
+
+        Use it if you want to inject static data to **all requests**, for example, an
+        API token that should always be present in headers:
+
+        .. code-block:: python
+
+            class APIWorkflow(schema.as_state_machine()):
+
+                def before_call(self, case):
+                    case.headers = case.headers or {}
+                    case.headers["Authorization"] = "Bearer <TOKEN>"
+        """
+
+    def after_call(self, response: GenericResponse, case: Case) -> None:
+        """Hook method for additional actions with case or response instances.
+
+        :param response: Response from the application under test.
+        :param Case case: Generated test case data that should be sent in an API call to the tested endpoint.
+
+        For example, you can log all response statuses by using this hook:
+
+        .. code-block:: python
+
+            import logging
+
+            logger = logging.getLogger(__file__)
+            logger.setLevel(logging.INFO)
+
+            class APIWorkflow(schema.as_state_machine()):
+
+                def after_call(self, response, case):
+                    logger.info(
+                        "%s %s -> %d",
+                        case.method,
+                        case.path,
+                        response.status_code,
+                    )
+
+            # POST /users/ -> 201
+            # GET /users/{user_id} -> 200
+            # PATCH /users/{user_id} -> 200
+            # GET /users/{user_id} -> 200
+            # PATCH /users/{user_id} -> 500
+        """
+
+    def call(self, case: Case) -> GenericResponse:
+        """Make a request to an endpoint.
+
+        :param Case case: Generated test case data that should be sent in an API call to the tested endpoint.
+        :return: Response from the application under test.
+
+        Here you can pass additional arguments to :func:`Case.call <schemathesis.models.Case.call>`, which mostly
+        are proxied to :func:`requests.request`:
+
+        .. code-block:: python
+
+            class APIWorkflow(schema.as_state_machine()):
+
+                def call(self, case):
+                    return case.call(verify=False)
+
+        The above example disables the server's TLS certificate verification.
+
+        Note that WSGI/ASGI applications are detected automatically in this method.
+        """
+        method: Callable
+        if case.app is not None:
+            if isinstance(case.app, Starlette):
+                method = case.call_asgi
+            else:
+                method = case.call_wsgi
+        else:
+            method = case.call
+        return method()
+
+    def validate_response(self, response: GenericResponse, case: Case) -> None:
+        """Validate an API response.
+
+        :param response: Response from the application under test.
+        :param Case case: Generated test case data that should be sent in an API call to the tested endpoint.
+        :raises CheckFailed: If any of the supplied checks failed.
+
+        If you need to change the default checks or provide custom validation rules, you can do it here.
+
+        .. code-block:: python
+
+            def my_check(response, case):
+                # some assertions
+
+            class APIWorkflow(schema.as_state_machine()):
+
+                def validate_response(self, response, case):
+                    case.validate_response(
+                        response,
+                        checks=(my_check, )
+                    )
+
+        The state machine from the example above will execute only the ``my_check`` check instead of all
+        available checks.
+
+        Each check function should accept ``response`` as the first argument and ``case`` as the second one and raise
+        ``AssertionError`` if the check fails.
+
+        **Note** that it is preferred to pass check functions as an argument to ``case.validate_response``.
+        In this case, all checks will be executed, and you'll receive a grouped exception that contains results from
+        all provided checks rather than only the first encountered exception.
+        """
+        case.validate_response(response)
+
+    def store_result(self, response: GenericResponse, case: Case) -> StepResult:
+        return StepResult(response, case)

--- a/test/apps/_aiohttp/__init__.py
+++ b/test/apps/_aiohttp/__init__.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from functools import wraps
 from typing import Callable, Tuple
 
@@ -57,6 +58,7 @@ def create_openapi_app(
         + [web.route(item.value[0], item.value[1], wrapper(item.name)) for item in Endpoint]
     )
     app["users"] = {}
+    app["requests_history"] = defaultdict(list)
     app["incoming_requests"] = incoming_requests
     app["schema_requests"] = schema_requests
     app["config"] = {"should_fail": True, "schema_data": make_openapi_schema(endpoints, version)}
@@ -70,6 +72,7 @@ def reset_app(
 ) -> None:
     """Clean up all internal containers of the application and resets its config."""
     app["users"].clear()
+    app["requests_history"].clear()
     app["incoming_requests"][:] = []
     app["schema_requests"][:] = []
     app["config"].update({"should_fail": True, "schema_data": make_openapi_schema(endpoints, version)})

--- a/test/apps/_fastapi/__init__.py
+++ b/test/apps/_fastapi/__init__.py
@@ -1,11 +1,70 @@
-from fastapi import FastAPI
+from collections import defaultdict
+
+from fastapi import FastAPI, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from ..utils import OpenAPIVersion
 
 
-def create_app():
+class User(BaseModel):
+    username: str = Field(min_length=3)
+
+    class Config:
+        extra = "forbid"
+
+
+class Message(BaseModel):
+    detail: str
+
+    class Config:
+        extra = "forbid"
+
+
+def create_app(endpoints=("root",), version=OpenAPIVersion("3.0")):
+    if version != OpenAPIVersion("3.0"):
+        raise ValueError("FastAPI supports only Open API 3.0")
     app = FastAPI()
+    users = {}
+    history = defaultdict(list)
 
-    @app.get("/users")
-    async def root():
-        return {"success": True}
+    if "root" in endpoints:
+
+        @app.get("/users")
+        async def root():
+            return {"success": True}
+
+    if "create_user" in endpoints:
+
+        @app.post("/users/", status_code=201)
+        def create_user(user: User):
+            user_id = len(users) + 1
+            users[user_id] = {**user.dict(), "id": user_id}
+            history[user_id].append("POST")
+            return {"id": user_id}
+
+    if "get_user" in endpoints:
+
+        @app.get("/users/{user_id}", responses={404: {"model": Message}})
+        def get_user(user_id: int, uid: int = Query(...), code: int = Query(...)):
+            try:
+                user = users[user_id]
+                history[user_id].append("GET")
+                return user
+            except KeyError:
+                raise HTTPException(status_code=404, detail="Not found")
+
+    if "update_user" in endpoints:
+
+        @app.patch("/users/{user_id}", responses={404: {"model": Message}})
+        def update_user(user_id: int, update: User, common: int = Query(...)):
+            try:
+                user = users[user_id]
+                history[user_id].append("PATCH")
+                if history[user_id] == ["POST", "GET", "PATCH", "GET", "PATCH"]:
+                    raise HTTPException(status_code=500)
+                user["username"] = update.username
+                return user
+            except KeyError:
+                raise HTTPException(status_code=404, detail="Not found")
 
     return app

--- a/test/apps/utils.py
+++ b/test/apps/utils.py
@@ -246,10 +246,11 @@ def _make_openapi_2_schema(endpoints: Tuple[str, ...]) -> Dict:
                 },
             )
         elif endpoint == "get_user":
+            parent = template["paths"].setdefault(path, {})
+            parent["parameters"] = [{"in": "path", "name": "user_id", "required": True, "type": "integer"}]
             schema = {
                 "operationId": "getUser",
                 "parameters": [
-                    {"in": "path", "name": "user_id", "required": True, "type": "integer"},
                     {"in": "query", "name": "code", "required": True, "type": "integer"},
                     {"in": "query", "name": "user_id", "required": True, "type": "integer"},
                 ],
@@ -268,10 +269,14 @@ def _make_openapi_2_schema(endpoints: Tuple[str, ...]) -> Dict:
                 },
             }
         elif endpoint == "update_user":
+            parent = template["paths"].setdefault(path, {})
+            parent["parameters"] = [
+                {"in": "path", "name": "user_id", "required": True, "type": "integer"},
+                {"in": "query", "name": "common", "required": True, "type": "integer"},
+            ]
             schema = {
                 "operationId": "updateUser",
                 "parameters": [
-                    {"in": "path", "name": "user_id", "required": True, "type": "integer"},
                     {
                         "in": "body",
                         "name": "username",
@@ -286,8 +291,6 @@ def _make_openapi_2_schema(endpoints: Tuple[str, ...]) -> Dict:
                 ],
                 "responses": {"200": {"description": "OK"}, "404": {"description": "Not found"}},
             }
-            paths = template["paths"].setdefault(path, {})
-            paths["parameters"] = [{"in": "query", "name": "common", "required": True, "type": "integer"}]
         else:
             schema = {
                 "responses": {
@@ -501,10 +504,11 @@ def _make_openapi_3_schema(endpoints: Tuple[str, ...]) -> Dict:
                 },
             )
         elif endpoint == "get_user":
+            parent = template["paths"].setdefault(path, {})
+            parent["parameters"] = [{"in": "path", "name": "user_id", "required": True, "schema": {"type": "integer"}}]
             schema = {
                 "operationId": "getUser",
                 "parameters": [
-                    {"in": "path", "name": "user_id", "required": True, "schema": {"type": "integer"}},
                     {"in": "query", "name": "code", "required": True, "schema": {"type": "integer"}},
                     {"in": "query", "name": "user_id", "required": True, "schema": {"type": "integer"}},
                 ],
@@ -523,6 +527,11 @@ def _make_openapi_3_schema(endpoints: Tuple[str, ...]) -> Dict:
                 },
             }
         elif endpoint == "update_user":
+            parent = template["paths"].setdefault(path, {})
+            parent["parameters"] = [
+                {"in": "path", "name": "user_id", "required": True, "schema": {"type": "integer"}},
+                {"in": "query", "name": "common", "required": True, "schema": {"type": "integer"}},
+            ]
             schema = {
                 "operationId": "updateUser",
                 "requestBody": {
@@ -537,11 +546,8 @@ def _make_openapi_3_schema(endpoints: Tuple[str, ...]) -> Dict:
                         }
                     },
                 },
-                "parameters": [{"in": "path", "name": "user_id", "required": True, "schema": {"type": "integer"}}],
                 "responses": {"200": {"description": "OK"}, "404": {"description": "Not found"}},
             }
-            paths = template["paths"].setdefault(path, {})
-            paths["parameters"] = [{"in": "query", "name": "common", "required": True, "schema": {"type": "integer"}}]
         else:
             schema = {
                 "responses": {

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -89,6 +89,16 @@ def app(openapi_version, _app, reset_app):
 
 
 @pytest.fixture
+def open_api_2():
+    return OpenAPIVersion("2.0")
+
+
+@pytest.fixture
+def open_api_3():
+    return OpenAPIVersion("3.0")
+
+
+@pytest.fixture
 def openapi_2_app(_app, reset_app):
     reset_app(OpenAPIVersion("2.0"))
     return _app
@@ -444,14 +454,24 @@ def testdir(testdir):
     return testdir
 
 
-@pytest.fixture()
-def flask_app(endpoints):
-    return _flask.create_openapi_app(endpoints)
+@pytest.fixture
+def wsgi_app_factory():
+    return _flask.create_openapi_app
 
 
 @pytest.fixture()
-def fastapi_app():
-    return _fastapi.create_app()
+def flask_app(wsgi_app_factory, endpoints):
+    return wsgi_app_factory(endpoints)
+
+
+@pytest.fixture
+def asgi_app_factory():
+    return _fastapi.create_app
+
+
+@pytest.fixture()
+def fastapi_app(asgi_app_factory):
+    return asgi_app_factory()
 
 
 def make_importable(module):

--- a/test/runner/test_checks.py
+++ b/test/runner/test_checks.py
@@ -20,7 +20,7 @@ from schemathesis.schemas import BaseSchema
 
 def make_case(schema: BaseSchema, definition: Dict[str, Any]) -> models.Case:
     endpoint = models.Endpoint(
-        "/path", "GET", definition=EndpointDefinition(definition, definition, None), schema=schema
+        "/path", "GET", definition=EndpointDefinition(definition, definition, None, []), schema=schema
     )
     return models.Case(endpoint)
 

--- a/test/specs/openapi/test_schemas.py
+++ b/test/specs/openapi/test_schemas.py
@@ -8,7 +8,7 @@ def test_get_endpoint_via_remote_reference(openapi_version, swagger_20, schema_u
     resolved = swagger_20.get_endpoint_by_reference(f"{schema_url}#/paths/~1users~1{{user_id}}/patch")
     assert isinstance(resolved, Endpoint)
     assert resolved.path == "/users/{user_id}"
-    assert resolved.method == "PATCH"
+    assert resolved.method.upper() == "PATCH"
     # Via common parameters for all methods
     if openapi_version.is_openapi_2:
         assert resolved.query == {

--- a/test/specs/openapi/test_stateful.py
+++ b/test/specs/openapi/test_stateful.py
@@ -1,0 +1,161 @@
+import pytest
+from hypothesis import HealthCheck, settings
+from hypothesis.stateful import run_state_machine_as_test
+from requests import Response
+
+import schemathesis
+from schemathesis.exceptions import CheckFailed
+from schemathesis.specs.openapi.stateful.links import make_response_filter, match_status_code
+from schemathesis.stateful import StepResult
+
+
+def make_response(status_code):
+    response = Response()
+    response.status_code = status_code
+    return response
+
+
+@pytest.mark.parametrize(
+    "response_status, filter_value, matching",
+    (
+        (200, 200, True),
+        (200, 201, False),
+        (200, "20X", True),
+    ),
+)
+def test_match_status_code(response_status, filter_value, matching):
+    # When the response has `response_status` status
+    response = make_response(response_status)
+    # And the filter should filter by `filter_value`
+    filter_function = match_status_code(filter_value)
+    assert filter_function.__name__ == f"match_{filter_value}_response"
+    # Then that response should match or not depending on the `matching` value
+    assert filter_function(StepResult(response, None)) is matching
+
+
+@pytest.mark.parametrize(
+    "response_status, status_codes, matching",
+    (
+        (202, [200, "default"], True),
+        (200, [200, "default"], False),
+        (200, ["20X", "default"], False),
+        (210, ["20X", "default"], True),
+    ),
+)
+def test_default_status_code(response_status, status_codes, matching):
+    response = make_response(response_status)
+    filter_function = make_response_filter("default", status_codes)
+    assert filter_function(StepResult(response, None)) is matching
+
+
+@pytest.mark.endpoints("create_user", "get_user", "update_user")
+def test_hidden_failure(testdir, app_schema, openapi3_base_url):
+    # When we run test as a state machine
+    testdir.make_test(
+        f"""
+schema.base_url = "{openapi3_base_url}"
+TestStateful = schema.as_state_machine().TestCase
+TestStateful.settings = settings(
+    max_examples=300,
+    deadline=None,
+    derandomize=True,
+    suppress_health_check=HealthCheck.all(),
+    stateful_step_count=5  # There is no need for longer sequences to uncover the bug
+)
+""",
+        schema=app_schema,
+    )
+    result = testdir.runpytest("--hypothesis-seed=42")
+    # Then it should be able to find a hidden error that happens on the following sequence of API calls:
+    # ["POST", "GET", "PATCH", "GET", "PATCH"]
+    result.assert_outcomes(failed=1)
+    # And there should be Python code to reproduce the error in the PATCH call
+    result.stdout.re_match_lines([rf"E +requests\.patch\('{openapi3_base_url}/users/\d+'.+"])
+    # And the reproducing example should work
+    first = result.outlines.index("Falsifying example:") + 1
+    last = result.outlines.index("state.teardown()") + 1
+    example = "\n".join(result.outlines[first:last])
+    testdir.make_test(
+        f"""
+schema.base_url = "{openapi3_base_url}"
+APIWorkflow = schema.as_state_machine()
+{example}
+    """,
+        schema=app_schema,
+    )
+    result = testdir.runpytest()
+    assert "E   schemathesis.exceptions.CheckFailed: " in result.outlines
+
+
+@pytest.mark.parametrize("factory_name", ("wsgi_app_factory", "asgi_app_factory"))
+def test_hidden_failure_app(request, factory_name, open_api_3):
+    factory = request.getfixturevalue(factory_name)
+    app = factory(endpoints=("create_user", "get_user", "update_user"), version=open_api_3)
+
+    if factory_name == "asgi_app_factory":
+        schema = schemathesis.from_asgi("/openapi.json", app=app)
+        schema.add_link(
+            source=schema["/users/"]["POST"],
+            target=schema["/users/{user_id}"]["GET"],
+            status_code="201",
+            parameters={
+                "path.user_id": "$response.body#/id",
+                "query.uid": "$response.body#/id",
+            },
+        )
+        schema.add_link(
+            source=schema["/users/"]["POST"],
+            target=schema["/users/{user_id}"]["PATCH"],
+            status_code="201",
+            parameters={"user_id": "$response.body#/id"},
+            request_body={"username": "foo"},
+        )
+        schema.add_link(
+            source=schema["/users/{user_id}"]["GET"],
+            target="#/paths/~1users~1{user_id}/patch",
+            status_code="200",
+            parameters={"user_id": "$response.body#/id"},
+            request_body={"username": "foo"},
+        )
+    else:
+        schema = schemathesis.from_wsgi("/schema.yaml", app=app)
+
+    state_machine = schema.as_state_machine()
+
+    with pytest.raises(CheckFailed, match="Received a response with 5xx status code: 500"):
+        run_state_machine_as_test(
+            state_machine,
+            settings=settings(
+                max_examples=300,
+                deadline=None,
+                suppress_health_check=HealthCheck.all(),
+                derandomize=True,
+                stateful_step_count=5,
+            ),
+        )
+
+
+def test_custom_rule(testdir, openapi3_base_url):
+    # When the state machine contains a failing rule that does not expect `Case`
+    testdir.make_test(
+        f"""
+from hypothesis.stateful import initialize, rule
+
+schema.base_url = "{openapi3_base_url}"
+
+class APIWorkflow(schema.as_state_machine()):
+
+    def validate_response(self, response, case):
+        pass
+
+    @rule(data=st.just("foo"))
+    def some(self, data):
+        assert 0
+
+TestStateful = APIWorkflow.TestCase
+""",
+    )
+    result = testdir.runpytest()
+    # Then the reproducing steps should be correctly displayed
+    result.assert_outcomes(failed=1)
+    result.stdout.re_match_lines([r"state.some\(data='foo'\)"])

--- a/test/specs/openapi/test_utils.py
+++ b/test/specs/openapi/test_utils.py
@@ -1,0 +1,16 @@
+import pytest
+
+from schemathesis.specs.openapi.utils import expand_status_code
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    (
+        (500, [500]),
+        ("500", [500]),
+        ("50X", list(range(500, 510))),
+        ("50x", list(range(500, 510))),
+    ),
+)
+def test_expand_status_code(value, expected):
+    assert list(expand_status_code(value)) == expected

--- a/test/test_dereferencing.py
+++ b/test/test_dereferencing.py
@@ -492,7 +492,7 @@ def test_complex_dereference(testdir, complex_schema):
     assert schema.endpoints["/teapot"]["POST"] == Endpoint(
         base_url="file:///",
         path="/teapot",
-        method="POST",
+        method="post",
         definition=EndpointDefinition(
             {
                 "requestBody": {
@@ -553,6 +553,7 @@ def test_complex_dereference(testdir, complex_schema):
                 "tags": ["ancillaries"],
             },
             scope=f"{path.as_uri()}/root/paths/teapot.yaml#/TeapotCreatePath",
+            parameters=[],
         ),
         body={
             "additionalProperties": False,

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -18,7 +18,7 @@ from schemathesis.specs.openapi._hypothesis import (
 
 
 def make_endpoint(schema, **kwargs) -> Endpoint:
-    return Endpoint("/users", "POST", definition=EndpointDefinition({}, {}, "foo"), schema=schema, **kwargs)
+    return Endpoint("/users", "POST", definition=EndpointDefinition({}, {}, "foo", []), schema=schema, **kwargs)
 
 
 @pytest.mark.parametrize("name", sorted(PARAMETERS))
@@ -47,7 +47,7 @@ def test_no_body_in_get(swagger_20):
     endpoint = Endpoint(
         path="/api/success",
         method="GET",
-        definition=EndpointDefinition({}, {}, "foo"),
+        definition=EndpointDefinition({}, {}, "foo", []),
         schema=swagger_20,
         query={
             "required": ["name"],
@@ -66,7 +66,7 @@ def test_invalid_body_in_get(swagger_20):
     endpoint = Endpoint(
         path="/foo",
         method="GET",
-        definition=EndpointDefinition({}, {}, "foo"),
+        definition=EndpointDefinition({}, {}, "foo", []),
         schema=swagger_20,
         body={"required": ["foo"], "type": "object", "properties": {"foo": {"type": "string"}}},
     )
@@ -80,7 +80,7 @@ def test_invalid_body_in_get_disable_validation(simple_schema):
     endpoint = Endpoint(
         path="/foo",
         method="GET",
-        definition=EndpointDefinition({}, {}, "foo"),
+        definition=EndpointDefinition({}, {}, "foo", []),
         schema=schema,
         body={"required": ["foo"], "type": "object", "properties": {"foo": {"type": "string"}}},
     )
@@ -168,7 +168,7 @@ def test_valid_headers(openapi2_base_url, swagger_20, definition):
     endpoint = Endpoint(
         "/api/success",
         "GET",
-        definition=EndpointDefinition({}, {}, "foo"),
+        definition=EndpointDefinition({}, {}, "foo", []),
         schema=swagger_20,
         base_url=openapi2_base_url,
         headers={

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -11,7 +11,7 @@ from schemathesis.models import Case, Endpoint, Request, Response
 
 def test_path(swagger_20):
     endpoint = Endpoint("/users/{name}", "GET", {}, swagger_20)
-    case = Case(endpoint, path_parameters={"name": "test"})
+    case = endpoint.make_case(path_parameters={"name": "test"})
     assert case.formatted_path == "/users/test"
 
 
@@ -20,12 +20,10 @@ def test_path(swagger_20):
 def test_as_requests_kwargs(override, server, base_url, swagger_20, converter):
     base_url = converter(base_url)
     endpoint = Endpoint("/success", "GET", {}, swagger_20)
-    kwargs = {"endpoint": endpoint, "cookies": {"TOKEN": "secret"}}
+    case = endpoint.make_case(cookies={"TOKEN": "secret"})
     if override:
-        case = Case(**kwargs)
         data = case.as_requests_kwargs(base_url)
     else:
-        case = Case(**kwargs)
         endpoint.base_url = base_url
         data = case.as_requests_kwargs()
     assert data == {
@@ -53,8 +51,7 @@ def test_as_requests_kwargs(override, server, base_url, swagger_20, converter):
 def test_as_requests_kwargs_override_user_agent(server, openapi2_base_url, swagger_20, headers, expected):
     endpoint = Endpoint("/success", "GET", {}, swagger_20, base_url=openapi2_base_url)
     original_headers = headers.copy() if headers is not None else headers
-    kwargs = {"endpoint": endpoint, "headers": headers}
-    case = Case(**kwargs)
+    case = endpoint.make_case(headers=headers)
     data = case.as_requests_kwargs(headers={"X-Key": "foo"})
     assert data == {
         "headers": expected,
@@ -74,12 +71,10 @@ def test_as_requests_kwargs_override_user_agent(server, openapi2_base_url, swagg
 @pytest.mark.filterwarnings("always")
 def test_call(override, base_url, swagger_20):
     endpoint = Endpoint("/success", "GET", {}, swagger_20)
-    kwargs = {"endpoint": endpoint}
+    case = endpoint.make_case()
     if override:
-        case = Case(**kwargs)
         response = case.call(base_url)
     else:
-        case = Case(**kwargs)
         endpoint.base_url = base_url
         response = case.call()
     assert response.status_code == 200

--- a/test/test_schemas.py
+++ b/test/test_schemas.py
@@ -134,4 +134,4 @@ def test_get_endpoint_by_operation_id(operation_id, path, method):
     schema = schemathesis.from_dict(SCHEMA)
     endpoint = schema.get_endpoint_by_operation_id(operation_id)
     assert endpoint.path == path
-    assert endpoint.method == method
+    assert endpoint.method.upper() == method


### PR DESCRIPTION
A draft for #737. It seems like this approach is much more flexible:
- Arbitrary action sequences. E.g. it could be calling some endpoints more than once - broader test surface.
- Adding the "source" attribute is trivial, since it is done in a "flatmap" strategy - just attach an attribute. With the current approach, it is much harder since it involves generating a new endpoint that contains a bunch of schemas in "anyOf" - there is no connection with the original response. So it is not clear what parameter came from what response - it might be done with attaching some extra mapping and passing it along until the case creation, which is quite hacky.
- Different parameter types can be carried together. Currently, all parameter types are chosen independently - changing is problematic (#584 )
- It doesn't have a problem when the deeper the call goes, the fewer parameter options are possible. It is just a different approach without this problem. The current approach behaves like this: 1st "POST" call returns 50 successful responses that are suitable for Open API link, then there are 50 options for e.g. subsequent "GET" call, then these 50 calls might return fewer successful responses for the next level, etc, so the number is decreasing. With the new approach, new POST calls may be done at any time and the number of "source" responses grows.
- It is much easier to implement multiple sources for a call - it boils down to using multiple bundles as a source for the `flatmap` call.

CLI integration probably in a separate PR.