### PR TITLE
feat: Shortcut for response validation when Schemathesis's data generation is not used

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Added**
+
+- Shortcut for response validation when Schemathesis's data generation is not used. `#485`_
+
 **Changed**
 
 - Improve the error message when the application can not be loaded from the value passed to the ``--app`` command-line option. `#836`_
@@ -1534,6 +1538,7 @@ Deprecated
 .. _#496: https://github.com/schemathesis/schemathesis/issues/496
 .. _#492: https://github.com/schemathesis/schemathesis/issues/492
 .. _#489: https://github.com/schemathesis/schemathesis/issues/489
+.. _#485: https://github.com/schemathesis/schemathesis/issues/485
 .. _#473: https://github.com/schemathesis/schemathesis/issues/473
 .. _#469: https://github.com/schemathesis/schemathesis/issues/469
 .. _#468: https://github.com/schemathesis/schemathesis/issues/468

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -263,6 +263,21 @@ When the received response is validated, Schemathesis runs the following checks:
 
 Validation happens in the ``case.validate_response`` function, but you can add your code to verify the response conformance as you do in regular Python tests.
 
+If you don't use Schemathesis for data generation, you can still utilize response validation:
+
+.. code-block:: python
+
+    schema = schemathesis.from_uri("http://0.0.0.0/openapi.json")
+
+    def test_api():
+        response = requests.get("http://0.0.0.0/api/users")
+        # Raises a validation error
+        schema["/users"]["GET"].validate_response(response)
+        # Returns a boolean value
+        schema["/users"]["GET"].is_response_valid(response)
+
+The response will be validated the same way as it is validated in the ``response_schema_conformance`` check.
+
 Using additional Hypothesis strategies
 --------------------------------------
 

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -509,6 +509,16 @@ class Endpoint:
         path = self.path.replace("~", "~0").replace("/", "~1")
         return f"#/paths/{path}/{self.method}"
 
+    def validate_response(self, response: GenericResponse) -> None:
+        return self.schema.validate_response(self, response)
+
+    def is_response_valid(self, response: GenericResponse) -> bool:
+        try:
+            self.validate_response(response)
+            return True
+        except CheckFailed:
+            return False
+
 
 class Status(IntEnum):
     """Status of an action or multiple actions."""

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -261,6 +261,9 @@ class BaseSchema(Mapping):
     def get_links(self, endpoint: Endpoint) -> Dict[str, Dict[str, Any]]:
         raise NotImplementedError
 
+    def validate_response(self, endpoint: Endpoint, response: GenericResponse) -> None:
+        raise NotImplementedError
+
 
 def endpoints_to_dict(endpoints: Generator[Endpoint, None, None]) -> Dict[str, CaseInsensitiveDict]:
     output: Dict[str, CaseInsensitiveDict] = {}

--- a/test/runner/test_checks.py
+++ b/test/runner/test_checks.py
@@ -266,6 +266,7 @@ def test_response_schema_conformance_swagger(swagger_20, content, definition):
     response = make_response(content)
     case = make_case(swagger_20, definition)
     assert response_schema_conformance(response, case) is None
+    assert case.endpoint.is_response_valid(response)
 
 
 def test_response_schema_conformance_swagger_no_content_header(swagger_20):
@@ -324,6 +325,7 @@ def test_response_schema_conformance_openapi(openapi_30, content, definition):
     response = make_response(content)
     case = make_case(openapi_30, definition)
     assert response_schema_conformance(response, case) is None
+    assert case.endpoint.is_response_valid(response)
 
 
 @pytest.mark.parametrize(
@@ -338,6 +340,7 @@ def test_response_schema_conformance_invalid_swagger(swagger_20, content, defini
     case = make_case(swagger_20, definition)
     with pytest.raises(AssertionError) as exc_info:
         response_schema_conformance(response, case)
+    assert not case.endpoint.is_response_valid(response)
     assert "SchemaValidationError" in exc_info.type.__name__
 
 
@@ -367,6 +370,7 @@ def test_response_schema_conformance_invalid_openapi(openapi_30, content, defini
     case = make_case(openapi_30, definition)
     with pytest.raises(AssertionError):
         response_schema_conformance(response, case)
+    assert not case.endpoint.is_response_valid(response)
 
 
 @pytest.mark.hypothesis_nested
@@ -379,6 +383,7 @@ def test_response_schema_conformance_references_invalid(complex_schema):
         response = make_response(json.dumps({"foo": 1}).encode())
         with pytest.raises(AssertionError):
             case.validate_response(response)
+        assert not case.endpoint.is_response_valid(response)
 
     test()
 


### PR DESCRIPTION
A part of #485, but without automatic endpoint detection.

TODO:
- [x] Add tests specific to `is_valid_response`