### PR TITLE
chore: Improve error messages on invalid schemas and response validation errors

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,7 @@ User's Guide
    python
    stateful
    how
+   schemas
    compatibility
    examples
    graphql

--- a/docs/schemas.rst
+++ b/docs/schemas.rst
@@ -1,0 +1,26 @@
+************************
+Working with API schemas
+************************
+
+To effectively test API schemas, you need to fulfill certain Schemathesis’s expectations about them.
+This page describes how Schemathesis works with API schemas and how you can solve common problems and make testing more effective.
+
+Validation
+----------
+
+By default, Schemathesis validates Open API schemas according to their
+`official meta schemas <https://github.com/OAI/OpenAPI-Specification/tree/master/schemas>`_, defined in the JSON Schema format.
+
+If the input schema contains an error, you'll see an error like this:
+
+.. code-block::
+
+    Error: jsonschema.exceptions.ValidationError: 'query' is not one of ['body']
+
+    Failed validating 'enum' in schema[0]['properties']['in']:
+        {'description': 'Determines the location of the parameter.',
+         'enum': ['body'],
+         'type': 'string'}
+
+    On instance['in']:
+        'query'

--- a/src/schemathesis/exceptions.py
+++ b/src/schemathesis/exceptions.py
@@ -1,11 +1,12 @@
 from hashlib import sha1
 from json import JSONDecodeError
-from typing import Any, Callable, Dict, NoReturn, Optional, Type, Union
+from typing import Any, Callable, Dict, List, NoReturn, Optional, Type, Union
 
 import attr
-from jsonschema import ValidationError
+import jsonschema
 
 from .constants import SERIALIZERS_SUGGESTION_MESSAGE
+from .specs.openapi.definitions import OPENAPI_30_VALIDATOR, SWAGGER_20_VALIDATOR
 from .utils import GenericResponse
 
 
@@ -67,7 +68,7 @@ def get_missing_content_type_error() -> Type[CheckFailed]:
     return get_exception("MissingContentTypeError")
 
 
-def get_schema_validation_error(exception: ValidationError) -> Type[CheckFailed]:
+def get_schema_validation_error(exception: jsonschema.ValidationError) -> Type[CheckFailed]:
     """Return new exception for schema validation error."""
     return _get_hashed_exception("SchemaValidationError", str(exception))
 
@@ -80,29 +81,6 @@ def get_response_parsing_error(exception: JSONDecodeError) -> Type[CheckFailed]:
 def get_headers_error(message: str) -> Type[CheckFailed]:
     """Return new exception for missing headers."""
     return _get_hashed_exception("MissingHeadersError", message)
-
-
-@attr.s(slots=True)
-class InvalidSchema(Exception):
-    """Schema associated with an API operation contains an error."""
-
-    __module__ = "builtins"
-    message: Optional[str] = attr.ib(default=None)
-    path: Optional[str] = attr.ib(default=None)
-    method: Optional[str] = attr.ib(default=None)
-    full_path: Optional[str] = attr.ib(default=None)
-
-    def as_failing_test_function(self) -> Callable:
-        """Create a test function that will fail.
-
-        This approach allows us to use default pytest reporting style for operation-level schema errors.
-        """
-
-        def actual_test(*args: Any, **kwargs: Any) -> NoReturn:
-            __tracebackhide__ = True  # pylint: disable=unused-variable
-            raise self
-
-        return actual_test
 
 
 class NonCheckError(Exception):
@@ -142,3 +120,111 @@ class InvalidRegularExpression(Exception):
 class HTTPError(Exception):
     response: GenericResponse = attr.ib()  # pragma: no mutate
     url: str = attr.ib()  # pragma: no mutate
+
+
+@attr.s(slots=True)
+class InvalidSchema(Exception):
+    """Schema associated with an API operation contains an error."""
+
+    __module__ = "builtins"
+    message: Optional[str] = attr.ib(default=None)
+    path: Optional[str] = attr.ib(default=None)
+    method: Optional[str] = attr.ib(default=None)
+    full_path: Optional[str] = attr.ib(default=None)
+
+    def as_failing_test_function(self) -> Callable:
+        """Create a test function that will fail.
+
+        This approach allows us to use default pytest reporting style for operation-level schema errors.
+        """
+
+        def actual_test(*args: Any, **kwargs: Any) -> NoReturn:
+            __tracebackhide__ = True  # pylint: disable=unused-variable
+            raise self
+
+        return actual_test
+
+    @classmethod
+    def from_jsonschema(cls, exc: jsonschema.ValidationError, spec: str) -> "InvalidSchema":
+        # TODO. We need some heuristics to choose the most clear error description among the error tree.
+        # Not sure if it will work in all cases :( But errors like `"'query' is not one of ['header']"` are misleading
+        # "'int' is not one of ['string', 'number', 'boolean', 'integer', 'array']" might work better
+        # Ideas:
+        #   - $ref validator errors are not that important among oneOf/anyOf errors. How to detect that the schema is
+        #     `{"$ref": "#/definitions/jsonReference"}` ? by schema value? or check paths in the schema?
+        reason = exc.message
+        message = INVALID_SCHEMA_MESSAGE.format(
+            spec=spec,
+            location=f"schema{format_as_index(exc.absolute_path)}",
+            value=exc.instance,
+            reason=reason,
+        )
+        return cls(message)
+
+
+def format_as_index(indices: List) -> str:
+    if not indices:
+        return ""
+    return f"[{']['.join(repr(index) for index in indices)}]"
+
+
+# TODO.
+#   - improve formatting
+#   - move to another module - it belongs to open api
+#   - add the actual schema, why it is failed
+#   - display all references, so people can follow them
+#   - for "response schema" there should be a prefix
+#   - Write an error message below
+NUMERIC_STATUS_CODE_ERROR = ""
+INVALID_SCHEMA_MESSAGE = (
+    "\n\nYour schema does not conform to the {spec} specification!\n\n"
+    "Location:\n\n    {location}\n\n"
+    "Value:\n\n    {value}\n\n"
+    "Reason:\n\n    {reason}"
+)
+
+
+def _is_numeric_status_code_error(exc: TypeError) -> bool:
+    # TODO. Implement + doc why do we care (it is the most common schema error)
+    return True
+
+
+SCHEMA_ID_TO_NAME = {
+    SWAGGER_20_VALIDATOR: "Swagger 2.0",
+    OPENAPI_30_VALIDATOR: "Open API 3.0",
+}
+
+
+def validate_schema(instance: Dict[str, Any], validator: jsonschema.validators.Draft4Validator) -> None:
+    """Validate API schema against the given metaschema.
+
+    Exceptions, that happen during validation with `jsonschema` are very generic and often provide too much information
+    about the problem. Here we adapt these exceptions to API schema validation context and make more concise
+    error messages.
+    """
+    spec = SCHEMA_ID_TO_NAME[validator]
+    try:
+        errors = validator.iter_errors(instance)
+        error = next(errors)
+        if error is None:
+            return None
+        raise InvalidSchema.from_jsonschema(error, spec)
+    except TypeError as exc:
+        # Sometimes `jsonschema` raises exceptions on input that is not technically valid JSON but
+        # a valid Python object. For example, in JSON, all object keys are strings, but in Python dictionaries
+        # may have, e.g., integer keys, and they will be casted to strings during JSON serialization:
+        #
+        #   >>> json.dumps({200: "text"})
+        #   '{"200": "text"}'
+        #
+        # For this reason, such schemas are not valid, and Schemathesis needs to report it.
+        # The problem might be solved by serializing/deserializing the schema with:
+        #
+        #   >>> json.loads(json.dumps(schema))
+        #
+        # However, Schemathesis aims to report invalid schemas rather than trying to fix the input schema.
+        # See more information about this `jsonschema` behavior in this issue:
+        # https://github.com/Julian/jsonschema/pull/286
+        if _is_numeric_status_code_error(exc):
+            raise InvalidSchema(NUMERIC_STATUS_CODE_ERROR) from exc
+        raise

--- a/src/schemathesis/loaders.py
+++ b/src/schemathesis/loaders.py
@@ -5,14 +5,13 @@ from urllib.parse import urljoin
 import jsonschema
 import requests
 import yaml
-from jsonschema import ValidationError
 from starlette.applications import Starlette
 from starlette.testclient import TestClient as ASGIClient
 from werkzeug.test import Client
 from yarl import URL
 
+from . import exceptions
 from .constants import DEFAULT_DATA_GENERATION_METHODS, USER_AGENT, DataGenerationMethod
-from .exceptions import HTTPError
 from .hooks import HookContext, dispatch
 from .lazy import LazySchema
 from .specs.openapi import definitions
@@ -83,7 +82,7 @@ def from_uri(
     try:
         response.raise_for_status()
     except requests.HTTPError as exc:
-        raise HTTPError(response=response, url=uri) from exc
+        raise exceptions.HTTPError(response=response, url=uri) from exc
     return from_file(
         response.text,
         location=uri,
@@ -205,10 +204,7 @@ def _maybe_validate_schema(
     instance: Dict[str, Any], validator: jsonschema.validators.Draft4Validator, validate_schema: bool
 ) -> None:
     if validate_schema:
-        try:
-            validator.validate(instance)
-        except TypeError as exc:
-            raise ValidationError("Invalid schema") from exc
+        exceptions.validate_schema(instance, validator)
 
 
 def from_pytest_fixture(
@@ -370,7 +366,7 @@ def check_response(response: requests.Response, schema_path: str) -> None:
     # Raising exception to provide unified behavior
     # E.g. it will be handled in CLI - a proper error message will be shown
     if 400 <= response.status_code < 600:
-        raise HTTPError(response=response, url=schema_path)
+        raise exceptions.HTTPError(response=response, url=schema_path)
 
 
 def _setup_headers(kwargs: Dict[str, Any]) -> None:

--- a/test/test_schema_errors.py
+++ b/test/test_schema_errors.py
@@ -1,0 +1,54 @@
+import pytest
+
+from schemathesis.exceptions import NUMERIC_STATUS_CODE_ERROR, InvalidSchema, validate_schema
+from schemathesis.specs.openapi.definitions import OPENAPI_30, SWAGGER_20
+
+
+def test_numeric_status_codes():
+    schema = {
+        "openapi": "3.0.2",
+        "info": {"title": "Test", "description": "Test", "version": "0.1.0"},
+        "paths": {
+            "/users": {
+                "get": {
+                    "responses": {
+                        # Response code should be a string
+                        200: {"description": "OK"}
+                    }
+                }
+            }
+        },
+    }
+    with pytest.raises(InvalidSchema, match=NUMERIC_STATUS_CODE_ERROR):
+        validate_schema(schema, OPENAPI_30)
+
+
+def test_root_error():
+    schema = {
+        "openapi": 123,
+        "info": {"title": "Test", "description": "Test", "version": "0.1.0"},
+        "paths": {},
+    }
+    # TODO. Add more detail error message check
+    with pytest.raises(InvalidSchema, match="Your schema does not conform to the Open API 3.0 specification!"):
+        validate_schema(schema, OPENAPI_30)
+
+
+def test_error_in_parameters():
+    schema = {
+        "swagger": "2.0",
+        "info": {"title": "Test", "description": "Test", "version": "0.1.0"},
+        "paths": {
+            "/users": {
+                "get": {
+                    "parameters": [
+                        # Type should be "integer"
+                        {"in": "query", "type": "int"}
+                    ],
+                    "responses": {"200": {"description": "OK"}},
+                }
+            }
+        },
+    }
+    # with pytest.raises(InvalidSchema):
+    validate_schema(schema, SWAGGER_20)


### PR DESCRIPTION
TODO:
- [ ] Documentation on schema validation (a separate section + FAQ entry on status codes)
- [ ] Docstrings
- [ ] Tests for schemas with references, big schemas (to see that the error message is still comprehendible), response validation errors
- [x] Refs to the jsonschema issue on `patternProperties` & `TypeError`
- [ ] Handle prefixes for response validation errors
- [ ] Better formatting for invalid schema messages (actual schema)
- [ ] Specific error message for numeric status codes
- [ ] Ensure that some frames are hidden - some details from `jsonschema` shouldn't bother the end-user
- [ ] Show all references - if it is a separate file, then it should be clear, so people can look directly to that file and find the error cause faster
- [ ] Display the proper spec version
- [ ] Detect the "numeric status code" TypeError
- [ ] Changelog entry

Resolves #834 
Resolves #829