### PR TITLE
chore: Add a `data_generation_methods` option

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,11 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Added**
+
+- An option to set data generation methods. At the moment, it includes only "positive", which means that Schemathesis will
+  generate data that matches the schema.
+
 `2.7.5`_ - 2020-11-09
 ---------------------
 

--- a/src/schemathesis/__init__.py
+++ b/src/schemathesis/__init__.py
@@ -1,6 +1,6 @@
 from . import fixups, hooks, targets
 from .cli import register_check, register_target
-from .constants import __version__
+from .constants import DataGenerationMethod, __version__
 from .loaders import from_asgi, from_dict, from_file, from_path, from_pytest_fixture, from_uri, from_wsgi
 from .models import Case
 from .specs import graphql

--- a/src/schemathesis/checks.py
+++ b/src/schemathesis/checks.py
@@ -21,7 +21,7 @@ def not_a_server_error(response: GenericResponse, case: "Case") -> Optional[bool
     return None
 
 
-DEFAULT_CHECKS = (not_a_server_error,)
+DEFAULT_CHECKS: Tuple["CheckFunction", ...] = (not_a_server_error,)
 OPTIONAL_CHECKS = (
     status_code_conformance,
     content_type_conformance,

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -11,7 +11,7 @@ import yaml
 from .. import checks as checks_module
 from .. import runner
 from .. import targets as targets_module
-from ..constants import DEFAULT_STATEFUL_RECURSION_LIMIT
+from ..constants import DEFAULT_DATA_GENERATION_METHODS, DEFAULT_STATEFUL_RECURSION_LIMIT, DataGenerationMethod
 from ..fixups import ALL_FIXUPS
 from ..hooks import GLOBAL_HOOK_DISPATCHER, HookContext, HookDispatcher, HookScope
 from ..models import CheckFunction
@@ -91,6 +91,14 @@ def schemathesis(pre_run: Optional[str] = None) -> None:
 @click.argument("schema", type=str, callback=callbacks.validate_schema)
 @click.option(
     "--checks", "-c", multiple=True, help="List of checks to run.", type=CHECKS_TYPE, default=DEFAULT_CHECKS_NAMES
+)
+@click.option(
+    "--data-generation-method",
+    "-D",
+    "data_generation_methods",
+    help="Defines how Schemathesis generates data for tests.",
+    type=CSVOption(DataGenerationMethod),
+    default=DataGenerationMethod.default(),
 )
 @click.option(
     "--max-response-time",
@@ -259,6 +267,7 @@ def run(  # pylint: disable=too-many-arguments
     auth_type: str,
     headers: Dict[str, str],
     checks: Iterable[str] = DEFAULT_CHECKS_NAMES,
+    data_generation_methods: Tuple[DataGenerationMethod, ...] = DEFAULT_DATA_GENERATION_METHODS,
     max_response_time: Optional[int] = None,
     targets: Iterable[str] = DEFAULT_TARGETS_NAMES,
     exit_first: bool = False,
@@ -316,6 +325,7 @@ def run(  # pylint: disable=too-many-arguments
         exit_first=exit_first,
         store_interactions=store_network_log is not None,
         checks=selected_checks,
+        data_generation_methods=data_generation_methods,
         max_response_time=max_response_time,
         targets=selected_targets,
         workers_num=workers_num,

--- a/src/schemathesis/cli/output/default.py
+++ b/src/schemathesis/cli/output/default.py
@@ -19,16 +19,17 @@ def get_terminal_width() -> int:
     return shutil.get_terminal_size().columns
 
 
-def display_section_name(title: str, separator: str = "=", **kwargs: Any) -> None:
+def display_section_name(title: str, separator: str = "=", extra: str = "", **kwargs: Any) -> None:
     """Print section name with separators in terminal with the given title nicely centered."""
-    message = f" {title} ".center(get_terminal_width(), separator)
+    extra = extra if not extra else f" [{extra}]"
+    message = f" {title}{extra} ".center(get_terminal_width(), separator)
     kwargs.setdefault("bold", True)
     click.secho(message, **kwargs)
 
 
 def display_subsection(result: SerializedTestResult, color: Optional[str] = "red") -> None:
     section_name = f"{result.method}: {result.path}"
-    display_section_name(section_name, "_", fg=color)
+    display_section_name(section_name, "_", result.data_generation_method, fg=color)
 
 
 def get_percentage(position: int, length: int) -> str:

--- a/src/schemathesis/constants.py
+++ b/src/schemathesis/constants.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from ._compat import metadata
 
 try:
@@ -10,3 +12,22 @@ except metadata.PackageNotFoundError:
 USER_AGENT = f"schemathesis/{__version__}"
 DEFAULT_DEADLINE = 500  # pragma: no mutate
 DEFAULT_STATEFUL_RECURSION_LIMIT = 5  # pragma: no mutate
+
+
+class DataGenerationMethod(str, Enum):
+    """Defines what data Schemathesis generates for tests."""
+
+    # Generate data, that fits the API schema
+    positive = "positive"
+
+    @classmethod
+    def default(cls) -> "DataGenerationMethod":
+        return cls.positive
+
+    def as_short_name(self) -> str:
+        return {
+            DataGenerationMethod.positive: "P",
+        }[self]
+
+
+DEFAULT_DATA_GENERATION_METHODS = (DataGenerationMethod.default(),)

--- a/src/schemathesis/loaders.py
+++ b/src/schemathesis/loaders.py
@@ -1,6 +1,6 @@
 # pylint: disable=too-many-arguments
 import pathlib
-from typing import IO, Any, Callable, Dict, Optional, Union
+from typing import IO, Any, Callable, Dict, Iterable, Optional, Union
 from urllib.parse import urljoin
 
 import jsonschema
@@ -12,7 +12,7 @@ from starlette.testclient import TestClient as ASGIClient
 from werkzeug.test import Client
 from yarl import URL
 
-from .constants import USER_AGENT
+from .constants import DEFAULT_DATA_GENERATION_METHODS, USER_AGENT, DataGenerationMethod
 from .exceptions import HTTPError
 from .hooks import HookContext, dispatch
 from .lazy import LazySchema
@@ -33,6 +33,7 @@ def from_path(
     app: Any = None,
     validate_schema: bool = True,
     skip_deprecated_endpoints: bool = False,
+    data_generation_methods: Iterable[DataGenerationMethod] = DEFAULT_DATA_GENERATION_METHODS,
 ) -> BaseOpenAPISchema:
     """Load a file from OS path and parse to schema instance."""
     with open(path) as fd:
@@ -47,6 +48,7 @@ def from_path(
             app=app,
             validate_schema=validate_schema,
             skip_deprecated_endpoints=skip_deprecated_endpoints,
+            data_generation_methods=data_generation_methods,
         )
 
 
@@ -62,6 +64,7 @@ def from_uri(
     app: Any = None,
     validate_schema: bool = True,
     skip_deprecated_endpoints: bool = False,
+    data_generation_methods: Iterable[DataGenerationMethod] = DEFAULT_DATA_GENERATION_METHODS,
     **kwargs: Any,
 ) -> BaseOpenAPISchema:
     """Load a remote resource and parse to schema instance."""
@@ -86,6 +89,7 @@ def from_uri(
         app=app,
         validate_schema=validate_schema,
         skip_deprecated_endpoints=skip_deprecated_endpoints,
+        data_generation_methods=data_generation_methods,
     )
 
 
@@ -101,6 +105,7 @@ def from_file(
     app: Any = None,
     validate_schema: bool = True,
     skip_deprecated_endpoints: bool = False,
+    data_generation_methods: Iterable[DataGenerationMethod] = DEFAULT_DATA_GENERATION_METHODS,
     **kwargs: Any,  # needed in the runner to have compatible API across all loaders
 ) -> BaseOpenAPISchema:
     """Load a file content and parse to schema instance.
@@ -119,6 +124,7 @@ def from_file(
         app=app,
         validate_schema=validate_schema,
         skip_deprecated_endpoints=skip_deprecated_endpoints,
+        data_generation_methods=data_generation_methods,
     )
 
 
@@ -134,6 +140,7 @@ def from_dict(
     app: Any = None,
     validate_schema: bool = True,
     skip_deprecated_endpoints: bool = False,
+    data_generation_methods: Iterable[DataGenerationMethod] = DEFAULT_DATA_GENERATION_METHODS,
 ) -> BaseOpenAPISchema:
     """Get a proper abstraction for the given raw schema."""
     dispatch("before_load_schema", HookContext(), raw_schema)
@@ -150,6 +157,7 @@ def from_dict(
             app=app,
             validate_schema=validate_schema,
             skip_deprecated_endpoints=skip_deprecated_endpoints,
+            data_generation_methods=data_generation_methods,
         )
 
     if "openapi" in raw_schema:
@@ -165,6 +173,7 @@ def from_dict(
             app=app,
             validate_schema=validate_schema,
             skip_deprecated_endpoints=skip_deprecated_endpoints,
+            data_generation_methods=data_generation_methods,
         )
     raise ValueError("Unsupported schema type")
 
@@ -185,6 +194,7 @@ def from_pytest_fixture(
     operation_id: Optional[Filter] = NOT_SET,
     validate_schema: bool = True,
     skip_deprecated_endpoints: bool = False,
+    data_generation_methods: Iterable[DataGenerationMethod] = DEFAULT_DATA_GENERATION_METHODS,
 ) -> LazySchema:
     """Needed for a consistent library API."""
     return LazySchema(
@@ -195,6 +205,7 @@ def from_pytest_fixture(
         operation_id=operation_id,
         validate_schema=validate_schema,
         skip_deprecated_endpoints=skip_deprecated_endpoints,
+        data_generation_methods=data_generation_methods,
     )
 
 
@@ -208,6 +219,7 @@ def from_wsgi(
     operation_id: Optional[Filter] = None,
     validate_schema: bool = True,
     skip_deprecated_endpoints: bool = False,
+    data_generation_methods: Iterable[DataGenerationMethod] = DEFAULT_DATA_GENERATION_METHODS,
     **kwargs: Any,
 ) -> BaseOpenAPISchema:
     headers = kwargs.setdefault("headers", {})
@@ -230,6 +242,7 @@ def from_wsgi(
         app=app,
         validate_schema=validate_schema,
         skip_deprecated_endpoints=skip_deprecated_endpoints,
+        data_generation_methods=data_generation_methods,
     )
 
 
@@ -252,6 +265,7 @@ def from_aiohttp(
     *,
     validate_schema: bool = True,
     skip_deprecated_endpoints: bool = False,
+    data_generation_methods: Iterable[DataGenerationMethod] = DEFAULT_DATA_GENERATION_METHODS,
     **kwargs: Any,
 ) -> BaseOpenAPISchema:
     from .extra._aiohttp import run_server  # pylint: disable=import-outside-toplevel
@@ -268,6 +282,7 @@ def from_aiohttp(
         operation_id=operation_id,
         validate_schema=validate_schema,
         skip_deprecated_endpoints=skip_deprecated_endpoints,
+        data_generation_methods=data_generation_methods,
         **kwargs,
     )
 
@@ -281,6 +296,7 @@ def from_asgi(
     tag: Optional[Filter] = None,
     validate_schema: bool = True,
     skip_deprecated_endpoints: bool = False,
+    data_generation_methods: Iterable[DataGenerationMethod] = DEFAULT_DATA_GENERATION_METHODS,
     **kwargs: Any,
 ) -> BaseOpenAPISchema:
     headers = kwargs.setdefault("headers", {})
@@ -302,4 +318,5 @@ def from_asgi(
         app=app,
         validate_schema=validate_schema,
         skip_deprecated_endpoints=skip_deprecated_endpoints,
+        data_generation_methods=data_generation_methods,
     )

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -17,7 +17,7 @@ import werkzeug
 from hypothesis.strategies import SearchStrategy
 from starlette.testclient import TestClient as ASGIClient
 
-from .constants import USER_AGENT
+from .constants import USER_AGENT, DataGenerationMethod
 from .exceptions import CheckFailed, InvalidSchema, get_grouped_exception
 from .types import Body, Cookies, FormData, Headers, PathParameters, Query
 from .utils import GenericResponse, WSGIResponse
@@ -429,9 +429,12 @@ class Endpoint:
         return self.schema.get_links(self)
 
     def as_strategy(
-        self, hooks: Optional["HookDispatcher"] = None, feedback: Optional["Feedback"] = None
+        self,
+        hooks: Optional["HookDispatcher"] = None,
+        feedback: Optional["Feedback"] = None,
+        data_generation_method: DataGenerationMethod = DataGenerationMethod.default(),
     ) -> SearchStrategy:
-        return self.schema.get_case_strategy(self, hooks, feedback)
+        return self.schema.get_case_strategy(self, hooks, feedback, data_generation_method)
 
     def get_strategies_from_examples(self) -> List[SearchStrategy[Case]]:
         """Get examples from the endpoint."""
@@ -668,6 +671,7 @@ class TestResult:
     """Result of a single test."""
 
     endpoint: Endpoint = attr.ib()  # pragma: no mutate
+    data_generation_method: DataGenerationMethod = attr.ib()  # pragma: no mutate
     checks: List[Check] = attr.ib(factory=list)  # pragma: no mutate
     errors: List[Tuple[Exception, Optional[Case]]] = attr.ib(factory=list)  # pragma: no mutate
     interactions: List[Interaction] = attr.ib(factory=list)  # pragma: no mutate

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -7,7 +7,7 @@ from starlette.applications import Starlette
 from .. import fixups as _fixups
 from .. import loaders
 from ..checks import DEFAULT_CHECKS
-from ..constants import DEFAULT_STATEFUL_RECURSION_LIMIT
+from ..constants import DEFAULT_DATA_GENERATION_METHODS, DEFAULT_STATEFUL_RECURSION_LIMIT, DataGenerationMethod
 from ..models import CheckFunction
 from ..schemas import BaseSchema
 from ..stateful import Stateful
@@ -31,6 +31,7 @@ def prepare(  # pylint: disable=too-many-arguments
     *,
     # Runtime behavior
     checks: Iterable[CheckFunction] = DEFAULT_CHECKS,
+    data_generation_methods: Tuple[DataGenerationMethod, ...] = DEFAULT_DATA_GENERATION_METHODS,
     max_response_time: Optional[int] = None,
     targets: Iterable[Target] = DEFAULT_TARGETS,
     workers_num: int = 1,
@@ -92,6 +93,7 @@ def prepare(  # pylint: disable=too-many-arguments
         validate_schema=validate_schema,
         skip_deprecated_endpoints=skip_deprecated_endpoints,
         checks=checks,
+        data_generation_methods=data_generation_methods,
         max_response_time=max_response_time,
         targets=targets,
         hypothesis_options=hypothesis_options,
@@ -141,6 +143,7 @@ def execute_from_schema(
     validate_schema: bool = True,
     skip_deprecated_endpoints: bool = False,
     checks: Iterable[CheckFunction],
+    data_generation_methods: Tuple[DataGenerationMethod, ...] = DEFAULT_DATA_GENERATION_METHODS,
     max_response_time: Optional[int] = None,
     targets: Iterable[Target],
     workers_num: int = 1,
@@ -184,6 +187,7 @@ def execute_from_schema(
             method=method,
             tag=tag,
             operation_id=operation_id,
+            data_generation_methods=data_generation_methods,
         )
 
         runner: BaseRunner
@@ -305,6 +309,7 @@ def load_schema(
     app: Any = None,
     validate_schema: bool = True,
     skip_deprecated_endpoints: bool = False,
+    data_generation_methods: Tuple[DataGenerationMethod, ...] = DEFAULT_DATA_GENERATION_METHODS,
     # Network request parameters
     auth: Optional[Tuple[str, str]] = None,
     auth_type: Optional[str] = None,
@@ -317,7 +322,13 @@ def load_schema(
 ) -> BaseSchema:
     """Load schema via specified loader and parameters."""
     loader_options = dict_true_values(
-        base_url=base_url, endpoint=endpoint, method=method, tag=tag, operation_id=operation_id, app=app
+        base_url=base_url,
+        endpoint=endpoint,
+        method=method,
+        tag=tag,
+        operation_id=operation_id,
+        app=app,
+        data_generation_methods=data_generation_methods,
     )
 
     if not isinstance(schema_uri, dict):

--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -40,8 +40,17 @@ class Initialized(ExecutionEvent):
         )
 
 
+class CurrentPathMixin:
+    method: str
+    path: str
+
+    @property
+    def current_endpoint(self) -> str:
+        return f"{self.method} {self.path}"
+
+
 @attr.s(slots=True)  # pragma: no mutate
-class BeforeExecution(ExecutionEvent):
+class BeforeExecution(CurrentPathMixin, ExecutionEvent):
     """Happens before each examined endpoint.
 
     It happens before a single hypothesis test, that may contain many examples inside.
@@ -63,7 +72,7 @@ class BeforeExecution(ExecutionEvent):
 
 
 @attr.s(slots=True)  # pragma: no mutate
-class AfterExecution(ExecutionEvent):
+class AfterExecution(CurrentPathMixin, ExecutionEvent):
     """Happens after each examined endpoint."""
 
     method: str = attr.ib()  # pragma: no mutate

--- a/src/schemathesis/runner/serialization.py
+++ b/src/schemathesis/runner/serialization.py
@@ -87,6 +87,7 @@ class SerializedTestResult:
     has_logs: bool = attr.ib()  # pragma: no mutate
     is_errored: bool = attr.ib()  # pragma: no mutate
     seed: Optional[int] = attr.ib()  # pragma: no mutate
+    data_generation_method: str = attr.ib()  # pragma: no mutate
     checks: List[SerializedCheck] = attr.ib()  # pragma: no mutate
     logs: List[str] = attr.ib()  # pragma: no mutate
     errors: List[SerializedError] = attr.ib()  # pragma: no mutate
@@ -103,6 +104,7 @@ class SerializedTestResult:
             has_logs=result.has_logs,
             is_errored=result.is_errored,
             seed=result.seed,
+            data_generation_method=result.data_generation_method.as_short_name(),
             checks=[SerializedCheck.from_check(check, headers=result.overridden_headers) for check in result.checks],
             logs=[formatter.format(record) for record in result.logs],
             errors=[SerializedError.from_error(*error, headers=result.overridden_headers) for error in result.errors],

--- a/src/schemathesis/specs/graphql/loaders.py
+++ b/src/schemathesis/specs/graphql/loaders.py
@@ -99,4 +99,4 @@ def from_url(url: str) -> GraphQLSchema:
 
 def from_dict(raw_schema: Dict[str, Any], location: Optional[str] = None) -> GraphQLSchema:
     dispatch("before_load_schema", HookContext(), raw_schema)
-    return GraphQLSchema(raw_schema, location=location)
+    return GraphQLSchema(raw_schema, location=location)  # type: ignore

--- a/src/schemathesis/specs/graphql/schemas.py
+++ b/src/schemathesis/specs/graphql/schemas.py
@@ -8,6 +8,7 @@ from hypothesis import strategies as st
 from hypothesis.strategies import SearchStrategy
 from hypothesis_graphql import strategies as gql_st
 
+from ... import DataGenerationMethod
 from ...checks import not_a_server_error
 from ...hooks import HookDispatcher
 from ...models import Case, CheckFunction, Endpoint
@@ -70,7 +71,11 @@ class GraphQLSchema(BaseSchema):
         )
 
     def get_case_strategy(
-        self, endpoint: Endpoint, hooks: Optional[HookDispatcher] = None, feedback: Optional[Feedback] = None
+        self,
+        endpoint: Endpoint,
+        hooks: Optional[HookDispatcher] = None,
+        feedback: Optional[Feedback] = None,
+        data_generation_method: DataGenerationMethod = DataGenerationMethod.default(),
     ) -> SearchStrategy:
         constructor = partial(GraphQLCase, endpoint=endpoint)
         schema = graphql.build_client_schema(self.raw_schema)

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -12,6 +12,7 @@ import jsonschema
 import requests
 from hypothesis.strategies import SearchStrategy
 
+from ...constants import DataGenerationMethod
 from ...exceptions import InvalidSchema, get_response_parsing_error, get_schema_validation_error
 from ...hooks import HookContext, HookDispatcher
 from ...models import Case, Endpoint, EndpointDefinition, empty_object
@@ -185,9 +186,13 @@ class BaseOpenAPISchema(BaseSchema):
         return self.make_endpoint(path, method, parameters, resolved_definition, raw_definition)
 
     def get_case_strategy(
-        self, endpoint: Endpoint, hooks: Optional[HookDispatcher] = None, feedback: Optional[Feedback] = None
+        self,
+        endpoint: Endpoint,
+        hooks: Optional[HookDispatcher] = None,
+        feedback: Optional[Feedback] = None,
+        data_generation_method: DataGenerationMethod = DataGenerationMethod.default(),
     ) -> SearchStrategy:
-        return get_case_strategy(endpoint, hooks, feedback)
+        return get_case_strategy(endpoint, hooks, feedback, data_generation_method)
 
     def get_hypothesis_conversion(self, endpoint: Endpoint, location: str) -> Optional[Callable]:
         definitions = [item for item in endpoint.definition.resolved.get("parameters", []) if item["in"] == location]

--- a/src/schemathesis/stateful.py
+++ b/src/schemathesis/stateful.py
@@ -8,6 +8,7 @@ from hypothesis.stateful import RuleBasedStateMachine
 from requests.structures import CaseInsensitiveDict
 from starlette.applications import Starlette
 
+from .constants import DataGenerationMethod
 from .exceptions import InvalidSchema
 from .models import Case, CheckFunction, Endpoint
 from .utils import NOT_SET, GenericResponse
@@ -91,13 +92,16 @@ class Feedback:
 
     def get_stateful_tests(
         self, test: Callable, settings: Optional[hypothesis.settings], seed: Optional[int]
-    ) -> Generator[Tuple[Endpoint, Union[Callable, InvalidSchema]], None, None]:
+    ) -> Generator[Tuple[Endpoint, DataGenerationMethod, Union[Callable, InvalidSchema]], None, None]:
         """Generate additional tests that use data from the previous ones."""
         from ._hypothesis import make_test_or_exception  # pylint: disable=import-outside-toplevel
 
         for data in self.stateful_tests.values():
             endpoint = data.make_endpoint()
-            yield endpoint, make_test_or_exception(endpoint, test, settings, seed)
+            for data_generation_method in endpoint.schema.data_generation_methods:
+                yield endpoint, data_generation_method, make_test_or_exception(
+                    endpoint, test, settings, seed, data_generation_method
+                )
 
 
 @attr.s(slots=True)  # pragma: no mutate

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -14,7 +14,7 @@ import yaml
 from _pytest.main import ExitCode
 from hypothesis import HealthCheck, Phase, Verbosity
 
-from schemathesis import Case, fixups
+from schemathesis import Case, DataGenerationMethod, fixups
 from schemathesis._compat import metadata
 from schemathesis.checks import ALL_CHECKS
 from schemathesis.cli import reset_checks
@@ -166,6 +166,10 @@ def test_commands_run_help(cli):
         "  -c, --checks [not_a_server_error|status_code_conformance|"
         "content_type_conformance|response_headers_conformance|response_schema_conformance|all]",
         "                                  List of checks to run.",
+        "  -D, --data-generation-method [positive]",
+        "                                  Defines how Schemathesis generates data for",
+        "                                  tests.",
+        "",
         "  --max-response-time INTEGER RANGE",
         "                                  A custom check that will fail if the response",
         "                                  time is greater than the specified one in",
@@ -297,6 +301,7 @@ def test_execute_arguments(cli, mocker, simple_schema, args, expected):
         "operation_id": (),
         "schema_uri": SCHEMA_URI,
         "validate_schema": True,
+        "data_generation_methods": [DataGenerationMethod.default()],
         "skip_deprecated_endpoints": False,
         "loader": from_uri,
         "hypothesis_options": {},
@@ -348,6 +353,7 @@ def test_load_schema_arguments(cli, mocker, args, expected):
         "endpoint": (),
         "headers": {},
         "loader": from_uri,
+        "data_generation_methods": [DataGenerationMethod.default()],
         "method": (),
         "tag": (),
         "operation_id": (),
@@ -624,7 +630,7 @@ def test_flaky(cli, cli_args, workers):
         assert lines[10] == "E"
     # And it should be displayed only once in "ERRORS" section
     assert "= ERRORS =" in result.stdout
-    assert "_ GET: /api/flaky _" in result.stdout
+    assert "_ GET: /api/flaky [P] _" in result.stdout
     # And it should not go into "FAILURES" section
     assert "= FAILURES =" not in result.stdout
     # And more clear error message is displayed instead of Hypothesis one
@@ -759,8 +765,8 @@ def test_connection_error(cli, schema_url, workers):
     # And errors section title should be displayed
     assert "= ERRORS =" in result.stdout
     # And all endpoints should be mentioned in this section as subsections
-    assert "_ GET: /api/success _" in result.stdout
-    assert "_ GET: /api/failure _" in result.stdout
+    assert "_ GET: /api/success [P] _" in result.stdout
+    assert "_ GET: /api/failure [P] _" in result.stdout
     # And the proper error messages should be displayed for each endpoint
     assert "Max retries exceeded with url: /api/success" in result.stdout
     assert "Max retries exceeded with url: /api/failure" in result.stdout

--- a/test/specs/graphql/test_pytest.py
+++ b/test/specs/graphql/test_pytest.py
@@ -18,5 +18,5 @@ def test_(request, case):
     result = testdir.runpytest("-v", "-s")
     result.assert_outcomes(passed=1)
     result.stdout.re_match_lines(
-        [r"test_basic_pytest_graphql.py::test_\[POST:/graphql\] PASSED", r"Hypothesis calls: 10"]
+        [r"test_basic_pytest_graphql.py::test_\[POST:/graphql\]\[P\] PASSED", r"Hypothesis calls: 10"]
     )

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -28,7 +28,7 @@ async def test_(request, case):
     result = testdir.runpytest("-v")
     result.assert_outcomes(passed=1)
     # Then it should be executed as any other test
-    result.stdout.re_match_lines([r"test_simple.py::test_\[GET:/v1/users\] PASSED", r"Hypothesis calls: 1"])
+    result.stdout.re_match_lines([r"test_simple.py::test_\[GET:/v1/users\]\[P\] PASSED", r"Hypothesis calls: 1"])
 
 
 def test_settings_first(testdir, plugin):

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -23,7 +23,7 @@ def test_(request, case):
     result = testdir.runpytest("-v", "-s")
     result.assert_outcomes(passed=1)
     # Then only tests for these endpoints should be generated
-    result.stdout.re_match_lines([r"test_endpoint_filter.py::test_\[GET:/v1/foo\] PASSED"])
+    result.stdout.re_match_lines([r"test_endpoint_filter.py::test_[GET:/v1/foo][P] PASSED"])
 
 
 @pytest.mark.parametrize("method", ("'get'", "'GET'", ["GET"], ["get"]))
@@ -47,7 +47,10 @@ def test_(request, case):
     result.assert_outcomes(passed=2)
     # Then only tests for this method should be generated
     result.stdout.re_match_lines(
-        [r"test_method_filter.py::test_\[GET:/v1/foo\] PASSED", r"test_method_filter.py::test_\[GET:/v1/users\] PASSED"]
+        [
+            r"test_method_filter.py::test_[GET:/v1/foo][P] PASSED",
+            r"test_method_filter.py::test_[GET:/v1/users][P] PASSED",
+        ]
     )
 
 
@@ -72,7 +75,7 @@ def test_(request, case):
     result = testdir.runpytest("-v", "-s")
     result.assert_outcomes(passed=1)
     # Then only tests for this tag should be generated
-    result.stdout.re_match_lines([r"test_tag_filter.py::test_[GET:/v1/bar] PASSED"])
+    result.stdout.re_match_lines([r"test_tag_filter.py::test_[GET:/v1/bar][P] PASSED"])
 
 
 def test_loader_filter(testdir):
@@ -159,7 +162,7 @@ def test_(request, case):
     result = testdir.runpytest("-v", "-s")
     result.assert_outcomes(passed=1)
 
-    result.stdout.re_match_lines([r"test_operation_id_filter.py::test_[GET:/v1/bar] PASSED"])
+    result.stdout.re_match_lines([r"test_operation_id_filter.py::test_[GET:/v1/bar][P] PASSED"])
 
 
 def test_operation_id_list_filter(testdir):
@@ -185,5 +188,5 @@ def test_(request, case):
     result = testdir.runpytest("-v", "-s")
     result.assert_outcomes(passed=2)
 
-    result.stdout.re_match_lines([r"test_operation_id_list_filter.py::test_[GET:/v1/foo] PASSED"])
-    result.stdout.re_match_lines([r"test_operation_id_list_filter.py::test_[POST:/v1/foo] PASSED"])
+    result.stdout.re_match_lines([r"test_operation_id_list_filter.py::test_[GET:/v1/foo][P] PASSED"])
+    result.stdout.re_match_lines([r"test_operation_id_list_filter.py::test_[POST:/v1/foo][P] PASSED"])

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -83,9 +83,9 @@ def test_(request, case):
     result.assert_outcomes(passed=1, failed=1)
     result.stdout.re_match_lines(
         [
-            r"test_invalid_endpoint.py::test_[GET:/v1/valid] PASSED                    [ 25%]",
-            r"test_invalid_endpoint.py::test_[GET:/v1/invalid] FAILED                  [ 50%]",
-            r"test_invalid_endpoint.py::test_[GET:/v1/users] PASSED                    [ 75%]",
+            r"test_invalid_endpoint.py::test_[GET:/v1/valid][P] PASSED                 [ 25%]",
+            r"test_invalid_endpoint.py::test_[GET:/v1/invalid][P] FAILED               [ 50%]",
+            r"test_invalid_endpoint.py::test_[GET:/v1/users][P] PASSED                 [ 75%]",
             r".*1 passed",
         ]
     )

--- a/test/test_parametrization.py
+++ b/test/test_parametrization.py
@@ -24,7 +24,9 @@ def test_(request, case):
     result.assert_outcomes(passed=1)
     # Then test name should contain method:endpoint
     # And there should be only 1 hypothesis call
-    result.stdout.re_match_lines([r"test_parametrization.py::test_\[GET:/v1/users\] PASSED", r"Hypothesis calls: 1"])
+    result.stdout.re_match_lines(
+        [r"test_parametrization.py::test_\[GET:/v1/users\]\[P\] PASSED", r"Hypothesis calls: 1"]
+    )
 
 
 def test_pytest_parametrize(testdir):
@@ -52,8 +54,8 @@ def test_(request, param, case):
     result.assert_outcomes(passed=4)
     result.stdout.re_match_lines(
         [
-            r"test_pytest_parametrize.py::test_\[GET:/v1/users\]\[A\] PASSED",
-            r"test_pytest_parametrize.py::test_\[GET:/v1/users\]\[B\] PASSED",
+            r"test_pytest_parametrize.py::test_\[GET:/v1/users\]\[P\]\[A\] PASSED",
+            r"test_pytest_parametrize.py::test_\[GET:/v1/users\]\[P\]\[B\] PASSED",
             r"Hypothesis calls: 4",
         ]
     )
@@ -82,8 +84,8 @@ class TestAPI:
     result.assert_outcomes(passed=2)
     result.stdout.re_match_lines(
         [
-            r"test_method.py::TestAPI::test_\[GET:/v1/users\] PASSED",
-            r"test_method.py::TestAPI::test_\[POST:/v1/users\] PASSED",
+            r"test_method.py::TestAPI::test_\[GET:/v1/users\]\[P\] PASSED",
+            r"test_method.py::TestAPI::test_\[POST:/v1/users\]\[P\] PASSED",
             r"Hypothesis calls: 2",
         ]
     )
@@ -479,12 +481,12 @@ def test_b(request, case):
     result.assert_outcomes(passed=5)
     result.stdout.re_match_lines(
         [
-            r".*test_a\[PATCH:/v1/users\]",
-            r".*test_a\[GET:/v1/users\]",
+            r".*test_a\[PATCH:/v1/users\]\[P\]",
+            r".*test_a\[GET:/v1/users\]\[P\]",
             # Here POST is not skipped due to using skip_deprecated_endpoints=False in the `parametrize` call
-            r".*test_b\[POST:/v1/users\]",
-            r".*test_b\[PATCH:/v1/users\]",
-            r".*test_b\[GET:/v1/users\]",
+            r".*test_b\[POST:/v1/users\]\[P\]",
+            r".*test_b\[PATCH:/v1/users\]\[P\]",
+            r".*test_b\[GET:/v1/users\]\[P\]",
             r"Hypothesis calls: 5",
         ]
     )
@@ -622,7 +624,7 @@ def test_(request, case):
     result = testdir.runpytest("-v", "-rf")
     # Then the tests should fail with the relevant error message
     result.assert_outcomes(failed=1, passed=2)
-    result.stdout.re_match_lines([r".*test_invalid_endpoint.py::test_\[GET:/v1/invalid\] FAILED"])
+    result.stdout.re_match_lines([r".*test_invalid_endpoint.py::test_\[GET:/v1/invalid\]\[P\] FAILED"])
 
 
 def test_no_base_path(testdir):

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -32,10 +32,10 @@ def test_(request, param, case):
     result.assert_outcomes(passed=4)
     result.stdout.re_match_lines(
         [
-            r"test_pytest_parametrize_fixture.py::test_\[GET:/v1/users\]\[A\] PASSED",
-            r"test_pytest_parametrize_fixture.py::test_\[GET:/v1/users\]\[B\] PASSED",
-            r"test_pytest_parametrize_fixture.py::test_\[POST:/v1/users\]\[A\] PASSED",
-            r"test_pytest_parametrize_fixture.py::test_\[POST:/v1/users\]\[B\] PASSED",
+            r"test_pytest_parametrize_fixture.py::test_\[GET:/v1/users\]\[P\]\[A\] PASSED",
+            r"test_pytest_parametrize_fixture.py::test_\[GET:/v1/users\]\[P\]\[B\] PASSED",
+            r"test_pytest_parametrize_fixture.py::test_\[POST:/v1/users\]\[P\]\[A\] PASSED",
+            r"test_pytest_parametrize_fixture.py::test_\[POST:/v1/users\]\[P\]\[B\] PASSED",
             r"Hypothesis calls: 4",
         ]
     )
@@ -74,10 +74,10 @@ class TestAPI:
     result.assert_outcomes(passed=4)
     result.stdout.re_match_lines(
         [
-            r"test_pytest_parametrize_class_fixture.py::TestAPI::test_\[GET:/v1/users\]\[A\] PASSED",
-            r"test_pytest_parametrize_class_fixture.py::TestAPI::test_\[GET:/v1/users\]\[B\] PASSED",
-            r"test_pytest_parametrize_class_fixture.py::TestAPI::test_\[POST:/v1/users\]\[A\] PASSED",
-            r"test_pytest_parametrize_class_fixture.py::TestAPI::test_\[POST:/v1/users\]\[B\] PASSED",
+            r"test_pytest_parametrize_class_fixture.py::TestAPI::test_\[GET:/v1/users\]\[P\]\[A\] PASSED",
+            r"test_pytest_parametrize_class_fixture.py::TestAPI::test_\[GET:/v1/users\]\[P\]\[B\] PASSED",
+            r"test_pytest_parametrize_class_fixture.py::TestAPI::test_\[POST:/v1/users\]\[P\]\[A\] PASSED",
+            r"test_pytest_parametrize_class_fixture.py::TestAPI::test_\[POST:/v1/users\]\[P\]\[B\] PASSED",
             r"Hypothesis calls: 4",
         ]
     )

--- a/test/test_stateful.py
+++ b/test/test_stateful.py
@@ -48,11 +48,13 @@ def test_(request, case):
     result = testdir.run_and_assert("-v", passed=4)
     result.stdout.re_match_lines(
         [
-            r"test_stateful_enabled.py::test_\[POST:/api/users/\] PASSED",
-            r"test_stateful_enabled.py::test_\[POST:/api/users/ -> GET:/api/users/{user_id}\] PASSED * \[ 66%\]",
-            r"test_stateful_enabled.py::test_"
-            r"\[POST:/api/users/ -> GET:/api/users/{user_id} -> PATCH:/api/users/{user_id}\] PASSED * \[ 75%\]",
-            r"test_stateful_enabled.py::test_\[POST:/api/users/ -> PATCH:/api/users/{user_id}\] PASSED * \[100%\]",
+            r"test_stateful_enabled.py::test_\[POST:/api/users/\]\[P\] PASSED",
+            r"test_stateful_enabled.py::test_\[POST:/api/users/ -> GET:/api/users/{user_id}\]"
+            r"\[P\] PASSED * \[ 66%\]",
+            r"test_stateful_enabled.py::test_\[POST:/api/users/ -> GET:/api/users/{user_id} -> "
+            r"PATCH:/api/users/{user_id}\]\[P\] PASSED * \[ 75%\]",
+            r"test_stateful_enabled.py::test_\[POST:/api/users/ -> PATCH:/api/users/{user_id}\]"
+            r"\[P\] PASSED * \[100%\]",
             r"Hypothesis calls: 8",
         ]
     )
@@ -81,9 +83,11 @@ def test_(request, case):
     result = testdir.run_and_assert("-v", passed=3)
     result.stdout.re_match_lines(
         [
-            r"test_stateful_enabled_limit.py::test_\[POST:/api/users/\] PASSED",
-            r"test_stateful_enabled_limit.py::test_\[POST:/api/users/ -> GET:/api/users/{user_id}\] PASSED * \[ 66%\]",
-            r"test_stateful_enabled_limit.py::test_\[POST:/api/users/ -> PATCH:/api/users/{user_id}\] PASSED * \[100%\]",
+            r"test_stateful_enabled_limit.py::test_\[POST:/api/users/\]\[P\] PASSED",
+            r"test_stateful_enabled_limit.py::test_\[POST:/api/users/ -> GET:/api/users/{user_id}\]"
+            r"\[P\] PASSED * \[ 66%\]",
+            r"test_stateful_enabled_limit.py::test_\[POST:/api/users/ -> PATCH:/api/users/{user_id}\]"
+            r"\[P\] PASSED * \[100%\]",
             r"Hypothesis calls: 6",
         ]
     )
@@ -107,7 +111,7 @@ def test_(request, case):
     result = testdir.run_and_assert("-v", passed=1)
     result.stdout.re_match_lines(
         [
-            r"test_stateful_disabled.py::test_\[POST:/api/users/\] PASSED",
+            r"test_stateful_disabled.py::test_\[POST:/api/users/\]\[P\] PASSED",
             r"Hypothesis calls: 2",
         ]
     )
@@ -130,7 +134,7 @@ def test_(request, case):
     result = testdir.run_and_assert("-v", passed=1)
     result.stdout.re_match_lines(
         [
-            r"test_stateful_not_used.py::test_\[POST:/api/users/\] PASSED",
+            r"test_stateful_not_used.py::test_\[POST:/api/users/\]\[P\] PASSED",
             r"Hypothesis calls: 2",
         ]
     )


### PR DESCRIPTION
Mostly to be forward-compatible with #831 and reduce its size, we'll need to add the "negative" option.

TODO:
- [x] `testing_mode(s)`, maybe just `mode(s)`?
- [x] Pytest naming `positive` vs `+`?
- [x] Add this option to the CLI
- [x] Properly handle it for lazy schemas
- [x] Add it to GraphQL as well
- [ ] Adjust CLI output handler so it can output N dots (one per data generation method) for each endpoint (not sure if it is not working already) (probably later)
