### PR TITLE
feat: Generate tests for all defined media types

### DIFF
--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -23,6 +23,7 @@ def create_test(
     settings: Optional[hypothesis.settings] = None,
     seed: Optional[int] = None,
     data_generation_method: DataGenerationMethod = DataGenerationMethod.default(),
+    media_type: Optional[str] = None,
     _given_args: Tuple[GivenInput, ...] = (),
     _given_kwargs: Optional[Dict[str, GivenInput]] = None,
 ) -> Callable:
@@ -34,7 +35,7 @@ def create_test(
     else:
         feedback = None
     strategy = endpoint.as_strategy(
-        hooks=hook_dispatcher, feedback=feedback, data_generation_method=data_generation_method
+        hooks=hook_dispatcher, feedback=feedback, data_generation_method=data_generation_method, media_type=media_type
     )
     _given_kwargs = (_given_kwargs or {}).copy()
     _given_kwargs.setdefault("case", strategy)
@@ -62,13 +63,19 @@ def setup_default_deadline(wrapped_test: Callable) -> None:
 def make_test_or_exception(
     endpoint: Endpoint,
     func: Callable,
+    media_type: Optional[str],
     settings: Optional[hypothesis.settings] = None,
     seed: Optional[int] = None,
     data_generation_method: DataGenerationMethod = DataGenerationMethod.default(),
 ) -> Union[Callable, InvalidSchema]:
     try:
         return create_test(
-            endpoint=endpoint, test=func, settings=settings, seed=seed, data_generation_method=data_generation_method
+            endpoint=endpoint,
+            test=func,
+            settings=settings,
+            seed=seed,
+            data_generation_method=data_generation_method,
+            media_type=media_type,
         )
     except InvalidSchema as exc:
         return exc

--- a/src/schemathesis/extra/pytest_plugin.py
+++ b/src/schemathesis/extra/pytest_plugin.py
@@ -200,9 +200,12 @@ class SchemathesisFunction(Function):  # pylint: disable=too-many-ancestors
                 data_generation_method=data_generation_method,
             )
 
+        # TODO. use media-type
         return [
             make_test(endpoint, test, data_generation_method, previous_test_name)
-            for (endpoint, data_generation_method, test) in feedback.get_stateful_tests(self.test_function, None, None)
+            for (endpoint, media_type, data_generation_method, test) in feedback.get_stateful_tests(
+                self.test_function, None, None
+            )
         ]
 
     def add_stateful_tests(self) -> None:

--- a/src/schemathesis/lazy.py
+++ b/src/schemathesis/lazy.py
@@ -72,7 +72,8 @@ class LazySchema:
                 settings = getattr(test, "_hypothesis_internal_use_settings", None)
                 tests = list(schema.get_all_tests(func, settings))
                 request.session.testscollected += len(tests)
-                for _endpoint, data_generation_method, sub_test in tests:
+                # TODO. Use media_type
+                for _endpoint, _, data_generation_method, sub_test in tests:
                     actual_test = get_test(sub_test)
                     subtests.item._nodeid = _get_node_name(node_id, _endpoint, data_generation_method)
                     run_subtest(_endpoint, fixtures, actual_test, subtests)

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -432,8 +432,9 @@ class Endpoint:
         hooks: Optional["HookDispatcher"] = None,
         feedback: Optional["Feedback"] = None,
         data_generation_method: DataGenerationMethod = DataGenerationMethod.default(),
+        media_type: Optional[str] = None,
     ) -> SearchStrategy:
-        return self.schema.get_case_strategy(self, hooks, feedback, data_generation_method)
+        return self.schema.get_case_strategy(self, hooks, feedback, data_generation_method, media_type)
 
     def get_strategies_from_examples(self) -> List[SearchStrategy[Case]]:
         """Get examples from the endpoint."""
@@ -442,8 +443,8 @@ class Endpoint:
     def get_stateful_tests(self, response: GenericResponse, stateful: Optional["Stateful"]) -> Sequence["StatefulTest"]:
         return self.schema.get_stateful_tests(response, self, stateful)
 
-    def get_hypothesis_conversions(self, location: str) -> Optional[Callable]:
-        return self.schema.get_hypothesis_conversion(self, location)
+    def get_data_serializerss(self, location: str) -> Optional[Callable]:
+        return self.schema.get_data_serializers(self, location)
 
     def prepare_multipart(self, form_data: Optional[FormData]) -> Tuple[Optional[List], Optional[Dict[str, Any]]]:
         if not form_data:

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -77,7 +77,8 @@ class BaseRunner:
         """Run tests and recursively run additional tests."""
         if recursion_level > self.stateful_recursion_limit:
             return
-        for endpoint, data_generation_method, test in maker(template, settings, seed):
+        # TODO. use media-type
+        for endpoint, _, data_generation_method, test in maker(template, settings, seed):
             feedback = Feedback(self.stateful, endpoint)
             for event in run_test(
                 endpoint,

--- a/src/schemathesis/specs/graphql/schemas.py
+++ b/src/schemathesis/specs/graphql/schemas.py
@@ -76,6 +76,7 @@ class GraphQLSchema(BaseSchema):
         hooks: Optional[HookDispatcher] = None,
         feedback: Optional[Feedback] = None,
         data_generation_method: DataGenerationMethod = DataGenerationMethod.default(),
+        media_type: Optional[str] = None,
     ) -> SearchStrategy:
         constructor = partial(GraphQLCase, endpoint=endpoint)
         schema = graphql.build_client_schema(self.raw_schema)
@@ -84,5 +85,5 @@ class GraphQLSchema(BaseSchema):
     def get_strategies_from_examples(self, endpoint: Endpoint) -> List[SearchStrategy[Case]]:
         return []
 
-    def get_hypothesis_conversion(self, endpoint: Endpoint, location: str) -> Optional[Callable]:
+    def get_data_serializers(self, endpoint: Endpoint, location: str) -> Optional[Callable]:
         return None

--- a/src/schemathesis/specs/openapi/_hypothesis.py
+++ b/src/schemathesis/specs/openapi/_hypothesis.py
@@ -74,6 +74,7 @@ def get_case_strategy(
     hooks: Optional[HookDispatcher] = None,
     feedback: Optional[Feedback] = None,
     data_generation_method: DataGenerationMethod = DataGenerationMethod.default(),
+    media_type: Optional[str] = None,
 ) -> st.SearchStrategy:
     """Create a strategy for a complete test case.
 
@@ -83,10 +84,14 @@ def get_case_strategy(
     static_kwargs: Dict[str, Any] = {"feedback": feedback}
     for parameter in PARAMETERS:
         value = getattr(endpoint, parameter)
+        # TODO. The body structure should be the same across all usages, stateful, explicit examples, etc
+        if parameter == "body" and value is not None:
+            if media_type is not None and isinstance(value, dict):
+                value = value[media_type]["schema"]
         if value is not None:
             location = {"headers": "header", "cookies": "cookie", "path_parameters": "path"}.get(parameter, parameter)
             strategies[parameter] = prepare_strategy(
-                parameter, value, endpoint.get_hypothesis_conversions(location), data_generation_method
+                parameter, value, endpoint.get_data_serializerss(location), data_generation_method
             )
         else:
             static_kwargs[parameter] = None

--- a/src/schemathesis/specs/openapi/examples.py
+++ b/src/schemathesis/specs/openapi/examples.py
@@ -112,9 +112,7 @@ def get_strategies_from_examples(endpoint: Endpoint, examples_field: str = "exam
 
 def get_strategy(endpoint: Endpoint, static_parameters: Dict[str, Any]) -> SearchStrategy[Case]:
     strategies = {
-        parameter: prepare_strategy(
-            parameter, getattr(endpoint, parameter), endpoint.get_hypothesis_conversions(parameter)
-        )
+        parameter: prepare_strategy(parameter, getattr(endpoint, parameter), endpoint.get_data_serializerss(parameter))
         for parameter in PARAMETERS - set(static_parameters)
         if getattr(endpoint, parameter) is not None
     }

--- a/src/schemathesis/stateful.py
+++ b/src/schemathesis/stateful.py
@@ -92,15 +92,15 @@ class Feedback:
 
     def get_stateful_tests(
         self, test: Callable, settings: Optional[hypothesis.settings], seed: Optional[int]
-    ) -> Generator[Tuple[Endpoint, DataGenerationMethod, Union[Callable, InvalidSchema]], None, None]:
+    ) -> Generator[Tuple[Endpoint, Optional[str], DataGenerationMethod, Union[Callable, InvalidSchema]], None, None]:
         """Generate additional tests that use data from the previous ones."""
         from ._hypothesis import make_test_or_exception  # pylint: disable=import-outside-toplevel
 
         for data in self.stateful_tests.values():
             endpoint = data.make_endpoint()
             for data_generation_method in endpoint.schema.data_generation_methods:
-                yield endpoint, data_generation_method, make_test_or_exception(
-                    endpoint, test, settings, seed, data_generation_method
+                yield endpoint, None, data_generation_method, make_test_or_exception(
+                    endpoint, test, None, settings, seed, data_generation_method
                 )
 
 

--- a/test/apps/utils.py
+++ b/test/apps/utils.py
@@ -337,7 +337,9 @@ def _make_openapi_3_schema(endpoints: Tuple[str, ...]) -> Dict:
             definitions["Node"] = make_node_definition(reference)
         elif endpoint in ("payload", "get_payload"):
             schema = {
-                "requestBody": {"content": {"application/json": {"schema": PAYLOAD}}},
+                "requestBody": {
+                    "content": {"application/json": {"schema": PAYLOAD}, "text/plain": {"schema": {"type": "string"}}}
+                },
                 "responses": {"200": {"description": "OK", "content": {"application/json": {"schema": PAYLOAD}}}},
             }
         elif endpoint == "unsatisfiable":


### PR DESCRIPTION
For each defined media type, there will be a test. The obvious benefit is that Schemathesis will be able to test more. However, it also simplifies the serialization step (basically a `map` function applied to the relevant strategy). Inside `get_case_strategy`, there will be media type available, so we can choose how to serialize any media type + allow to register custom serializers. As the next step, it will be easy to implement serializers for `text/plain`.

Resolves #690 
Resolves #472 

TODO:
- [ ] In CLI, all tests for the same endpoint should be displayed in the same line;
- [ ] A way to register custom serializers;
- [ ] Display media type in the test node name in pytest;
- [ ] Move "body" serialization out of `get_hypothesis_conversions`
- [ ] It will be nice to perform **any** body serialization in the function passed to `map`, including multipart & forms, so `get_requests_kwargs`, etc. will be cleaner
- [ ] Rename `get_hypothesis_conversions`, it is more about serialization
- [ ] Serialize forms & json in serializers
- [ ] Fix stateful schemas
- [ ] Fix explicit examples handling
- [ ] Documentation
- [ ] Make some separate structures to handle body / other parameters? 
- [ ] Use `consumes` for Swagger 2.0