### PR TITLE
fix: Response conformance check for responses without "Content-Type" header

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,11 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Handling of 204 responses in the ``response_schema_conformance`` check. Before, all responses were required to have the
+  ``Content-Type`` header. `#844`_
+
 **Deprecated**
 
 - Using of ``Case.form_data`` and ``Endpoint.form_data``. In the ``3.0`` release, you'll need to use relevant ``body`` attributes instead.
@@ -1505,6 +1510,7 @@ Deprecated
 
 .. _#858: https://github.com/schemathesis/schemathesis/issues/858
 .. _#851: https://github.com/schemathesis/schemathesis/issues/851
+.. _#844: https://github.com/schemathesis/schemathesis/issues/844
 .. _#841: https://github.com/schemathesis/schemathesis/issues/841
 .. _#839: https://github.com/schemathesis/schemathesis/issues/839
 .. _#836: https://github.com/schemathesis/schemathesis/issues/836

--- a/src/schemathesis/specs/openapi/checks.py
+++ b/src/schemathesis/specs/openapi/checks.py
@@ -78,9 +78,4 @@ def response_headers_conformance(response: GenericResponse, case: "Case") -> Opt
 def response_schema_conformance(response: GenericResponse, case: "Case") -> None:
     if not isinstance(case.endpoint.schema, BaseOpenAPISchema):
         raise TypeError("This check can be used only with Open API schemas")
-    content_type = response.headers.get("Content-Type")
-    if content_type is None:
-        raise get_missing_content_type_error()("Response is missing the `Content-Type` header")
-    if not content_type.startswith("application/json"):
-        return
     return case.endpoint.validate_response(response)


### PR DESCRIPTION
Fixes #844 