### PR TITLE
fix: Catch `OverflowError` in input regex validation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,7 @@ Changelog
 
 - Handling of 204 responses in the ``response_schema_conformance`` check. Before, all responses were required to have the
   ``Content-Type`` header. `#844`_
+- Catch ``OverflowError`` when an invalid regex is passed to ``-E`` / ``-M`` / ``-T`` / ``-O`` CLI options. `#870`_
 
 **Deprecated**
 
@@ -1519,6 +1520,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#870: https://github.com/schemathesis/schemathesis/issues/870
 .. _#858: https://github.com/schemathesis/schemathesis/issues/858
 .. _#855: https://github.com/schemathesis/schemathesis/issues/855
 .. _#851: https://github.com/schemathesis/schemathesis/issues/851

--- a/src/schemathesis/cli/callbacks.py
+++ b/src/schemathesis/cli/callbacks.py
@@ -106,7 +106,7 @@ def validate_regex(ctx: click.core.Context, param: click.core.Parameter, raw_val
     for value in raw_value:
         try:
             re.compile(value)
-        except re.error as exc:
+        except (re.error, OverflowError) as exc:
             raise click.BadParameter(f"Invalid regex: {exc.args[0]}")
     return raw_value
 

--- a/test/cli/test_callbacks.py
+++ b/test/cli/test_callbacks.py
@@ -66,11 +66,7 @@ def test_reraise_format_error():
 
 @pytest.mark.parametrize(
     "value",
-    (
-        "+",
-        "\\",
-        "[",
-    ),
+    ("+", "\\", "[", r"0EEE|[>:>\UEEEEEEEEEEEEEEEEEEEEEEEE>"),
 )
 def test_validate_regex(value):
     with pytest.raises(click.BadParameter, match="Invalid regex: "):


### PR DESCRIPTION
Fixes #870