### PR TITLE
feat: `--force-schema-version` CLI option

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -24,7 +24,8 @@ disable =
   inconsistent-return-statements,
   too-many-arguments,
   too-many-instance-attributes,
-  too-many-public-methods
+  too-many-public-methods,
+  too-many-locals
 
 
 [REPORTS]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Added**
+
+- ``--force-schema-version`` CLI option to force Schemathesis to use the specific Open API spec version when parsing the schema. `#876`_
+
 `2.8.0`_ - 2020-11-24
 ---------------------
 
@@ -1526,6 +1530,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#876: https://github.com/schemathesis/schemathesis/issues/876
 .. _#874: https://github.com/schemathesis/schemathesis/issues/874
 .. _#872: https://github.com/schemathesis/schemathesis/issues/872
 .. _#870: https://github.com/schemathesis/schemathesis/issues/870

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -259,6 +259,11 @@ def schemathesis(pre_run: Optional[str] = None) -> None:
     removed_in="3.0",
 )
 @click.option(
+    "--force-schema-version",
+    help="Force Schemathesis to parse the input schema with the specified spec version.",
+    type=click.Choice(["20", "30"]),
+)
+@click.option(
     "--hypothesis-deadline",
     help="Duration in milliseconds that each individual example with a test is not allowed to exceed.",
     # max value to avoid overflow. It is the maximum amount of days in milliseconds
@@ -314,6 +319,7 @@ def run(
     fixups: Tuple[str] = (),  # type: ignore
     stateful: Optional[Stateful] = None,
     stateful_recursion_limit: int = DEFAULT_STATEFUL_RECURSION_LIMIT,
+    force_schema_version: Optional[str] = None,
     hypothesis_deadline: Optional[Union[int, NotSet]] = None,
     hypothesis_derandomize: Optional[bool] = None,
     hypothesis_max_examples: Optional[int] = None,
@@ -362,6 +368,7 @@ def run(
         fixups=fixups,
         stateful=stateful,
         stateful_recursion_limit=stateful_recursion_limit,
+        force_schema_version=force_schema_version,
         hypothesis_deadline=hypothesis_deadline,
         hypothesis_derandomize=hypothesis_derandomize,
         hypothesis_max_examples=hypothesis_max_examples,

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -56,6 +56,7 @@ def prepare(
     app: Optional[str] = None,
     validate_schema: bool = True,
     skip_deprecated_endpoints: bool = False,
+    force_schema_version: Optional[str] = None,
     # Hypothesis-specific configuration
     hypothesis_deadline: Optional[Union[int, NotSet]] = None,
     hypothesis_derandomize: Optional[bool] = None,
@@ -93,6 +94,7 @@ def prepare(
         app=app,
         validate_schema=validate_schema,
         skip_deprecated_endpoints=skip_deprecated_endpoints,
+        force_schema_version=force_schema_version,
         checks=checks,
         data_generation_methods=data_generation_methods,
         max_response_time=max_response_time,
@@ -144,6 +146,7 @@ def execute_from_schema(
     app: Optional[str] = None,
     validate_schema: bool = True,
     skip_deprecated_endpoints: bool = False,
+    force_schema_version: Optional[str] = None,
     checks: Iterable[CheckFunction],
     data_generation_methods: Tuple[DataGenerationMethod, ...] = DEFAULT_DATA_GENERATION_METHODS,
     max_response_time: Optional[int] = None,
@@ -191,6 +194,7 @@ def execute_from_schema(
             tag=tag,
             operation_id=operation_id,
             data_generation_methods=data_generation_methods,
+            force_schema_version=force_schema_version,
         )
 
         runner: BaseRunner
@@ -315,6 +319,7 @@ def load_schema(
     validate_schema: bool = True,
     skip_deprecated_endpoints: bool = False,
     data_generation_methods: Tuple[DataGenerationMethod, ...] = DEFAULT_DATA_GENERATION_METHODS,
+    force_schema_version: Optional[str] = None,
     # Network request parameters
     auth: Optional[Tuple[str, str]] = None,
     auth_type: Optional[str] = None,
@@ -354,6 +359,7 @@ def load_schema(
         schema_uri,
         validate_schema=validate_schema,
         skip_deprecated_endpoints=skip_deprecated_endpoints,
+        force_schema_version=force_schema_version,
         **loader_options,
     )
 

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -223,6 +223,9 @@ def test_commands_run_help(cli):
         "  --stateful [links]              Utilize stateful testing capabilities.",
         "  --stateful-recursion-limit INTEGER RANGE",
         "                                  Limit recursion depth for stateful testing.",
+        "  --force-schema-version [20|30]  Force Schemathesis to parse the input schema",
+        "                                  with the specified spec version.",
+        "",
         "  --hypothesis-deadline INTEGER RANGE",
         "                                  Duration in milliseconds that each individual",
         "                                  example with a test is not allowed to exceed.",
@@ -308,6 +311,7 @@ def test_execute_arguments(cli, mocker, simple_schema, args, expected):
         "validate_schema": True,
         "data_generation_methods": [DataGenerationMethod.default()],
         "skip_deprecated_endpoints": False,
+        "force_schema_version": None,
         "loader": from_uri,
         "hypothesis_options": {},
         "workers_num": 1,
@@ -365,6 +369,7 @@ def test_load_schema_arguments(cli, mocker, args, expected):
         "operation_id": (),
         "validate_schema": True,
         "skip_deprecated_endpoints": False,
+        "force_schema_version": None,
         **expected,
     }
 

--- a/test/test_loaders.py
+++ b/test/test_loaders.py
@@ -6,6 +6,7 @@ from yarl import URL
 
 import schemathesis
 from schemathesis.constants import USER_AGENT
+from schemathesis.specs.openapi.schemas import OpenApi30, SwaggerV20
 
 from .utils import SIMPLE_PATH, make_schema
 
@@ -119,3 +120,20 @@ def test_number_deserializing(testdir):
     # and the value should be a number
     value = parsed.raw_schema["paths"]["/teapot"]["get"]["parameters"][0]["schema"]["multipleOf"]
     assert isinstance(value, float)
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    (
+        ("20", SwaggerV20),
+        ("30", OpenApi30),
+    ),
+)
+def test_force_open_api_version(version, expected):
+    schema = {
+        # Invalid schema, but it happens in real applications
+        "swagger": "2.0",
+        "openapi": "3.0.0",
+    }
+    loaded = schemathesis.from_dict(schema, force_schema_version=version, validate_schema=False)
+    assert isinstance(loaded, expected)


### PR DESCRIPTION
It forces Schemathesis to use the specific Open API spec version when parsing the schema

Closes #876
