### PR TITLE
chore: The `content_type_conformance` check now raises a well-formed error message when encounters a malformed media type value

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,10 @@ Changelog
 
 - ``--force-schema-version`` CLI option to force Schemathesis to use the specific Open API spec version when parsing the schema. `#876`_
 
+**Changed**
+
+- The ``content_type_conformance`` check now raises a well-formed error message when encounters a malformed media type value. `#877`_
+
 `2.8.0`_ - 2020-11-24
 ---------------------
 
@@ -1530,6 +1534,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#877: https://github.com/schemathesis/schemathesis/issues/877
 .. _#876: https://github.com/schemathesis/schemathesis/issues/876
 .. _#874: https://github.com/schemathesis/schemathesis/issues/874
 .. _#872: https://github.com/schemathesis/schemathesis/issues/872

--- a/src/schemathesis/exceptions.py
+++ b/src/schemathesis/exceptions.py
@@ -52,6 +52,11 @@ def get_response_type_error(expected: str, received: str) -> Type[CheckFailed]:
     return get_exception(name)
 
 
+def get_malformed_media_type_error(media_type: str) -> Type[CheckFailed]:
+    name = f"MalformedMediaType{media_type}"
+    return get_exception(name)
+
+
 def get_missing_content_type_error() -> Type[CheckFailed]:
     """Return new exception for a missing Content-Type header."""
     return get_exception("MissingContentTypeError")

--- a/src/schemathesis/specs/openapi/checks.py
+++ b/src/schemathesis/specs/openapi/checks.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Union
 
 from ...exceptions import (
     get_headers_error,
+    get_malformed_media_type_error,
     get_missing_content_type_error,
     get_response_type_error,
     get_status_code_error,
@@ -48,8 +49,11 @@ def content_type_conformance(response: GenericResponse, case: "Case") -> Optiona
     if not content_type:
         raise get_missing_content_type_error()("Response is missing the `Content-Type` header")
     for option in content_types:
-        if are_content_types_equal(option, content_type):
-            return None
+        try:
+            if are_content_types_equal(option, content_type):
+                return None
+        except ValueError as exc:
+            raise get_malformed_media_type_error(str(exc))(str(exc)) from exc
         expected_main, expected_sub = parse_content_type(option)
         received_main, received_sub = parse_content_type(content_type)
     exc_class = get_response_type_error(f"{expected_main}_{expected_sub}", f"{received_main}_{received_sub}")

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -130,8 +130,11 @@ def format_exception(error: Exception, include_traceback: bool = False) -> str:
 
 def parse_content_type(content_type: str) -> Tuple[str, str]:
     """Parse Content Type and return main type and subtype."""
-    content_type, _ = cgi.parse_header(content_type)
-    main_type, sub_type = content_type.split("/", 1)
+    try:
+        content_type, _ = cgi.parse_header(content_type)
+        main_type, sub_type = content_type.split("/", 1)
+    except ValueError as exc:
+        raise ValueError(f"Malformed media type: `{content_type}`") from exc
     return main_type.lower(), sub_type.lower()
 
 


### PR DESCRIPTION
Resolves #877