### PR TITLE
fix: Internal error during verifying explicit examples if an example has no `value` key

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,10 @@ Changelog
 
 - The ``content_type_conformance`` check now raises a well-formed error message when encounters a malformed media type value. `#877`_
 
+**Fixed**
+
+- Internal error during verifying explicit examples if an example has no ``value`` key. `#882`_
+
 `2.8.0`_ - 2020-11-24
 ---------------------
 
@@ -1534,6 +1538,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#882: https://github.com/schemathesis/schemathesis/issues/882
 .. _#877: https://github.com/schemathesis/schemathesis/issues/877
 .. _#876: https://github.com/schemathesis/schemathesis/issues/876
 .. _#874: https://github.com/schemathesis/schemathesis/issues/874

--- a/src/schemathesis/specs/openapi/examples.py
+++ b/src/schemathesis/specs/openapi/examples.py
@@ -21,7 +21,7 @@ def get_parameter_examples(endpoint_def: Dict[str, Any], examples_field: str) ->
         {
             "type": LOCATION_TO_CONTAINER.get(parameter["in"]),
             "name": parameter["name"],
-            "examples": [example["value"] for example in parameter[examples_field].values()],
+            "examples": [example["value"] for example in parameter[examples_field].values() if "value" in example],
         }
         for parameter in endpoint_def.get("parameters", [])
         if examples_field in parameter
@@ -55,7 +55,7 @@ def get_request_body_examples(endpoint_def: Dict[str, Any], examples_field: str)
     parameter_type = "body" if media_type != "multipart/form-data" else "form_data"
     return {
         "type": parameter_type,
-        "examples": [example["value"] for example in schema.get(examples_field, {}).values()],
+        "examples": [example["value"] for example in schema.get(examples_field, {}).values() if "value" in example],
     }
 
 


### PR DESCRIPTION
Fixes #882