### PR TITLE
fix: Use `--request-tls-verify` during schema loading as well

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Use ``--request-tls-verify`` during schema loading as well. `#897`_
+
 `2.8.3`_ - 2020-11-27
 ---------------------
 
@@ -1564,6 +1568,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#897: https://github.com/schemathesis/schemathesis/issues/897
 .. _#895: https://github.com/schemathesis/schemathesis/issues/895
 .. _#890: https://github.com/schemathesis/schemathesis/issues/890
 .. _#889: https://github.com/schemathesis/schemathesis/issues/889

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -195,6 +195,7 @@ def execute_from_schema(
             operation_id=operation_id,
             data_generation_methods=data_generation_methods,
             force_schema_version=force_schema_version,
+            request_tls_verify=request_tls_verify,
         )
 
         runner: BaseRunner
@@ -320,6 +321,7 @@ def load_schema(
     skip_deprecated_endpoints: bool = False,
     data_generation_methods: Tuple[DataGenerationMethod, ...] = DEFAULT_DATA_GENERATION_METHODS,
     force_schema_version: Optional[str] = None,
+    request_tls_verify: Union[bool, str] = True,
     # Network request parameters
     auth: Optional[Tuple[str, str]] = None,
     auth_type: Optional[str] = None,
@@ -354,6 +356,8 @@ def load_schema(
 
     if loader is loaders.from_uri and loader_options.get("auth"):
         loader_options["auth"] = get_requests_auth(loader_options["auth"], loader_options.pop("auth_type", None))
+    if loader in (loaders.from_uri, loaders.from_aiohttp):
+        loader_options["verify"] = request_tls_verify
 
     return loader(
         schema_uri,

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -370,6 +370,7 @@ def test_load_schema_arguments(cli, mocker, args, expected):
         "validate_schema": True,
         "skip_deprecated_endpoints": False,
         "force_schema_version": None,
+        "request_tls_verify": True,
         **expected,
     }
 


### PR DESCRIPTION
Fixes #897