### PR TITLE
test: Use `assume` in some pytester-style tests

### DIFF
--- a/test/test_dereferencing.py
+++ b/test/test_dereferencing.py
@@ -377,12 +377,12 @@ def test_nullable_properties(testdir):
     testdir.make_test(
         """
 @schema.parametrize(method="POST")
-@settings(max_examples=10)
+@settings(max_examples=1)
 def test_(request, case):
+    assume(case.body["id"] is None)
     assert case.path == "/users"
     assert case.method == "POST"
-    if case.body["id"] is None:
-        request.config.HYPOTHESIS_CASES += 1
+    request.config.HYPOTHESIS_CASES += 1
 """,
         paths={
             "/users": {
@@ -408,8 +408,7 @@ def test_(request, case):
     result = testdir.runpytest("-vv", "-s")
     result.assert_outcomes(passed=1)
     # At least one `None` value should be generated
-    hypothesis_calls = int(result.stdout.lines[-1].split(":")[-1].strip())
-    assert hypothesis_calls > 0
+    result.stdout.re_match_lines([r"Hypothesis calls: 1$"])
 
 
 def test_nullable_ref(testdir):

--- a/test/test_petstore.py
+++ b/test/test_petstore.py
@@ -54,8 +54,8 @@ def test_find_by_status(testdir):
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
     assert_list(case.query["status"])
-    if case.query["status"]:
-        assert case.query["status"][0] in ("available", "pending", "sold")
+    for item in case.query["status"]:
+        assert item in ("available", "pending", "sold")
     assert_requests_call(case)
 """
     )
@@ -96,12 +96,13 @@ def test_update_pet(testdir):
 @schema.parametrize(method="POST", endpoint="/pet/{petId}$")
 @settings(max_examples=5, deadline=None)
 def test_(request, case):
+    assume(case.body is not None)
+    assume("name" in case.body)
+    assume("status" in case.body)
     request.config.HYPOTHESIS_CASES += 1
     assert_int(case.path_parameters["petId"])
-    if case.body and "name" in case.body:
-        assert_str(case.body["name"])
-    if case.body and "status" in case.body:
-        assert_str(case.body["status"])
+    assert_str(case.body["name"])
+    assert_str(case.body["status"])
     assert_requests_call(case)
 """
     )
@@ -129,12 +130,13 @@ def test_upload_image(testdir):
 @schema.parametrize(endpoint="/pet/{petId}/uploadImage$")
 @settings(max_examples=5, deadline=None)
 def test_(request, case):
-    request.config.HYPOTHESIS_CASES += 1
+    assume(case.body is not None)
     assert_int(case.path_parameters["petId"])
     if case.endpoint.schema.spec_version == "2.0":
-        if case.body is not None and "additionalMetadata" in case.body:
-            assert_str(case.body["additionalMetadata"])
+        assume("additionalMetadata" in case.body)
+        assert_str(case.body["additionalMetadata"])
     assert_requests_call(case)
+    request.config.HYPOTHESIS_CASES += 1
 """
     )
     testdir.assert_petstore()


### PR DESCRIPTION
It ensures that values are actually generated. Otherwise, some test branches may not be executed