### PR TITLE
fix: Apply body-level hooks

### DIFF
--- a/src/schemathesis/specs/openapi/_hypothesis.py
+++ b/src/schemathesis/specs/openapi/_hypothesis.py
@@ -114,6 +114,7 @@ def get_case_strategy(  # pylint: disable=too-many-locals
         if endpoint.body:
             parameter = draw(st.sampled_from(endpoint.body.items))
             strategy = _get_body_strategy(parameter, to_strategy, endpoint.schema)
+            strategy = apply_hooks(endpoint, context, hooks, strategy, "body")
             media_type = parameter.media_type
             body = draw(strategy)
     else:

--- a/test/hooks/test_hooks.py
+++ b/test/hooks/test_hooks.py
@@ -48,6 +48,23 @@ def test_global_query_hook(schema, schema_url):
 
 
 @pytest.mark.hypothesis_nested
+@pytest.mark.endpoints("payload")
+def test_global_body_hook(schema):
+    @schemathesis.hooks.register
+    def before_generate_body(context, strategy):
+        return strategy.filter(lambda x: len(x["name"]) == 5)
+
+    strategy = schema.endpoints["/payload"]["POST"].as_strategy()
+
+    @given(case=strategy)
+    @settings(max_examples=3)
+    def test(case):
+        assert len(case.body["name"]) == 5
+
+    test()
+
+
+@pytest.mark.hypothesis_nested
 @pytest.mark.endpoints("custom_format")
 def test_schema_query_hook(schema, schema_url):
     @schema.hooks.register


### PR DESCRIPTION
It was missed during the parameters parsing refactoring