### PR TITLE
fix: Skip explicit examples generation if this phase is disabled via config

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,7 @@ Changelog
 - ``--exitfirst`` CLI option trims the progress bar output when a failure occurs. `#951`_
 - Internal error if filling missing explicit examples led to ``Unsatisfiable`` errors. `#904`_
 - Do not suggest to disable schema validation if it is already disabled. `#914`_
+- Skip explicit examples generation if this phase is disabled via config. `#905`_
 
 **Removed**
 
@@ -1630,6 +1631,7 @@ Deprecated
 .. _#916: https://github.com/schemathesis/schemathesis/issues/916
 .. _#914: https://github.com/schemathesis/schemathesis/issues/914
 .. _#911: https://github.com/schemathesis/schemathesis/issues/911
+.. _#905: https://github.com/schemathesis/schemathesis/issues/905
 .. _#904: https://github.com/schemathesis/schemathesis/issues/904
 .. _#897: https://github.com/schemathesis/schemathesis/issues/897
 .. _#895: https://github.com/schemathesis/schemathesis/issues/895

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -3,6 +3,7 @@ import asyncio
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import hypothesis
+from hypothesis import Phase
 from hypothesis import strategies as st
 from hypothesis.errors import Unsatisfiable
 from hypothesis.strategies import SearchStrategy
@@ -40,7 +41,10 @@ def create_test(
     setup_default_deadline(wrapped_test)
     if settings is not None:
         wrapped_test = settings(wrapped_test)
-    return add_examples(wrapped_test, endpoint, hook_dispatcher=hook_dispatcher)
+    existing_settings = getattr(wrapped_test, "_hypothesis_internal_use_settings", None)
+    if existing_settings and Phase.explicit in existing_settings.phases:
+        wrapped_test = add_examples(wrapped_test, endpoint, hook_dispatcher=hook_dispatcher)
+    return wrapped_test
 
 
 def setup_default_deadline(wrapped_test: Callable) -> None:


### PR DESCRIPTION
Fixes #905