### PR TITLE
chore: Deduplicate collected errors that don't come from failed checks

### DIFF
--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -132,7 +132,7 @@ def run_test(  # pylint: disable=too-many-locals
         # It could be an error in user-defined extensions, network errors or internal Schemathesis errors
         status = Status.error
         result.mark_errored()
-        for error in errors:
+        for error in deduplicate_errors(errors):
             result.add_error(error)
     except hypothesis.errors.MultipleFailures:
         # Schemathesis may detect multiple errors that come from different check results
@@ -192,6 +192,17 @@ def reraise(error: AssertionError) -> InvalidSchema:
         raise InvalidSchema(message) from error
     except InvalidSchema as exc:
         return exc
+
+
+def deduplicate_errors(errors: List[Exception]) -> Generator[Exception, None, None]:
+    """Deduplicate errors by their messages + tracebacks."""
+    seen = set()
+    for error in errors:
+        message = format_exception(error, True)
+        if message in seen:
+            continue
+        seen.add(message)
+        yield error
 
 
 def run_checks(

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -474,6 +474,7 @@ def test_internal_exceptions(args, mocker):
     exceptions = [i.exception.strip() for i in others[1].result.errors]
     for exc_type in exc_types:
         assert str(exc_type.__name__) in exceptions
+    assert len(exceptions) == len(exc_types)
 
 
 @pytest.mark.endpoints("payload")


### PR DESCRIPTION
Forgot to implement it in #976 

Ref: #975
