### PR TITLE
fix: Collecting nullable parameters that are behind references

### DIFF
--- a/src/schemathesis/specs/openapi/references.py
+++ b/src/schemathesis/specs/openapi/references.py
@@ -38,24 +38,14 @@ def load_remote_uri(uri: str) -> Any:
     return yaml.load(response.content, StringDatesYAMLLoader)
 
 
-class ConvertingResolver(jsonschema.RefResolver):
-    """A custom resolver converts resolved OpenAPI schemas to JSON Schema.
+class InliningResolver(jsonschema.RefResolver):
+    """Inlines resolved schemas."""
 
-    When recursive schemas are validated we need to have resolved documents properly converted.
-    This approach is the simplest one, since this logic isolated in a single place.
-    """
-
-    def __init__(self, *args: Any, nullable_name: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         kwargs.setdefault(
             "handlers", {"file": load_file_uri, "": load_file, "http": load_remote_uri, "https": load_remote_uri}
         )
         super().__init__(*args, **kwargs)
-        self.nullable_name = nullable_name
-
-    def resolve(self, ref: str) -> Tuple[str, Any]:
-        url, document = super().resolve(ref)
-        document = traverse_schema(document, to_json_schema, nullable_name=self.nullable_name)
-        return url, document
 
     @overload  # pragma: no mutate
     def resolve_all(
@@ -93,3 +83,20 @@ class ConvertingResolver(jsonschema.RefResolver):
                 new_scope, definition = deepcopy(self.resolve(definition["$ref"]))
             scopes.append(new_scope)
         return scopes, definition
+
+
+class ConvertingResolver(InliningResolver):
+    """Convert resolved OpenAPI schemas to JSON Schema.
+
+    When recursive schemas are validated we need to have resolved documents properly converted.
+    This approach is the simplest one, since this logic isolated in a single place.
+    """
+
+    def __init__(self, *args: Any, nullable_name: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.nullable_name = nullable_name
+
+    def resolve(self, ref: str) -> Tuple[str, Any]:
+        url, document = super().resolve(ref)
+        document = traverse_schema(document, to_json_schema, nullable_name=self.nullable_name)
+        return url, document

--- a/test/specs/openapi/test_security.py
+++ b/test/specs/openapi/test_security.py
@@ -1,4 +1,4 @@
-from schemathesis.specs.openapi.references import ConvertingResolver
+from schemathesis.specs.openapi.references import InliningResolver
 from schemathesis.specs.openapi.security import OpenAPISecurityProcessor
 
 
@@ -11,5 +11,5 @@ def test_ref_resolving():
         "paths": {"foo": {"get": {"responses": {"200": {"description": "OK"}}}}},
         "components": {"securitySchemes": {"$ref": "#/components/HTTPSchema"}, "HTTPSchema": http_schema},
     }
-    resolver = ConvertingResolver("", schema, nullable_name="nullable")
+    resolver = InliningResolver("", schema)
     assert OpenAPISecurityProcessor().get_security_definitions(schema, resolver) == http_schema

--- a/test/test_dereferencing.py
+++ b/test/test_dereferencing.py
@@ -568,8 +568,10 @@ def test_complex_dereference(testdir, complex_schema):
                                 "schema": {
                                     "additionalProperties": False,
                                     "properties": {
-                                        "key": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                                        "referenced": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                                        # Note, these `nullable` keywords are not transformed at this point
+                                        # It is done during the response validation.
+                                        "key": {"type": "string", "nullable": True},
+                                        "referenced": {"type": "string", "nullable": True},
                                     },
                                     "required": ["key", "referenced"],
                                     "type": "object",

--- a/test/test_schemas.py
+++ b/test/test_schemas.py
@@ -8,7 +8,7 @@ import schemathesis
 from schemathesis.exceptions import InvalidSchema
 from schemathesis.parameters import PayloadAlternatives
 from schemathesis.specs.openapi.parameters import OpenAPI20Body
-from schemathesis.specs.openapi.schemas import ConvertingResolver
+from schemathesis.specs.openapi.schemas import InliningResolver
 
 
 @pytest.mark.parametrize("base_path", ("/v1", "/v1/"))
@@ -48,13 +48,13 @@ def test_open_api_verbose_name(openapi_30):
 
 def test_resolver_cache(simple_schema, mocker):
     schema = schemathesis.from_dict(simple_schema)
-    spy = mocker.patch("schemathesis.specs.openapi.schemas.ConvertingResolver", wraps=ConvertingResolver)
+    spy = mocker.patch("schemathesis.specs.openapi.schemas.InliningResolver", wraps=InliningResolver)
     assert "_resolver" not in schema.__dict__
-    assert isinstance(schema.resolver, ConvertingResolver)
+    assert isinstance(schema.resolver, InliningResolver)
     assert spy.call_count == 1
     # Cached
     assert "_resolver" in schema.__dict__
-    assert isinstance(schema.resolver, ConvertingResolver)
+    assert isinstance(schema.resolver, InliningResolver)
     assert spy.call_count == 1
 
 


### PR DESCRIPTION
Regression after parameter parsing refactoring - such parameters were converted to `anyOf` schemas and cause a `KeyError` during parsing.