### PR TITLE
fix: Invalid types in `x-examples`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -41,6 +41,7 @@ Changelog
 - ``Unsatisfiable`` error in stateful testing caused by all API operations having inbound links. `#965`_, `#822`_
 - A possibility to override ``APIStateMachine.step``. `#970`_
 - ``TypeError`` on nullable parameters during Open API specific serialization. `#980`_
+- Invalid types in ``x-examples``. `#982`_
 
 **Removed**
 
@@ -1625,6 +1626,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#982: https://github.com/schemathesis/schemathesis/issues/982
 .. _#980: https://github.com/schemathesis/schemathesis/issues/980
 .. _#975: https://github.com/schemathesis/schemathesis/issues/975
 .. _#970: https://github.com/schemathesis/schemathesis/issues/970

--- a/src/schemathesis/specs/openapi/examples.py
+++ b/src/schemathesis/specs/openapi/examples.py
@@ -21,7 +21,12 @@ def get_parameter_examples(endpoint_def: Dict[str, Any], examples_field: str) ->
         {
             "type": LOCATION_TO_CONTAINER.get(parameter["in"]),
             "name": parameter["name"],
-            "examples": [example["value"] for example in parameter[examples_field].values() if "value" in example],
+            "examples": [
+                example["value"]
+                for example in parameter[examples_field].values()
+                # IDEA: report when it is not a dictionary
+                if isinstance(example, dict) and "value" in example
+            ],
         }
         for parameter in endpoint_def.get("parameters", [])
         if examples_field in parameter
@@ -47,6 +52,7 @@ def get_parameter_example_from_properties(endpoint_def: Dict[str, Any]) -> Dict[
 
 def get_request_body_examples(endpoint_def: Dict[str, Any], examples_field: str) -> Dict[str, Any]:
     """Gets request body examples from OAS3 `examples` keyword or `x-examples` for Swagger 2."""
+    # NOTE. `requestBody` is OAS3-specific. How should it work with OAS2?
     request_bodies_items = endpoint_def.get("requestBody", {}).get("content", {}).items()
     if not request_bodies_items:
         return {}

--- a/test/specs/openapi/test_examples.py
+++ b/test/specs/openapi/test_examples.py
@@ -427,3 +427,21 @@ def test_multipart_examples():
     strategies = schema["/test"]["POST"].get_strategies_from_examples()
     assert len(strategies) == 1
     assert find(strategies[0], lambda case: case.body == {"key": "test"})
+
+
+def test_invalid_x_examples(empty_open_api_2_schema):
+    # See GH-982
+    # When an Open API 2.0 schema contains a non-object type in `x-examples`
+    empty_open_api_2_schema["paths"] = {
+        "/test": {
+            "post": {
+                "parameters": [
+                    {"name": "body", "in": "body", "schema": {"type": "integer"}, "x-examples": {"foo": "value"}}
+                ],
+                "responses": {"default": {"description": "OK"}},
+            }
+        }
+    }
+    schema = schemathesis.from_dict(empty_open_api_2_schema)
+    # Then such examples should be skipped as invalid (there should be an object)
+    assert schema["/test"]["POST"].get_strategies_from_examples() == []


### PR DESCRIPTION
Fixes #982