### PR TITLE
perf: Decrease memory usage

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,6 +46,7 @@ Changelog
 **Performance**
 
 - Use compiled versions of Open API spec validators.
+- Decrease CLI memory usage. `#987`_
 
 **Removed**
 
@@ -1630,6 +1631,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#987: https://github.com/schemathesis/schemathesis/issues/987
 .. _#982: https://github.com/schemathesis/schemathesis/issues/982
 .. _#980: https://github.com/schemathesis/schemathesis/issues/980
 .. _#975: https://github.com/schemathesis/schemathesis/issues/975

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -713,7 +713,8 @@ class Interaction:
 class TestResult:
     """Result of a single test."""
 
-    endpoint: Endpoint = attr.ib()  # pragma: no mutate
+    method: str = attr.ib()  # pragma: no mutate
+    path: str = attr.ib()  # pragma: no mutate
     data_generation_method: DataGenerationMethod = attr.ib()  # pragma: no mutate
     checks: List[Check] = attr.ib(factory=list)  # pragma: no mutate
     errors: List[Tuple[Exception, Optional[Case]]] = attr.ib(factory=list)  # pragma: no mutate

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -118,7 +118,12 @@ def run_test(  # pylint: disable=too-many-locals
     **kwargs: Any,
 ) -> Generator[events.ExecutionEvent, None, None]:
     """A single test run with all error handling needed."""
-    result = TestResult(endpoint=endpoint, overridden_headers=headers, data_generation_method=data_generation_method)
+    result = TestResult(
+        method=endpoint.method.upper(),
+        path=endpoint.full_path,
+        overridden_headers=headers,
+        data_generation_method=data_generation_method,
+    )
     yield events.BeforeExecution.from_endpoint(endpoint=endpoint, recursion_level=recursion_level)
     hypothesis_output: List[str] = []
     errors: List[Exception] = []

--- a/src/schemathesis/runner/serialization.py
+++ b/src/schemathesis/runner/serialization.py
@@ -96,8 +96,8 @@ class SerializedTestResult:
     def from_test_result(cls, result: TestResult) -> "SerializedTestResult":
         formatter = logging.Formatter("[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
         return SerializedTestResult(
-            method=result.endpoint.method.upper(),
-            path=result.endpoint.full_path,
+            method=result.method,
+            path=result.path,
             has_failures=result.has_failures,
             has_errors=result.has_errors,
             has_logs=result.has_logs,

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -115,7 +115,11 @@ class BaseSchema(Mapping):
 
     @property
     def endpoints_count(self) -> int:
-        return len(list(self.get_all_endpoints()))
+        total = 0
+        # Avoid creating a list of all endpoints - for large schemas it consumes too much memory
+        for _ in self.get_all_endpoints():
+            total += 1
+        return total
 
     def get_all_endpoints(self) -> Generator[Endpoint, None, None]:
         raise NotImplementedError


### PR DESCRIPTION
Fixes #987 

However, this PR doesn't change the multi-worker implementation, it still significantly reduces memory usage:

- There is no peak during the initialization. Before a list of all endpoints was created - now it iterates over all endpoints.
- `endpoint` is not stored inside the test results, so it can be garbage collected during the run


