### PR TITLE
fix: CLI crash on schemas with operation names longer than the current terminal width

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -42,6 +42,7 @@ Changelog
 - A possibility to override ``APIStateMachine.step``. `#970`_
 - ``TypeError`` on nullable parameters during Open API specific serialization. `#980`_
 - Invalid types in ``x-examples``. `#982`_
+- CLI crash on schemas with operation names longer than the current terminal width. `#990`_
 
 **Performance**
 
@@ -1631,6 +1632,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#990: https://github.com/schemathesis/schemathesis/issues/990
 .. _#987: https://github.com/schemathesis/schemathesis/issues/987
 .. _#982: https://github.com/schemathesis/schemathesis/issues/982
 .. _#980: https://github.com/schemathesis/schemathesis/issues/980

--- a/test/cli/output/test_default.py
+++ b/test/cli/output/test_default.py
@@ -158,8 +158,9 @@ def test_display_percentage(
     # When percentage is displayed
     default.display_percentage(execution_context, after_execution)
     out = capsys.readouterr().out
-    # Then the whole line fits precisely to the terminal width
-    assert len(click.unstyle(out)) + current_line_length == default.get_terminal_width()
+    # Then the whole line fits precisely to the terminal width. Note `-1` is padding, that is calculated in a
+    # different place when the line is printed
+    assert len(click.unstyle(out)) + current_line_length - 1 == default.get_terminal_width()
     # And the percentage displayed as expected in cyan color
     assert out.strip() == strip_style_win32(click.style(percentage, fg="cyan"))
 


### PR DESCRIPTION
Fixes #990