### PR TITLE
fix: Handling of API operations that contain reserved characters in their paths

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -123,6 +123,7 @@ By default, the server will generate an API schema with the following endpoints:
 - ``POST /api/users/`` (``create_user``) - creates a user and stores it in memory. Provides Open API links to the endpoints below
 - ``GET /api/users/{user_id}`` (``get_user``) - returns a user stored in memory
 - ``PATCH /api/users/{user_id}`` (``update_user``) - updates a user stored in memory
+- ``GET /api/foo:bar`` (``reserved``) - contains ``:`` in its path
 
 You can find the complete schema at ``http://127.0.0.1:8081/schema.yaml`` (replace 8081 with the port you chose in the start server command).
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,7 @@ Changelog
 - ``TypeError`` on nullable parameters during Open API specific serialization. `#980`_
 - Invalid types in ``x-examples``. `#982`_
 - CLI crash on schemas with operation names longer than the current terminal width. `#990`_
+- Handling of API operations that contain reserved characters in their paths. `#992`_
 
 **Performance**
 
@@ -1632,6 +1633,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#992: https://github.com/schemathesis/schemathesis/issues/992
 .. _#990: https://github.com/schemathesis/schemathesis/issues/990
 .. _#987: https://github.com/schemathesis/schemathesis/issues/987
 .. _#982: https://github.com/schemathesis/schemathesis/issues/982

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -23,7 +23,7 @@ from typing import (
     Union,
     cast,
 )
-from urllib.parse import urljoin, urlsplit, urlunsplit
+from urllib.parse import quote, unquote, urljoin, urlsplit, urlunsplit
 
 import attr
 import curlify
@@ -244,7 +244,7 @@ class Case:  # pylint: disable=too-many-public-methods
             final_headers["Content-Type"] = self.media_type
         base_url = self._get_base_url(base_url)
         formatted_path = self.formatted_path.lstrip("/")  # pragma: no mutate
-        url = urljoin(base_url + "/", formatted_path)
+        url = unquote(urljoin(base_url + "/", quote(formatted_path)))
         extra: Dict[str, Any]
         serializer = self._get_serializer()
         if serializer is not None and self.body is not NOT_SET:

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -9,7 +9,7 @@ They give only static definitions of endpoints.
 from collections.abc import Mapping
 from difflib import get_close_matches
 from typing import Any, Callable, Dict, Generator, Iterable, Iterator, List, Optional, Sequence, Tuple, Type, Union
-from urllib.parse import urljoin, urlsplit, urlunsplit
+from urllib.parse import quote, unquote, urljoin, urlsplit, urlunsplit
 
 import attr
 import hypothesis
@@ -76,7 +76,7 @@ class BaseSchema(Mapping):
 
     def get_full_path(self, path: str) -> str:
         """Compute full path for the given path."""
-        return urljoin(self.base_path, path.lstrip("/"))  # pragma: no mutate
+        return unquote(urljoin(self.base_path, quote(path.lstrip("/"))))  # pragma: no mutate
 
     @property
     def base_path(self) -> str:

--- a/test/apps/_aiohttp/handlers.py
+++ b/test/apps/_aiohttp/handlers.py
@@ -227,6 +227,7 @@ async def update_user(request: web.Request) -> web.Response:
 
 get_payload = payload
 path_variable = success
+reserved = success
 invalid = success
 invalid_path_parameter = success
 missing_path_parameter = success

--- a/test/apps/_flask/__init__.py
+++ b/test/apps/_flask/__init__.py
@@ -54,6 +54,10 @@ def create_openapi_app(
             1 / 0
         return jsonify({"success": True})
 
+    @app.route("/api/foo:bar", methods=["GET"])
+    def reserved():
+        return jsonify({"success": True})
+
     @app.route("/api/recursive", methods=["GET"])
     def recursive():
         return jsonify({"children": [{"children": [{"children": []}]}]})

--- a/test/apps/utils.py
+++ b/test/apps/utils.py
@@ -31,6 +31,7 @@ class Endpoint(Enum):
     invalid_path_parameter = ("GET", "/api/invalid_path_parameter/{id}")
     missing_path_parameter = ("GET", "/api/missing_path_parameter/{id}")
     headers = ("GET", "/api/headers")
+    reserved = ("GET", "/api/foo:bar")
 
     create_user = ("POST", "/api/users/")
     get_user = ("GET", "/api/users/{user_id}")

--- a/test/cli/test_cassettes.py
+++ b/test/cli/test_cassettes.py
@@ -204,7 +204,7 @@ async def test_replay(openapi_version, cli, schema_url, app, reset_app, cassette
             url = urlunparse(
                 (parsed.scheme, parsed.netloc, encoded_path, parsed.params, encoded_query, parsed.fragment)
             )
-            assert url == serialized["uri"], request.url
+            assert unquote_plus(url) == unquote_plus(serialized["uri"]), request.url
             content = await request.read()
             assert content == base64.b64decode(serialized["body"]["base64_string"])
             compare_headers(request, serialized["headers"])

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -1710,3 +1710,20 @@ def test_long_operation_output(testdir, empty_open_api_3_schema):
     assert result.ret == ExitCode.OK
     assert "GET /aaaaaaaaaa .                                                         [ 50%]" in result.outlines
     assert "GET /aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[...] . [100%]" in result.outlines
+
+
+def test_reserved_characters_in_operation_name(testdir, empty_open_api_3_schema):
+    # See GH-992
+    # When an API operation name contains `:`
+    empty_open_api_3_schema["paths"] = {
+        f"/foo:bar": {
+            "get": {
+                "responses": {"200": {"description": "OK"}},
+            }
+        },
+    }
+    schema_file = testdir.makefile(".yaml", schema=yaml.dump(empty_open_api_3_schema))
+    result = testdir.run("schemathesis", "run", str(schema_file), "--dry-run")
+    # Then this operation name should be displayed with the leading `/`
+    assert result.ret == ExitCode.OK
+    assert "GET /foo:bar .                                                            [100%]" in result.outlines

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -776,3 +776,18 @@ def test_dry_run_asgi(loadable_fastapi_app):
     execute("/openapi.json", app=loadable_fastapi_app, checks=(check,), dry_run=True)
     # Then no requests should be sent & no responses checked
     assert not called
+
+
+@pytest.mark.endpoints("reserved")
+def test_reserved_characters_in_operation_name(args):
+    # See GH-992
+
+    def check(response, case):
+        assert response.status_code == 200
+
+    # When there is `:` in the API operation path
+    app, kwargs = args
+    result = execute(checks=(check,), **kwargs)
+    # Then it should be reachable
+    assert not result.has_errors
+    assert not result.has_failures

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -55,6 +55,15 @@ def test_as_requests_kwargs(override, server, base_url, swagger_20, converter):
     assert response.json() == {"success": True}
 
 
+def test_reserved_characters_in_operation_name(swagger_20):
+    # See GH-992
+    # When an API operation name contains `:`
+    endpoint = Endpoint("/foo:bar", "GET", {}, swagger_20)
+    case = endpoint.make_case()
+    # Then it should not be truncated during API call
+    assert case.as_requests_kwargs("/")["url"] == "/foo:bar"
+
+
 @pytest.mark.parametrize(
     "headers, expected",
     (


### PR DESCRIPTION
Fixes #992
