### PR TITLE
fix: Processing parameters common for multiple API operations if they are behind a reference

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Processing parameters common for multiple API operations if they are behind a reference. `#1015`_
+
 `3.0.1`_ - 2021-01-15
 ---------------------
 
@@ -1672,6 +1676,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1015: https://github.com/schemathesis/schemathesis/issues/1015
 .. _#1010: https://github.com/schemathesis/schemathesis/issues/1010
 .. _#1007: https://github.com/schemathesis/schemathesis/issues/1007
 .. _#1003: https://github.com/schemathesis/schemathesis/issues/1003

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -107,7 +107,7 @@ class BaseOpenAPISchema(BaseSchema):
                     continue
                 self.dispatch_hook("before_process_path", context, path, methods)
                 scope, raw_methods = self._resolve_methods(methods)
-                common_parameters = methods.get("parameters", [])
+                common_parameters = self.resolver.resolve_all(methods.get("parameters", []), RECURSION_DEPTH_LIMIT - 5)
                 for method, definition in raw_methods.items():
                     try:
                         # Setting a low recursion limit doesn't solve the problem with recursive references & inlining

--- a/test/test_common_parameters.py
+++ b/test/test_common_parameters.py
@@ -47,6 +47,7 @@ def impl(request, case):
     if case.method == "POST":
         assert_int(case.body)
     assert_int(case.query["not_common_id"])
+    assert_int(case.query["key"])
 
 @schema.parametrize(endpoint="/foo")
 @settings(max_examples=1)
@@ -61,7 +62,8 @@ def test_b(request, case):
         paths={
             "/foo": {
                 "parameters": [
-                    {"schema": {"$ref": "#/definitions/SimpleIntRef"}, "in": "body", "name": "id", "required": True}
+                    {"$ref": "#/parameters/Param"},
+                    {"schema": {"$ref": "#/definitions/SimpleIntRef"}, "in": "body", "name": "id", "required": True},
                 ],
                 "put": {
                     "parameters": [integer(name="not_common_id", required=True)],
@@ -74,6 +76,7 @@ def test_b(request, case):
             }
         },
         definitions={"SimpleIntRef": {"type": "integer"}},
+        parameters={"Param": {"in": "query", "name": "key", "required": True, "type": "integer"}},
     )
     result = testdir.runpytest("-v", "-s")
     # Then this parameter should be used in all generated tests


### PR DESCRIPTION
Fixes #1015