### PR TITLE
fix: Return a default terminal size to prevent crashes on systems with zero-width terminals

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Return a default terminal size to prevent crashes on systems with zero-width terminals (some CI/CD servers).
+
 **Added**
 
 - Support for external examples via the ``externalValue`` keyword. `#884`_

--- a/src/schemathesis/cli/output/default.py
+++ b/src/schemathesis/cli/output/default.py
@@ -22,7 +22,8 @@ DISABLE_SCHEMA_VALIDATION_MESSAGE = (
 
 
 def get_terminal_width() -> int:
-    return shutil.get_terminal_size().columns
+    # Some CI/CD providers (e.g. CircleCI) return a (0, 0) terminal size so provide a default
+    return shutil.get_terminal_size((80, 24)).columns
 
 
 def display_section_name(title: str, separator: str = "=", extra: str = "", **kwargs: Any) -> None:

--- a/test/cli/output/test_default.py
+++ b/test/cli/output/test_default.py
@@ -54,6 +54,10 @@ def after_execution(results_set, operation, swagger_20):
     )
 
 
+def test_get_terminal_width():
+    assert default.get_terminal_width() >= 80
+
+
 @pytest.mark.parametrize(
     "title,separator,printed,expected",
     [


### PR DESCRIPTION
CircleCI returns a zero-width terminal which was causing the schemathesis CLI to crash during jobs. Providing a default prevents crashing in these cases.

The default terminal size of 80w 24h was chosen because it seems to be a historically 'standard' terminal size.

Ref: (https://softwareengineering.stackexchange.com/questions/148754/why-is-24-lines-a-common-default-terminal-height)