### PR TITLE
fix: Return a minimum terminal width to prevent crashes on systems with zero-width terminals

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Prevent a small terminal width causing a crash (due to negative length used in an f-string) when printing percentage
+
 **Added**
 
 - Support for external examples via the ``externalValue`` keyword. `#884`_

--- a/src/schemathesis/cli/output/default.py
+++ b/src/schemathesis/cli/output/default.py
@@ -61,7 +61,7 @@ def display_percentage(context: ExecutionContext, event: events.AfterExecution) 
     styled = click.style(current_percentage, fg="cyan")
     # Total length of the message, so it will fill to the right border of the terminal.
     # Padding is already taken into account in `context.current_line_length`
-    length = get_terminal_width() - context.current_line_length + len(styled) - len(current_percentage)
+    length = max(get_terminal_width() - context.current_line_length + len(styled) - len(current_percentage), 1)
     template = f"{{:>{length}}}"
     click.echo(template.format(styled))
 


### PR DESCRIPTION
Hello again!

Sorry, the fix that I implemented yesterday didn't work because I misunderstood how the `fallback` parameter of `shutil.get_terminal_size` worked. That value is only used if a terminal doesn't report a terminal size, but some CI/CD providers (like ours) DO provide a terminal size, it's just 0.

This fix will guarantee that a minimum terminal width of 80 is returned and I have tested this on our CI provider.