### PR TITLE
fix: Percent-encode `.` and `..` strings in path parameters

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Percent-encode the generated ``.`` and ``..`` strings in path parameters to avoid resolving relative paths and changing the tested path structure. `#1036`_
+
 `3.1.1`_ - 2021-03-05
 ---------------------
 
@@ -1609,6 +1613,7 @@ Deprecated
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
 .. _#1039: https://github.com/schemathesis/schemathesis/issues/1039
+.. _#1036: https://github.com/schemathesis/schemathesis/issues/1036
 .. _#1033: https://github.com/schemathesis/schemathesis/issues/1033
 .. _#1028: https://github.com/schemathesis/schemathesis/issues/1028
 .. _#1022: https://github.com/schemathesis/schemathesis/issues/1022

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -17,6 +17,7 @@ from schemathesis.specs.openapi._hypothesis import (
     is_valid_path,
     is_valid_query,
     make_positive_strategy,
+    quote_all,
 )
 from schemathesis.specs.openapi.parameters import OpenAPI20Body, OpenAPI20CompositeBody, OpenAPI20Parameter
 from schemathesis.utils import NOT_SET
@@ -362,6 +363,12 @@ def test_is_valid_query(value, expected):
 @pytest.mark.parametrize("value", ("/", "\udc9b"))
 def test_filter_path_parameters(value):
     assert not is_valid_path({"foo": value})
+
+
+@pytest.mark.parametrize("value, expected", ((".", "%2E"), ("..", "%2E%2E"), (".foo", ".foo")))
+def test_path_parameters_quotation(value, expected):
+    # See GH-1036
+    assert quote_all({"foo": value})["foo"] == expected
 
 
 @pytest.mark.hypothesis_nested


### PR DESCRIPTION
Avoid resolving relative paths and changing the tested path structure.

Fixes #1036