### PR TITLE
feat: Add `count_operations` flag to `runner.prepare`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,12 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Added**
+
+- ``count_operations`` boolean flag to ``runner.prepare``. In case of ``False`` value, Schemathesis won't count the total number of operations upfront.
+  It improves performance for the direct ``runner`` usage, especially on large schemas.
+  Schemathesis CLI will still use these calculations to display the progress during execution, but this behavior may become configurable in the future.
+
 `3.1.2`_ - 2021-03-08
 ---------------------
 

--- a/src/schemathesis/cli/output/default.py
+++ b/src/schemathesis/cli/output/default.py
@@ -289,7 +289,7 @@ def display_internal_error(context: ExecutionContext, event: events.InternalErro
 
 def handle_initialized(context: ExecutionContext, event: events.Initialized) -> None:
     """Display information about the test session."""
-    context.operations_count = event.operations_count
+    context.operations_count = cast(int, event.operations_count)  # INVARIANT: should not be `None`
     display_section_name("Schemathesis test session starts")
     versions = (
         f"platform {platform.system()} -- "
@@ -310,8 +310,8 @@ def handle_initialized(context: ExecutionContext, event: events.Initialized) -> 
     click.echo(f"Base URL: {event.base_url}")
     click.echo(f"Specification version: {event.specification_name}")
     click.echo(f"Workers: {context.workers_num}")
-    click.secho(f"Collected API operations: {event.operations_count}", bold=True)
-    if event.operations_count >= 1:
+    click.secho(f"Collected API operations: {context.operations_count}", bold=True)
+    if context.operations_count >= 1:
         click.echo()
 
 

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -58,6 +58,7 @@ def prepare(
     validate_schema: bool = True,
     skip_deprecated_operations: bool = False,
     force_schema_version: Optional[str] = None,
+    count_operations: bool = True,
     # Hypothesis-specific configuration
     hypothesis_deadline: Optional[Union[int, NotSet]] = None,
     hypothesis_derandomize: Optional[bool] = None,
@@ -114,6 +115,7 @@ def prepare(
         fixups=fixups,
         stateful=stateful,
         stateful_recursion_limit=stateful_recursion_limit,
+        count_operations=count_operations,
     )
 
 
@@ -167,6 +169,7 @@ def execute_from_schema(
     fixups: Iterable[str] = (),
     stateful: Optional[Stateful] = None,
     stateful_recursion_limit: int = DEFAULT_STATEFUL_RECURSION_LIMIT,
+    count_operations: bool = True,
 ) -> Generator[events.ExecutionEvent, None, None]:
     """Execute tests for the given schema.
 
@@ -222,6 +225,7 @@ def execute_from_schema(
                     store_interactions=store_interactions,
                     stateful=stateful,
                     stateful_recursion_limit=stateful_recursion_limit,
+                    count_operations=count_operations,
                 )
             elif isinstance(schema.app, Starlette):
                 runner = ThreadPoolASGIRunner(
@@ -239,8 +243,8 @@ def execute_from_schema(
                     store_interactions=store_interactions,
                     stateful=stateful,
                     stateful_recursion_limit=stateful_recursion_limit,
+                    count_operations=count_operations,
                 )
-
             else:
                 runner = ThreadPoolWSGIRunner(
                     schema=schema,
@@ -258,8 +262,8 @@ def execute_from_schema(
                     store_interactions=store_interactions,
                     stateful=stateful,
                     stateful_recursion_limit=stateful_recursion_limit,
+                    count_operations=count_operations,
                 )
-
         else:
             if not schema.app:
                 runner = SingleThreadRunner(
@@ -279,6 +283,7 @@ def execute_from_schema(
                     store_interactions=store_interactions,
                     stateful=stateful,
                     stateful_recursion_limit=stateful_recursion_limit,
+                    count_operations=count_operations,
                 )
             elif isinstance(schema.app, Starlette):
                 runner = SingleThreadASGIRunner(
@@ -296,6 +301,7 @@ def execute_from_schema(
                     store_interactions=store_interactions,
                     stateful=stateful,
                     stateful_recursion_limit=stateful_recursion_limit,
+                    count_operations=count_operations,
                 )
             else:
                 runner = SingleThreadWSGIRunner(
@@ -313,8 +319,8 @@ def execute_from_schema(
                     store_interactions=store_interactions,
                     stateful=stateful,
                     stateful_recursion_limit=stateful_recursion_limit,
+                    count_operations=count_operations,
                 )
-
         yield from runner.execute()
     except Exception as exc:
         yield events.InternalError.from_exc(exc)

--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -21,7 +21,7 @@ class Initialized(ExecutionEvent):
     """Runner is initialized, settings are prepared, requests session is ready."""
 
     # Total number of operations in the schema
-    operations_count: int = attr.ib()  # pragma: no mutate
+    operations_count: Optional[int] = attr.ib()  # pragma: no mutate
     location: Optional[str] = attr.ib()  # pragma: no mutate
     base_url: str = attr.ib()  # pragma: no mutate
     specification_name: str = attr.ib()  # pragma: no mutate
@@ -29,10 +29,10 @@ class Initialized(ExecutionEvent):
     start_time: float = attr.ib(factory=time.monotonic)  # pragma: no mutate
 
     @classmethod
-    def from_schema(cls, *, schema: BaseSchema) -> "Initialized":
+    def from_schema(cls, *, schema: BaseSchema, count_operations: bool = True) -> "Initialized":
         """Computes all needed data from a schema instance."""
         return cls(
-            operations_count=schema.operations_count,
+            operations_count=schema.operations_count if count_operations else None,
             location=schema.location,
             base_url=schema.get_base_url(),
             specification_name=schema.verbose_name,

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -56,12 +56,13 @@ class BaseRunner:
     dry_run: bool = attr.ib(default=False)  # pragma: no mutate
     stateful: Optional[Stateful] = attr.ib(default=None)  # pragma: no mutate
     stateful_recursion_limit: int = attr.ib(default=DEFAULT_STATEFUL_RECURSION_LIMIT)  # pragma: no mutate
+    count_operations: bool = attr.ib(default=True)  # pragma: no mutate
 
     def execute(self) -> Generator[events.ExecutionEvent, None, None]:
         """Common logic for all runners."""
         results = TestResultSet()
 
-        initialized = events.Initialized.from_schema(schema=self.schema)
+        initialized = events.Initialized.from_schema(schema=self.schema, count_operations=self.count_operations)
         yield initialized
 
         for event in self._execute(results):

--- a/test-corpus/test_corpus.py
+++ b/test-corpus/test_corpus.py
@@ -171,6 +171,7 @@ def test_runner(schema_path):
         validate_schema=False,
         hypothesis_suppress_health_check=HealthCheck.all(),
         hypothesis_phases=[Phase.explicit, Phase.generate],
+        count_operations=False,
     )
 
     schema_id = get_id(schema_path)

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -351,6 +351,7 @@ def test_execute_arguments(cli, mocker, simple_schema, args, expected):
         "store_interactions": False,
         "seed": None,
         "max_response_time": None,
+        "count_operations": True,
         **expected,
     }
 

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -791,3 +791,10 @@ def test_reserved_characters_in_operation_name(args):
     # Then it should be reachable
     assert not result.has_errors
     assert not result.has_failures
+
+
+def test_count_operations(openapi3_schema_url):
+    # When `count_operations` is set to `False`
+    event = next(prepare(openapi3_schema_url, count_operations=False))
+    # Then the total number of operations is not calculated in the `Initialized` event
+    assert event.operations_count is None


### PR DESCRIPTION
Passing `False` will skip some calculations which may significantly improve performance.