### PR TITLE
fix: Wrong test results in some cases when the tested schema contains a media type that Schemathesis doesn't know how to work with

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Wrong test results in some cases when the tested schema contains a media type that Schemathesis doesn't know how to work with. `#1046`_
+
 `3.2.0`_ - 2021-03-09
 ---------------------
 
@@ -1639,6 +1643,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1046: https://github.com/schemathesis/schemathesis/issues/1046
 .. _#1039: https://github.com/schemathesis/schemathesis/issues/1039
 .. _#1036: https://github.com/schemathesis/schemathesis/issues/1036
 .. _#1033: https://github.com/schemathesis/schemathesis/issues/1033

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -10,7 +10,7 @@ import attr
 import hypothesis
 import requests
 from _pytest.logging import LogCaptureHandler, catching_logs
-from hypothesis.errors import InvalidArgument
+from hypothesis.errors import HypothesisException, InvalidArgument
 from hypothesis_jsonschema._canonicalise import HypothesisRefResolutionError
 from requests.auth import HTTPDigestAuth, _basic_auth_str
 
@@ -360,6 +360,9 @@ class ErrorCollector:
         #   - The testing process is interrupted
         if not exc_type or issubclass(exc_type, CheckFailed) or not issubclass(exc_type, Exception):
             return False
+        # These exceptions are needed for control flow on the Hypothesis side. E.g. rejecting unsatisfiable examples
+        if isinstance(exc_val, HypothesisException):
+            raise
         # Exception value is not `None` and is a subclass of `Exception` at this point
         exc_val = cast(Exception, exc_val)
         self.errors.append(exc_val.with_traceback(exc_tb))


### PR DESCRIPTION
Fixes #1046