### PR TITLE
chore(internal): Make `SerializedCheck.example` and `Check.example` not optional

### DIFF
--- a/src/schemathesis/cli/handlers.py
+++ b/src/schemathesis/cli/handlers.py
@@ -21,7 +21,7 @@ def get_unique_failures(checks: List[SerializedCheck]) -> List[SerializedCheck]:
     unique_checks = []
     for check in reversed(checks):
         # There are also could be checks that didn't fail
-        if check.example is not None and check.value == Status.failure and (check.name, check.message) not in seen:
+        if check.value == Status.failure and (check.name, check.message) not in seen:
             unique_checks.append(check)
             seen.add((check.name, check.message))
     return unique_checks

--- a/src/schemathesis/cli/output/default.py
+++ b/src/schemathesis/cli/output/default.py
@@ -174,8 +174,7 @@ def display_failures_for_single_test(context: ExecutionContext, result: Serializ
             message = f"{idx}. {check.message}"
         else:
             message = None
-        example = cast(SerializedCase, check.example)  # filtered in `get_unique_failures`
-        display_example(context, example, check.response, message, result.seed)
+        display_example(context, check.example, check.response, message, result.seed)
         # Display every time except the last check
         if idx != len(checks):
             click.echo("\n")

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -634,7 +634,7 @@ class Check:
     value: Status = attr.ib()  # pragma: no mutate
     response: GenericResponse = attr.ib()  # pragma: no mutate
     elapsed: float = attr.ib()  # pragma: no mutate
-    example: Optional[Case] = attr.ib(default=None)  # pragma: no mutate
+    example: Case = attr.ib()  # pragma: no mutate
     message: Optional[str] = attr.ib(default=None)  # pragma: no mutate
 
 

--- a/src/schemathesis/runner/serialization.py
+++ b/src/schemathesis/runner/serialization.py
@@ -39,7 +39,7 @@ class SerializedCheck:
     value: Status = attr.ib()  # pragma: no mutate
     request: Request = attr.ib()  # pragma: no mutate
     response: Response = attr.ib()  # pragma: no mutate
-    example: Optional[SerializedCase] = attr.ib(default=None)  # pragma: no mutate
+    example: SerializedCase = attr.ib()  # pragma: no mutate
     message: Optional[str] = attr.ib(default=None)  # pragma: no mutate
 
     @classmethod
@@ -52,7 +52,7 @@ class SerializedCheck:
         return SerializedCheck(
             name=check.name,
             value=check.value,
-            example=SerializedCase.from_case(check.example, headers) if check.example else None,
+            example=SerializedCase.from_case(check.example, headers),
             message=check.message,
             request=request,
             response=response,

--- a/test/cli/output/test_default.py
+++ b/test/cli/output/test_default.py
@@ -113,8 +113,8 @@ def test_handle_initialized(capsys, execution_context, results_set, swagger_20):
 
 def test_display_statistic(capsys, swagger_20, execution_context, operation, response):
     # Given multiple successful & failed checks in a single test
-    success = models.Check("not_a_server_error", models.Status.success, response, 0)
-    failure = models.Check("not_a_server_error", models.Status.failure, response, 0)
+    success = models.Check("not_a_server_error", models.Status.success, response, 0, models.Case(operation))
+    failure = models.Check("not_a_server_error", models.Status.failure, response, 0, models.Case(operation))
     single_test_statistic = models.TestResult(
         operation.method,
         operation.full_path,
@@ -125,7 +125,7 @@ def test_display_statistic(capsys, swagger_20, execution_context, operation, res
             success,
             failure,
             failure,
-            models.Check("different_check", models.Status.success, response, 0),
+            models.Check("different_check", models.Status.success, response, 0, models.Case(operation)),
         ],
     )
     results = models.TestResultSet([single_test_statistic])
@@ -204,7 +204,7 @@ def test_display_hypothesis_output(capsys):
 @pytest.mark.parametrize("body", ({}, {"foo": "bar"}, None))
 def test_display_single_failure(capsys, swagger_20, execution_context, operation, body, response):
     # Given a single test result with multiple successful & failed checks
-    success = models.Check("not_a_server_error", models.Status.success, response, 0)
+    success = models.Check("not_a_server_error", models.Status.success, response, 0, models.Case(operation, body=body))
     failure = models.Check("not_a_server_error", models.Status.failure, response, 0, models.Case(operation, body=body))
     test_statistic = models.TestResult(
         operation.method,
@@ -216,7 +216,7 @@ def test_display_single_failure(capsys, swagger_20, execution_context, operation
             success,
             failure,
             failure,
-            models.Check("different_check", models.Status.success, response, 0),
+            models.Check("different_check", models.Status.success, response, 0, models.Case(operation, body=body)),
         ],
     )
     # When this failure is displayed


### PR DESCRIPTION
They are practically never optional