### PR TITLE
fix: Displaying wrong headers in the `FAILURES` block of the CLI output

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -110,6 +110,7 @@ By default, the server will generate an API schema with the following API operat
 - ``POST /api/performance`` - depending on the number of "0" in the input value, responds slower and if the input value has more than ten "0", returns 500
 - ``GET /api/flaky`` - returns 1:1 ratio of 200/500 responses
 - ``GET /api/recursive`` - accepts a recursive structure and responds with a recursive one
+- ``GET /api/basic`` - Requires HTTP basic auth (use `test` as username and password)
 - ``POST /api/multipart`` - accepts two body parameters as multipart payload
 - ``POST /api/upload_file`` - accepts a file and a body parameter
 - ``POST /api/form`` - accepts ``application/x-www-form-urlencoded`` payload

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Displaying wrong headers in the ``FAILURES`` block of the CLI output. `#792`_
+
 `3.3.0`_ - 2021-03-17
 ---------------------
 
@@ -1742,6 +1746,7 @@ Deprecated
 .. _#812: https://github.com/schemathesis/schemathesis/issues/812
 .. _#795: https://github.com/schemathesis/schemathesis/issues/795
 .. _#793: https://github.com/schemathesis/schemathesis/issues/793
+.. _#792: https://github.com/schemathesis/schemathesis/issues/792
 .. _#788: https://github.com/schemathesis/schemathesis/issues/788
 .. _#783: https://github.com/schemathesis/schemathesis/issues/783
 .. _#768: https://github.com/schemathesis/schemathesis/issues/768

--- a/src/schemathesis/cli/output/default.py
+++ b/src/schemathesis/cli/output/default.py
@@ -202,8 +202,7 @@ def display_example(
         click.echo()
     for line in case.text_lines:
         click.secho(line, fg="red")
-    if case.text_lines:
-        click.echo()
+    click.echo()
     if response is not None:
         payload = base64.b64decode(response.body).decode("utf8", errors="replace")
         click.secho(f"----------\n\nResponse payload: `{payload}`\n", fg="red")

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -140,7 +140,7 @@ class Case:  # pylint: disable=too-many-public-methods
             return urlunsplit(("http", "localhost", path or "", "", ""))
         return self.base_url
 
-    def as_text_lines(self) -> List[str]:
+    def as_text_lines(self, headers: Optional[Dict[str, Any]] = None) -> List[str]:
         """Textual representation.
 
         Each component is a separate line.
@@ -152,6 +152,11 @@ class Case:  # pylint: disable=too-many-public-methods
             "Query": self.query,
             "Body": self.body,
         }
+        if headers:
+            final_headers = output["Headers"] or {}
+            final_headers = cast(Dict[str, Any], final_headers)
+            final_headers.update(headers)
+            output["Headers"] = final_headers
         max_length = max(map(len, output))
         template = f"{{:<{max_length}}} : {{}}"
 
@@ -776,7 +781,8 @@ class TestResult:
     logs: List[LogRecord] = attr.ib(factory=list)  # pragma: no mutate
     is_errored: bool = attr.ib(default=False)  # pragma: no mutate
     seed: Optional[int] = attr.ib(default=None)  # pragma: no mutate
-    # To show a proper reproduction code if a failure happens
+    # To show a proper reproduction code if an error happens and there is no way to get actual headers that were
+    # sent over the network. Or there could be no actual requests at all
     overridden_headers: Optional[Dict[str, Any]] = attr.ib(default=None)  # pragma: no mutate
 
     def mark_errored(self) -> None:

--- a/test/apps/_aiohttp/handlers.py
+++ b/test/apps/_aiohttp/handlers.py
@@ -26,6 +26,12 @@ async def success(request: web.Request) -> web.Response:
     return web.json_response({"success": True})
 
 
+async def basic(request: web.Request) -> web.Response:
+    if "Authorization" in request.headers and request.headers["Authorization"] == "Basic dGVzdDp0ZXN0":
+        return web.json_response({"secret": 42})
+    raise web.HTTPUnauthorized(text='{"detail": "Unauthorized"}', content_type="application/json")
+
+
 async def payload(request: web.Request) -> web.Response:
     body = await request.read()
     if body:

--- a/test/apps/_flask/__init__.py
+++ b/test/apps/_flask/__init__.py
@@ -78,6 +78,12 @@ def create_openapi_app(
     def get_payload():
         return jsonify(request.json)
 
+    @app.route("/api/basic", methods=["GET"])
+    def basic():
+        if "Authorization" in request.headers and request.headers["Authorization"] == "Basic dGVzdDp0ZXN0":
+            return jsonify({"secret": 42})
+        return {"detail": "Unauthorized"}, 401
+
     @app.route("/api/headers", methods=["GET"])
     def headers():
         values = dict(request.headers)

--- a/test/cli/output/test_default.py
+++ b/test/cli/output/test_default.py
@@ -321,7 +321,8 @@ def test_display_failures(swagger_20, capsys, execution_context, results_set, ve
     assert " GET: /v1/api/failure " in out
     assert "Message" in out
     assert "Run this Python code to reproduce this failure: " in out
-    assert f"requests.get('http://127.0.0.1:8080/api/failure', headers={{'User-Agent': '{USER_AGENT}'}})" in out
+    headers = f"{{'User-Agent': '{USER_AGENT}', 'Content-Type': 'application/json', 'Content-Length': '0'}}"
+    assert f"requests.get('http://127.0.0.1:8080/api/failure', headers={headers})" in out
 
 
 @pytest.mark.parametrize("show_errors_tracebacks", (True, False))


### PR DESCRIPTION
Resolves #792