### PR TITLE
fix: Output types for evaluation results of `$response.body` and `$request.body` runtime expressions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 **Fixed**
 
 - Missing ``body`` parameters during Open API links processing in CLI. `#1069`_
+- Output types for evaluation results of ``$response.body`` and ``$request.body`` runtime expressions. `#1068`_
 
 `3.4.1`_ - 2021-03-21
 ---------------------
@@ -1709,6 +1710,7 @@ Deprecated
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
 .. _#1069: https://github.com/schemathesis/schemathesis/issues/1069
+.. _#1068: https://github.com/schemathesis/schemathesis/issues/1068
 .. _#1059: https://github.com/schemathesis/schemathesis/issues/1059
 .. _#1050: https://github.com/schemathesis/schemathesis/issues/1050
 .. _#1046: https://github.com/schemathesis/schemathesis/issues/1046

--- a/test/specs/openapi/test_expressions.py
+++ b/test/specs/openapi/test_expressions.py
@@ -60,14 +60,14 @@ def context(case, response):
         ("spam_{$request.path.user_id}", "spam_5"),
         ("spam_{$request.header.X-Token}", "spam_secret"),
         ("spam_{$request.header.x-token}", "spam_secret"),
-        ("$request.body", '{"a": 1}'),
+        ("$request.body", {"a": 1}),
         ("$request.body#/a", 1),
         ("spam_{$response.header.X-Response}", "spam_Y"),
         ("spam_{$response.header.x-response}", "spam_Y"),
         ("$response.body#/foo/0", "bar"),
         ("$response.body#/g|h", 4),
         (42, 42),
-        ("$response.body", json.dumps(DOCUMENT)),
+        ("$response.body", DOCUMENT),
         ("ID_{$response.body#/g|h}", "ID_4"),
         ("ID_{$response.body#/g|h}_{$response.body#/a~1b}", "ID_4_1"),
     ),
@@ -105,13 +105,6 @@ def test_random_expression(expr):
         expressions.evaluate(expr, context)
     except RuntimeExpressionError:
         pass
-
-
-def test_non_json_serializable_body(operation, response):
-    case = Case(operation, body={"a": b"content"})
-    context = expressions.ExpressionContext(response=response, case=case)
-    with pytest.raises(RuntimeExpressionError, match="^The request body is not JSON-serializable$"):
-        expressions.evaluate("$request.body", context=context)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1068