### PR TITLE
use functioning fixup name in example: fast_api instead of fastapi

### DIFF
--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -23,6 +23,6 @@ To use it, you need to add this code before you load your schema with Schemathes
     # will install all available compatibility fixups.
     schemathesis.fixups.install()
     # You can provide a list of fixup names as the first argument
-    # schemathesis.fixups.install(["fastapi"])
+    # schemathesis.fixups.install(["fast_api"])
 
 If you use the Command Line Interface, then you can utilize the ``--fixups=all`` option.


### PR DESCRIPTION
https://github.com/schemathesis/schemathesis/blob/master/src/schemathesis/fixups/__init__.py#L5 uses `fast_api` and not `fastapi`.

### Description
The commented out example used "fastapi", but using that raised a KeyError in fixups/__init__.py. 

The fixup module is named "fast_api", as is the key in ALL_FIXUPS, so it seemed more acceptable to adapt the documentation to the code.

### Checklist
- [-] Created tests which fail without the change (if possible)
- [?] All tests passing (did not check)
- [-] Added a changelog entry
- [+] Extended the README / documentation, if necessary
