### PR TITLE
docs: use functioning fixup name in example

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ Changelog
 
 - Add the missing ``@schema.given`` implementation for schemas created via the ``from_pytest_fixture`` loader. `#1093`_
 - Silently ignoring some incorrect usages of ``@schema.given``.
+- Fixups examples were using incorrect fixup name.
 
 `3.5.3`_ - 2021-03-27
 ---------------------

--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -23,6 +23,6 @@ To use it, you need to add this code before you load your schema with Schemathes
     # will install all available compatibility fixups.
     schemathesis.fixups.install()
     # You can provide a list of fixup names as the first argument
-    # schemathesis.fixups.install(["fastapi"])
+    # schemathesis.fixups.install(["fast_api"])
 
 If you use the Command Line Interface, then you can utilize the ``--fixups=all`` option.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -107,7 +107,7 @@ Schemathesis is more strict in schema handling by default, but we provide option
     # will install all available compatibility fixups.
     schemathesis.fixups.install()
     # You can also provide a list of fixup names as the first argument
-    # schemathesis.fixups.install(["fastapi"])
+    # schemathesis.fixups.install(["fast_api"])
 
 For more information, take a look into the "Compatibility" section.
 


### PR DESCRIPTION
### Description
Replace "fastapi" with "fast_api", since that is the name of the fixup module.

### Checklist
- [-] Created tests which fail without the change (if possible)
- [/] All tests passing, pylint and mypy fail; pytest and commitsar pass
- [+] Added a changelog entry
- [+] Extended the README / documentation, if necessary
