### PR TITLE
fix: Using parametrized `pytest` fixtures with the `from_pytest_fixture` loader

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Using parametrized ``pytest`` fixtures with the ``from_pytest_fixture`` loader. `#1121`_
+
 `3.6.0`_ - 2021-04-04
 ---------------------
 
@@ -1811,6 +1815,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1121: https://github.com/schemathesis/schemathesis/issues/1121
 .. _#1100: https://github.com/schemathesis/schemathesis/issues/1100
 .. _#1097: https://github.com/schemathesis/schemathesis/issues/1097
 .. _#1093: https://github.com/schemathesis/schemathesis/issues/1093

--- a/src/schemathesis/lazy.py
+++ b/src/schemathesis/lazy.py
@@ -2,6 +2,7 @@ from inspect import signature
 from typing import Any, Callable, Dict, Iterable, Optional, Union
 
 import attr
+import pytest
 from _pytest.fixtures import FixtureRequest
 from pytest_subtests import SubTests, nullcontext
 
@@ -120,6 +121,8 @@ class LazySchema:
                     else:
                         _schema_error(subtests, result.err(), node_id, data_generation_method)
                 subtests.item._nodeid = node_id
+
+            test = pytest.mark.usefixtures(self.fixture_name)(test)
 
             # Needed to prevent a failure when settings are applied to the test function
             test.is_hypothesis_test = True  # type: ignore


### PR DESCRIPTION
Fixes #1121