### PR TITLE
fix: `UnicodeEncodeError` when sending `application/octet-stream` payloads that have no `format: binary` in their schemas

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 **Fixed**
 
 - Bump minimum ``hypothesis-graphql`` version to ``0.4.1``. It fixes `a problem <https://github.com/Stranger6667/hypothesis-graphql/issues/30>`_ with generating queries with surrogate characters.
+- ``UnicodeEncodeError`` when sending ``application/octet-stream`` payloads that have no ``format: binary`` in their schemas. `#1134`_
 
 `3.6.2`_ - 2021-04-15
 ---------------------
@@ -1832,6 +1833,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1134: https://github.com/schemathesis/schemathesis/issues/1134
 .. _#1121: https://github.com/schemathesis/schemathesis/issues/1121
 .. _#1100: https://github.com/schemathesis/schemathesis/issues/1100
 .. _#1097: https://github.com/schemathesis/schemathesis/issues/1097

--- a/src/schemathesis/serializers.py
+++ b/src/schemathesis/serializers.py
@@ -147,6 +147,8 @@ def _prepare_form_data(data: Dict[str, Any]) -> Dict[str, Any]:
 
 def _to_bytes(value: Any) -> bytes:
     """Convert the input value to bytes and ignore any conversion errors."""
+    if isinstance(value, bytes):
+        return value
     return str(value).encode(errors="ignore")
 
 
@@ -188,10 +190,10 @@ class TextSerializer:
 @register("application/octet-stream")
 class OctetStreamSerializer:
     def as_requests(self, context: SerializerContext, value: Any) -> Dict[str, Any]:
-        return {"data": value}
+        return {"data": _to_bytes(value)}
 
     def as_werkzeug(self, context: SerializerContext, value: Any) -> Dict[str, Any]:
-        return {"data": value}
+        return {"data": _to_bytes(value)}
 
 
 def get(media_type: str) -> Optional[Type[Serializer]]:


### PR DESCRIPTION
Fixes #1134