### PR TITLE
feat: Support for disabling ANSI color escape codes via the `NO_COLOR` environment variable or the `--no-color` CLI option

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Added**
+
+- Support for disabling ANSI color escape codes via the `NO_COLOR <https://no-color.org/>` environment variable or the ``--no-color`` CLI option. `#1153`_
+
 **Changed**
 
 - Generate valid header values for Bearer auth by construction rather than by filtering.
@@ -1849,6 +1853,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1153: https://github.com/schemathesis/schemathesis/issues/1153
 .. _#1134: https://github.com/schemathesis/schemathesis/issues/1134
 .. _#1121: https://github.com/schemathesis/schemathesis/issues/1121
 .. _#1100: https://github.com/schemathesis/schemathesis/issues/1100

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -46,6 +46,8 @@ loaded API schema, processed operations, found errors, and used checks.
 
 By default, Schemathesis refuses to work with schemas that do not conform to the Open API spec, but you can disable this behavior with ``--validate-schema=false``.
 
+.. note:: Schemathesis supports colorless output via the `NO_COLOR <https://no-color.org/>` environment variable or the ``--no-color`` CLI option.
+
 Testing specific operations
 ---------------------------
 

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -277,6 +277,7 @@ def test_commands_run_help(cli):
         "  --force-schema-version [20|30]  Force Schemathesis to parse the input schema",
         "                                  with the specified spec version.",
         "",
+        "  --no-color                      Disable ANSI color escape codes.",
         "  -v, --verbosity                 Reduce verbosity of error output.",
         "  -h, --help                      Show this message and exit.",
     ]
@@ -1910,3 +1911,17 @@ def test_response_payload_encoding(cli, cli_args):
     assert result.exit_code == ExitCode.TESTS_FAILED, result.stdout
     # Then it should be displayed according its actual encoding
     assert "Response payload: `Тест`" in result.stdout.splitlines()
+
+
+@pytest.mark.parametrize("kind", ("env_var", "arg"))
+@pytest.mark.parametrize("openapi_version", (OpenAPIVersion("3.0"),))
+@pytest.mark.operations("success")
+def test_no_color(monkeypatch, cli, schema_url, kind):
+    args = (schema_url,)
+    if kind == "env_var":
+        monkeypatch.setenv("NO_COLOR", "1")
+    if kind == "arg":
+        args += ("--no-color",)
+    result = cli.run(*args, color=True)
+    assert result.exit_code == ExitCode.OK, result.stdout
+    assert "[1m" not in result.stdout


### PR DESCRIPTION
Resolves #1153