### PR TITLE
chore: Use different exception classes for `not_a_server_error` and `status_code_conformance` checks.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Changed**
+
+- Use different exception classes for ``not_a_server_error`` and ``status_code_conformance`` checks. It improves the variance of found errors.
+
 `3.6.11`_ - 2021-05-20
 ----------------------
 

--- a/src/schemathesis/checks.py
+++ b/src/schemathesis/checks.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Optional, Tuple
 
-from .exceptions import get_status_code_error
+from .exceptions import get_server_error
 from .specs.openapi.checks import (
     content_type_conformance,
     response_headers_conformance,
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 def not_a_server_error(response: GenericResponse, case: "Case") -> Optional[bool]:  # pylint: disable=useless-return
     """A check to verify that the response is not a server-side error."""
     if response.status_code >= 500:
-        exc_class = get_status_code_error(response.status_code)
+        exc_class = get_server_error(response.status_code)
         raise exc_class(f"Received a response with 5xx status code: {response.status_code}")
     return None
 

--- a/src/schemathesis/exceptions.py
+++ b/src/schemathesis/exceptions.py
@@ -47,6 +47,12 @@ def get_grouped_exception(prefix: str, *exceptions: AssertionError) -> Type[Chec
     return _get_hashed_exception("GroupedException", f"{prefix}{message}")
 
 
+def get_server_error(status_code: int) -> Type[CheckFailed]:
+    """Return new exception for the Internal Server Error cases."""
+    name = f"ServerError{status_code}"
+    return get_exception(name)
+
+
 def get_status_code_error(status_code: int) -> Type[CheckFailed]:
     """Return new exception for an unexpected status code."""
     name = f"StatusCodeError{status_code}"


### PR DESCRIPTION
It improves the variance of found errors.