### PR TITLE
perf: Reduce the amount of filtering needed to generate valid headers and cookies

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,10 @@ Changelog
 
 - Invalid multipart payload generated for unusual schemas for the ``multipart/form-data`` media type.
 
+**Performance**
+
+- Reduce the amount of filtering needed to generate valid headers and cookies.
+
 `3.7.2`_ - 2021-05-27
 ---------------------
 

--- a/src/schemathesis/specs/openapi/utils.py
+++ b/src/schemathesis/specs/openapi/utils.py
@@ -1,9 +1,23 @@
 import string
 from itertools import product
-from typing import Generator, Union
+from typing import Any, Dict, Generator, Union
 
 
 def expand_status_code(status_code: Union[str, int]) -> Generator[int, None, None]:
     chars = [list(string.digits) if digit == "X" else [digit] for digit in str(status_code).upper()]
     for expanded in product(*chars):
         yield int("".join(expanded))
+
+
+def set_keyword_on_properties(schema: Dict[str, Any], keyword: str, value: Any) -> None:
+    """Set JSON Schema keyword on all properties in the schema.
+
+    Useful if all properties should have the same keyword. No-op if this keyword is already set.
+    """
+    for sub_schema in schema.get("properties", {}).values():
+        sub_schema.setdefault(keyword, value)
+
+
+def is_header_location(location: str) -> bool:
+    """Whether this location affects HTTP headers."""
+    return location in ("header", "cookie")

--- a/test/specs/openapi/test_hypothesis.py
+++ b/test/specs/openapi/test_hypothesis.py
@@ -1,8 +1,10 @@
+import sys
+
 import pytest
 from hypothesis import assume, given, settings
 
 import schemathesis
-from schemathesis.specs.openapi._hypothesis import get_case_strategy
+from schemathesis.specs.openapi._hypothesis import get_case_strategy, is_valid_header, make_positive_strategy
 
 
 @pytest.fixture
@@ -116,5 +118,27 @@ def test_inlined_definitions(deeply_nested_schema):
     def test(case):
         # Then the referenced schema should be properly transformed to the JSON Schema form
         assume(case.query["key"] is None)
+
+    test()
+
+
+@pytest.mark.hypothesis_nested
+def test_always_valid_headers():
+    # When headers are generated
+    # And there is no custom "format"
+    strategy = make_positive_strategy(
+        {
+            "type": "object",
+            "properties": {"X-Foo": {"type": "string"}},
+            "required": ["X-Foo"],
+            "additionalProperties": False,
+        },
+        "header",
+    )
+
+    @given(strategy)
+    def test(headers):
+        # Then headers are always valid
+        assert is_valid_header(headers)
 
     test()


### PR DESCRIPTION
It slightly improves the data generation performance - around 15% on the built-in `/headers/` API operation, and ~5% when running schemathesis against all operations in the built-in test server.