### PR TITLE
fix: Disable filtering optimization for headers when there are keywords other than `type`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Disable filtering optimization for headers when there are keywords other than ``type``. `#1189`_
+
 `3.7.5`_ - 2021-05-31
 ---------------------
 

--- a/src/schemathesis/specs/openapi/_hypothesis.py
+++ b/src/schemathesis/specs/openapi/_hypothesis.py
@@ -286,7 +286,7 @@ def make_positive_strategy(schema: Dict[str, Any], location: str) -> st.SearchSt
         # We try to enforce the right header values via "format"
         # This way, only allowed values will be used during data generation, which reduces the amount of filtering later
         # If a property schema contains `pattern` it leads to heavy filtering and worse performance - therefore, skip it
-        set_keyword_on_properties(schema, "format", "_header_value", lambda s: "pattern" not in s)
+        set_keyword_on_properties(schema, "format", "_header_value", lambda s: len(s) == 1 and "type" in s)
     return from_schema(schema, custom_formats=STRING_FORMATS)
 
 

--- a/test/specs/openapi/test_hypothesis.py
+++ b/test/specs/openapi/test_hypothesis.py
@@ -124,9 +124,9 @@ def test_inlined_definitions(deeply_nested_schema):
 
 @pytest.mark.parametrize("keywords", ({}, {"pattern": r"\A[A-F0-9]{12}\Z"}))
 @pytest.mark.hypothesis_nested
-def test_always_valid_headers(keywords):
+def test_valid_headers(keywords):
     # When headers are generated
-    # And there is no custom "format"
+    # And there is no other keywords than "type"
     strategy = make_positive_strategy(
         {
             "type": "object",
@@ -141,5 +141,27 @@ def test_always_valid_headers(keywords):
     def test(headers):
         # Then headers are always valid
         assert is_valid_header(headers)
+
+    test()
+
+
+@pytest.mark.hypothesis_nested
+def test_no_much_filtering_in_headers():
+    # When headers are generated
+    # And there are keywords other than "type"
+    strategy = make_positive_strategy(
+        {
+            "type": "object",
+            "properties": {"X-Foo": {"type": "string", "minLength": 12, "maxLength": 12}},
+            "required": ["X-Foo"],
+            "additionalProperties": False,
+        },
+        "header",
+    )
+
+    @given(strategy)
+    def test(_):
+        # Then there should be no failed health checks
+        pass
 
     test()


### PR DESCRIPTION
In the first PR I missed that filtering still a problem when other keywords are present in headers' schemas

Ref: #1189

