### PR TITLE
chore: Raise `UsageError` if `schema.parametrize` or `schema.given` are applied to the same function more than once

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,10 @@ Changelog
 
 - Negative testing. `#65`_
 
+**Changed**
+
+- Raise ``UsageError` if ``schema.parametrize`` or ``schema.given`` are applied to the same function more than once. `#1194`_
+
 `3.7.8`_ - 2021-06-02
 ---------------------
 
@@ -2006,6 +2010,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1194: https://github.com/schemathesis/schemathesis/issues/1194
 .. _#1190: https://github.com/schemathesis/schemathesis/issues/1190
 .. _#1189: https://github.com/schemathesis/schemathesis/issues/1189
 .. _#1167: https://github.com/schemathesis/schemathesis/issues/1167

--- a/src/schemathesis/exceptions.py
+++ b/src/schemathesis/exceptions.py
@@ -1,6 +1,6 @@
 from hashlib import sha1
 from json import JSONDecodeError
-from typing import Any, Callable, Dict, NoReturn, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, NoReturn, Optional, Type, Union
 
 import attr
 import hypothesis.errors
@@ -9,7 +9,9 @@ from jsonschema import ValidationError
 
 from .constants import SERIALIZERS_SUGGESTION_MESSAGE
 from .failures import FailureContext
-from .utils import GenericResponse
+
+if TYPE_CHECKING:
+    from .utils import GenericResponse
 
 
 class CheckFailed(AssertionError):
@@ -179,7 +181,7 @@ class InvalidRegularExpression(Exception):
 
 @attr.s  # pragma: no mutate
 class HTTPError(Exception):
-    response: GenericResponse = attr.ib()  # pragma: no mutate
+    response: "GenericResponse" = attr.ib()  # pragma: no mutate
     url: str = attr.ib()  # pragma: no mutate
 
     @classmethod
@@ -195,3 +197,7 @@ class HTTPError(Exception):
         # E.g. it will be handled in CLI - a proper error message will be shown
         if 400 <= response.status_code < 600:
             raise cls(response=response, url=schema_path)
+
+
+class UsageError(Exception):
+    """Incorrect usage of Schemathesis functions."""

--- a/src/schemathesis/extra/pytest_plugin.py
+++ b/src/schemathesis/extra/pytest_plugin.py
@@ -17,6 +17,7 @@ from ..constants import RECURSIVE_REFERENCE_ERROR_MESSAGE
 from ..exceptions import InvalidSchema
 from ..models import APIOperation
 from ..utils import (
+    PARAMETRIZE_MARKER,
     Ok,
     Result,
     get_given_args,
@@ -81,7 +82,7 @@ class SchemathesisCase(PyCollector):
                 _init_with_valid_test(test_function, given_args, given_kwargs)
         else:
             _init_with_valid_test(test_function, given_args, given_kwargs)
-        self.schemathesis_case = test_function._schemathesis_test  # type: ignore
+        self.schemathesis_case = getattr(test_function, PARAMETRIZE_MARKER)
         super().__init__(*args, **kwargs)
 
     def _get_test_name(self, operation: APIOperation, data_generation_method: DataGenerationMethod) -> str:

--- a/test/hooks/test_hooks.py
+++ b/test/hooks/test_hooks.py
@@ -3,6 +3,7 @@ from hypothesis import HealthCheck, given, settings
 
 import schemathesis
 from schemathesis.hooks import HookContext, HookDispatcher, HookScope
+from schemathesis.utils import PARAMETRIZE_MARKER
 
 
 @pytest.fixture(autouse=True)
@@ -224,7 +225,7 @@ def test_save_test_function(schema):
     def test(case):
         pass
 
-    assert test._schemathesis_test.test_function is test
+    assert getattr(test, PARAMETRIZE_MARKER).test_function is test
 
 
 @pytest.mark.parametrize("apply_first", (True, False))
@@ -259,8 +260,8 @@ def test_local_dispatcher(schema, apply_first):
     assert test._schemathesis_hooks.get_all_by_name("before_generate_cookies") == [local_hook]
     assert test._schemathesis_hooks.get_all_by_name("before_generate_query") == []
     # And the schema-level dispatcher still contains only schema-level hooks
-    assert test._schemathesis_test.hooks.get_all_by_name("before_generate_query") == [schema_hook]
-    assert test._schemathesis_test.hooks.get_all_by_name("before_generate_cookies") == []
+    assert getattr(test, PARAMETRIZE_MARKER).hooks.get_all_by_name("before_generate_query") == [schema_hook]
+    assert getattr(test, PARAMETRIZE_MARKER).hooks.get_all_by_name("before_generate_cookies") == []
 
 
 @pytest.mark.hypothesis_nested

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -178,8 +178,8 @@ def teardown_module(module):
     result.assert_outcomes(passed=2)
 
 
-def test_invalid_given_usage(testdir):
-    # When `schema.given` is used incorrectly (e.g. called without arguments)
+def test_given_no_arguments(testdir):
+    # When `schema.given` is used without arguments
     testdir.make_test(
         """
 @schema.parametrize()
@@ -192,6 +192,39 @@ def test(case):
     result = testdir.runpytest()
     result.assert_outcomes(failed=1)
     result.stdout.re_match_lines([".+given must be called with at least one argument"])
+
+
+def test_given_no_override(testdir):
+    # When `schema.given` is used multiple times on the same test
+    testdir.make_test(
+        """
+@schema.parametrize()
+@schema.given(st.booleans())
+@schema.given(st.booleans())
+def test(case):
+    pass
+        """,
+    )
+    # Then the wrapped test should fail with an error
+    result = testdir.runpytest()
+    result.assert_outcomes(failed=1)
+    result.stdout.re_match_lines([".+You have applied `given` to the `test` test more than"])
+
+
+def test_parametrize_no_override(testdir):
+    # When `schema.parametrize` is used multiple times on the same test
+    testdir.make_test(
+        """
+@schema.parametrize()
+@schema.parametrize()
+def test(case):
+    pass
+        """,
+    )
+    # Then the wrapped test should fail with an error
+    result = testdir.runpytest()
+    result.assert_outcomes(failed=1)
+    result.stdout.re_match_lines([".+You have applied `parametrize` to the `test` test more than"])
 
 
 def test_invalid_test(testdir):


### PR DESCRIPTION
Resolves #1194