### PR TITLE
chore: Python values of `True`, `False` and `None` are converted to their JSON equivalents when generated for path parameters or query

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Changelog
 **Changed**
 
 - Raise ``UsageError` if ``schema.parametrize`` or ``schema.given`` are applied to the same function more than once. `#1194`_
+- Python values of ``True``, ``False`` and ``None`` are converted to their JSON equivalents when generated for path parameters or query. `#1166`_
 
 `3.7.8`_ - 2021-06-02
 ---------------------
@@ -2015,6 +2016,7 @@ Deprecated
 .. _#1190: https://github.com/schemathesis/schemathesis/issues/1190
 .. _#1189: https://github.com/schemathesis/schemathesis/issues/1189
 .. _#1167: https://github.com/schemathesis/schemathesis/issues/1167
+.. _#1166: https://github.com/schemathesis/schemathesis/issues/1166
 .. _#1164: https://github.com/schemathesis/schemathesis/issues/1164
 .. _#1162: https://github.com/schemathesis/schemathesis/issues/1162
 .. _#1160: https://github.com/schemathesis/schemathesis/issues/1160

--- a/src/schemathesis/specs/openapi/serialization.py
+++ b/src/schemathesis/specs/openapi/serialization.py
@@ -1,20 +1,12 @@
-import functools
 import json
 from typing import Any, Callable, Dict, Generator, List, Optional
+
+from ...utils import compose
 
 Generated = Dict[str, Any]
 Definition = Dict[str, Any]
 DefinitionList = List[Definition]
 MapFunction = Callable[[Generated], Generated]
-
-
-def compose(*functions: Callable) -> Callable:
-    """Compose multiple functions into a single one."""
-
-    def noop(x: Any) -> Any:
-        return x
-
-    return functools.reduce(lambda f, g: lambda x: f(g(x)), functions, noop)
 
 
 def make_serializer(

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -1,4 +1,5 @@
 import cgi
+import functools
 import pathlib
 import re
 import sys
@@ -405,3 +406,12 @@ def merge_given_args(func: GenericTest, args: Tuple, kwargs: Dict[str, Any]) -> 
 def validate_given_args(func: GenericTest, args: Tuple, kwargs: Dict[str, Any]) -> Optional[Callable]:
     argspec = getfullargspec(func)
     return is_invalid_test(func.__name__, argspec, args, kwargs)  # type: ignore
+
+
+def compose(*functions: Callable) -> Callable:
+    """Compose multiple functions into a single one."""
+
+    def noop(x: Any) -> Any:
+        return x
+
+    return functools.reduce(lambda f, g: lambda x: f(g(x)), functions, noop)

--- a/test/specs/openapi/test_hypothesis.py
+++ b/test/specs/openapi/test_hypothesis.py
@@ -117,7 +117,7 @@ def test_inlined_definitions(deeply_nested_schema):
     @settings(max_examples=1)
     def test(case):
         # Then the referenced schema should be properly transformed to the JSON Schema form
-        assume(case.query["key"] is None)
+        assume(case.query["key"] == "null")
 
     test()
 

--- a/test/test_dereferencing.py
+++ b/test/test_dereferencing.py
@@ -352,11 +352,10 @@ def test_nullable_parameters(request, testdir, spec_version, extra):
 @schema.parametrize()
 @settings(max_examples=1)
 def test_(request, case):
-    assume(case.query["id"] is None)
+    assume(case.query["id"] == "null")
     request.config.HYPOTHESIS_CASES += 1
     assert case.path == "/users"
     assert case.method == "GET"
-    assert case.query["id"] is None
 """,
         schema=schema,
     )
@@ -477,7 +476,7 @@ def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
     assert case.path == "/users"
     assert case.method == "GET"
-    assert case.query["id"] is None
+    assert case.query["id"] == "null"
 """,
         **as_param(integer(name="id", required=True, enum=[1, 2], **{"x-nullable": True})),
     )


### PR DESCRIPTION
Fixes  #1166