### PR TITLE
feat: A way to stop the Schemathesis runner's event stream manually via `events.stop()`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 **Added**
 
 - GraphQL support in CLI. `#746`_
+- A way to stop the Schemathesis runner's event stream manually via ``events.stop()``. `#1202`_
 
 **Changed**
 
@@ -2031,6 +2032,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1202: https://github.com/schemathesis/schemathesis/issues/1202
 .. _#1194: https://github.com/schemathesis/schemathesis/issues/1194
 .. _#1190: https://github.com/schemathesis/schemathesis/issues/1190
 .. _#1189: https://github.com/schemathesis/schemathesis/issues/1189

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -846,3 +846,26 @@ def test_graphql(graphql_url):
     )
     assert initialized.operations_count == 2
     assert finished.passed_count == 2
+
+
+@pytest.fixture
+def runner(swagger_20):
+    return from_schema(swagger_20)
+
+
+@pytest.fixture
+def event_stream(runner):
+    return runner.execute()
+
+
+def test_stop_event_stream(event_stream):
+    assert isinstance(next(event_stream), events.Initialized)
+    event_stream.stop()
+    assert isinstance(next(event_stream), events.Finished)
+
+
+def test_stop_event_stream_after_second_event(event_stream):
+    next(event_stream)
+    assert isinstance(next(event_stream), events.BeforeExecution)
+    event_stream.stop()
+    assert isinstance(next(event_stream), events.Finished)


### PR DESCRIPTION
Resolves #1202