### PR TITLE
fix: Incorrect deduplication applied to response schema conformance failures that happen to have the same failing validator but different input values

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,10 @@ Changelog
 
 - Return ``response`` from ``Case.call_and_validate``.
 
+**Fixed**
+
+- Incorrect deduplication applied to response schema conformance failures that happen to have the same failing validator but different input values. `#907`_
+
 `3.9.1`_ - 2021-06-13
 ---------------------
 
@@ -2111,6 +2115,7 @@ Deprecated
 .. _#914: https://github.com/schemathesis/schemathesis/issues/914
 .. _#911: https://github.com/schemathesis/schemathesis/issues/911
 .. _#908: https://github.com/schemathesis/schemathesis/issues/908
+.. _#907: https://github.com/schemathesis/schemathesis/issues/907
 .. _#905: https://github.com/schemathesis/schemathesis/issues/905
 .. _#904: https://github.com/schemathesis/schemathesis/issues/904
 .. _#897: https://github.com/schemathesis/schemathesis/issues/897

--- a/test/apps/openapi/_aiohttp/handlers.py
+++ b/test/apps/openapi/_aiohttp/handlers.py
@@ -26,6 +26,11 @@ async def success(request: web.Request) -> web.Response:
     return web.json_response({"success": True})
 
 
+async def conformance(request: web.Request) -> web.Response:
+    # The schema expects `value` to be "foo", but it is different every time
+    return web.json_response({"value": uuid4().hex})
+
+
 async def basic(request: web.Request) -> web.Response:
     if "Authorization" in request.headers and request.headers["Authorization"] == "Basic dGVzdDp0ZXN0":
         return web.json_response({"secret": 42})

--- a/test/apps/openapi/_flask/__init__.py
+++ b/test/apps/openapi/_flask/__init__.py
@@ -94,6 +94,11 @@ def create_app(
         values = dict(request.headers)
         return Response(json.dumps(values), content_type="application/json", headers=values)
 
+    @app.route("/api/conformance", methods=["GET"])
+    def conformance():
+        # The schema expects `value` to be "foo", but it is different every time
+        return jsonify({"value": uuid4().hex})
+
     @app.route("/api/failure", methods=["GET"])
     def failure():
         raise InternalServerError

--- a/test/apps/openapi/schema.py
+++ b/test/apps/openapi/schema.py
@@ -27,6 +27,7 @@ class Operation(Enum):
     teapot = ("POST", "/api/teapot")
     text = ("GET", "/api/text")
     cp866 = ("GET", "/api/cp866")
+    conformance = ("GET", "/api/conformance")
     plain_text_body = ("POST", "/api/text")
     csv_payload = ("POST", "/api/csv")
     malformed_json = ("GET", "/api/malformed_json")
@@ -245,6 +246,20 @@ def _make_openapi_2_schema(operations: Tuple[str, ...]) -> Dict:
                         "schema": {"type": "object", "properties": {"secret": {"type": "integer"}}},
                     },
                     # 401 is not described on purpose to cause a testing error
+                },
+            }
+        elif name == "conformance":
+            schema = {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {"value": {"enum": ["foo"]}},
+                            "required": ["value"],
+                            "additionalProperties": False,
+                        },
+                    },
                 },
             }
         elif name == "create_user":
@@ -573,6 +588,24 @@ def _make_openapi_3_schema(operations: Tuple[str, ...]) -> Dict:
                         },
                     },
                     # 401 is not described on purpose to cause a testing error
+                },
+            }
+        elif name == "conformance":
+            schema = {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {"value": {"enum": ["foo"]}},
+                                    "required": ["value"],
+                                    "additionalProperties": False,
+                                }
+                            }
+                        },
+                    },
                 },
             }
         elif name == "create_user":

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -1917,6 +1917,17 @@ def test_response_payload_encoding(cli, cli_args):
     assert "Response payload: `Тест`" in result.stdout.splitlines()
 
 
+@pytest.mark.operations("conformance")
+def test_response_schema_conformance_deduplication(cli, cli_args):
+    # See GH-907
+    # When the "response_schema_conformance" check is present
+    # And the app return different error messages caused by the same validator
+    result = cli.run(*cli_args, "--checks=response_schema_conformance")
+    assert result.exit_code == ExitCode.TESTS_FAILED, result.stdout
+    # Then the errors should be deduplicated
+    assert result.stdout.count("Response payload: ") == 1
+
+
 @pytest.mark.parametrize("kind", ("env_var", "arg"))
 @pytest.mark.parametrize("openapi_version", (OpenAPIVersion("3.0"),))
 @pytest.mark.operations("success")


### PR DESCRIPTION
Fixes #907