### PR TITLE
fix: `KeyError` when the `response_schema_conformance` check is executed against responses without schema definition

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- ``KeyError`` when the ``response_schema_conformance`` check is executed against responses without schema definition. `#1220`_
+
 `3.9.3`_ - 2021-06-22
 ---------------------
 
@@ -2071,6 +2075,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1220: https://github.com/schemathesis/schemathesis/issues/1220
 .. _#1202: https://github.com/schemathesis/schemathesis/issues/1202
 .. _#1194: https://github.com/schemathesis/schemathesis/issues/1194
 .. _#1190: https://github.com/schemathesis/schemathesis/issues/1190

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -629,7 +629,8 @@ class OpenApi30(SwaggerV20):  # pylint: disable=too-many-ancestors
         scopes, definition = self.resolver.resolve_in_scope(deepcopy(definition), scope)
         options = iter(definition.get("content", {}).values())
         option = next(options, None)
-        if option:
+        # "schema" is an optional key in the `MediaType` object
+        if option and "schema" in option:
             # Extra conversion to JSON Schema is needed here if there was one $ref in the input
             # because it is not converted
             return scopes, to_json_schema_recursive(option["schema"], self.nullable_name)

--- a/test/runner/test_checks.py
+++ b/test/runner/test_checks.py
@@ -453,6 +453,24 @@ def test_response_schema_conformance_invalid_openapi(openapi_30, media_type, con
     assert not case.operation.is_response_valid(response)
 
 
+def test_no_schema(openapi_30):
+    # See GH-1220
+    # When the response definition has no "schema" key
+    response = make_response(b"{}", "application/json")
+    definition = {
+        "responses": {
+            "default": {
+                "description": "text",
+                "content": {"application/problem": {"examples": {"test": {}}}},
+            }
+        }
+    }
+    case = make_case(openapi_30, definition)
+    # Then the check should be ignored
+    response_schema_conformance(response, case)
+    assert case.operation.is_response_valid(response)
+
+
 @pytest.mark.hypothesis_nested
 def test_response_schema_conformance_references_invalid(complex_schema):
     schema = schemathesis.from_path(complex_schema)


### PR DESCRIPTION
Fixes #1220