### PR TITLE
chore: Check non-string response statuses when Open API links are collected

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Changed**
+
+- Check non-string response status codes when Open API links are collected. `#1226`_
+
 `3.9.6`_ - 2021-07-15
 ---------------------
 
@@ -2096,6 +2100,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1226: https://github.com/schemathesis/schemathesis/issues/1226
 .. _#1224: https://github.com/schemathesis/schemathesis/issues/1224
 .. _#1220: https://github.com/schemathesis/schemathesis/issues/1220
 .. _#1208: https://github.com/schemathesis/schemathesis/issues/1208

--- a/src/schemathesis/specs/openapi/links.py
+++ b/src/schemathesis/specs/openapi/links.py
@@ -152,6 +152,8 @@ def get_links(response: GenericResponse, operation: APIOperation, field: str) ->
     responses = operation.definition.resolved["responses"]
     if str(response.status_code) in responses:
         response_definition = responses[str(response.status_code)]
+    elif response.status_code in responses:
+        response_definition = responses[response.status_code]
     else:
         response_definition = responses.get("default", {})
     links = response_definition.get(field, {})


### PR DESCRIPTION
Resolves #1226