### PR TITLE
fix: Minor typo in help message for --header

### DIFF
--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -242,7 +242,7 @@ class GroupedOption(click.Option):
     "--header",
     "-H",
     "headers",
-    help=r"Custom header in a that will be used in all requests to the server. Example: Authorization: Bearer\ 123",
+    help=r"Custom header that will be used in all requests to the server. Example: Authorization: Bearer\ 123",
     multiple=True,
     type=str,
     callback=callbacks.validate_headers,

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -236,7 +236,7 @@ def test_commands_run_help(cli):
         "  -A, --auth-type [basic|digest]  The authentication mechanism to be used.",
         "                                  Defaults to 'basic'.  [default: basic]",
         "",
-        "  -H, --header TEXT               Custom header in a that will be used in all",
+        "  -H, --header TEXT               Custom header that will be used in all",
         "                                  requests to the server. Example:",
         r"                                  Authorization: Bearer\ 123",
         "",


### PR DESCRIPTION
### Description
The help message for --header was grammatically incorrect, updated it for clarity


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Added a changelog entry
- [ ] Extended the README / documentation, if necessary
