### PR TITLE
fix: Stop worker threads on failures with `exit_first` enabled

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ Changelog
 - Worker threads may not be immediately stopped on SIGINT. `#1066`_
 - Re-used referenced objects during inlining. Now they are independent.
 - Rewrite not resolved remote references to local ones. `#986`_
+- Stop worker threads on failures with ``exit_first`` enabled. `#1204`_
 
 `3.9.7`_ - 2021-07-26
 ---------------------
@@ -2131,6 +2132,7 @@ Deprecated
 .. _#1224: https://github.com/schemathesis/schemathesis/issues/1224
 .. _#1220: https://github.com/schemathesis/schemathesis/issues/1220
 .. _#1208: https://github.com/schemathesis/schemathesis/issues/1208
+.. _#1204: https://github.com/schemathesis/schemathesis/issues/1204
 .. _#1202: https://github.com/schemathesis/schemathesis/issues/1202
 .. _#1194: https://github.com/schemathesis/schemathesis/issues/1194
 .. _#1190: https://github.com/schemathesis/schemathesis/issues/1190

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -84,18 +84,21 @@ class BaseRunner:
             yield _finish()
             return
 
-        for event in self._execute(results):
+        for event in self._execute(results, stop_event):
             yield event
-            if stop_event.is_set() or (
-                self.exit_first
-                and isinstance(event, events.AfterExecution)
-                and event.status in (Status.error, Status.failure)
-            ):
-                break
 
         yield _finish()
 
-    def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
+    def _should_stop(self, event: events.ExecutionEvent) -> bool:
+        return (
+            self.exit_first
+            and isinstance(event, events.AfterExecution)
+            and event.status in (Status.error, Status.failure)
+        )
+
+    def _execute(
+        self, results: TestResultSet, stop_event: threading.Event
+    ) -> Generator[events.ExecutionEvent, None, None]:
         raise NotImplementedError
 
     def _run_tests(


### PR DESCRIPTION
Resolves #1204
