### PR TITLE
fix: Properly report all failures when custom checks are passed to `case.validate_response`

### DIFF
--- a/.rstcheck.cfg
+++ b/.rstcheck.cfg
@@ -1,2 +1,3 @@
 [rstcheck]
 ignore_directives=code,autofunction,autoclass
+ignore_messages=(Hyperlink target ".+" is not referenced\.$)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ Changelog
 - Re-used referenced objects during inlining. Now they are independent.
 - Rewrite not resolved remote references to local ones. `#986`_
 - Stop worker threads on failures with ``exit_first`` enabled. `#1204`_
+- Properly report all failures when custom checks are passed to ``case.validate_response``.
 
 **Performance**
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -462,7 +462,11 @@ response code is ``200``.
             # check not relevant to this response, skip test
             return True
 
-See more information about customization in the "Customization" page.
+Skipped check calls will not be reported in the run summary.
+
+.. note::
+
+    Learn more about writing custom checks :ref:`here <writing-custom-checks>`.
 
 Debugging
 ---------

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -345,6 +345,39 @@ If you want to modify what keyword arguments will be given to ``case.call`` / ``
 If you test your app via the real network, then the hook above will disable resolving redirects during network calls.
 For WSGI integration, the keywords are different. See the documentation for ``werkzeug.Client.open``.
 
+.. _writing-custom-checks:
+
+Checks
+------
+
+Schemathesis provides a way to check app responses via user-defined functions called "checks".
+Each check is a function that accepts two arguments:
+
+.. code-block:: python
+
+    def my_check(response, case):
+        ...
+
+The first one is the app response, which is ``requests.Response`` or ``schemathesis.utils.WSGIResponse``, depending on
+whether you used the WSGI integration or not. The second one is the :class:`~schemathesis.Case` instance that was used to
+send data to the tested application.
+
+To indicate a failure, you need to raise ``AssertionError`` explicitly:
+
+.. code-block:: python
+
+    def my_check(response, case):
+        if response.text == "I am a teapot":
+            raise AssertionError("It is a teapot!")
+
+If the assertion fails, you'll see the assertion message in Schemathesis output. In the case of missing
+assertion message, Schemathesis will report "Check `my_check` failed".
+
+.. note::
+
+    If you use the ``assert`` statement and ``pytest`` as the test runner, then ``pytest`` may rewrite assertions which
+    affects error messages.
+
 Custom string strategies
 ------------------------
 

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -299,6 +299,10 @@ The code above will run only the ``not_a_server_error`` check. Or a tuple of add
         response = case.call()
         case.validate_response(response, additional_checks=(my_check,))
 
+.. note::
+
+    Learn more about writing custom checks :ref:`here <writing-custom-checks>`.
+
 If you don't use Schemathesis for data generation, you can still utilize response validation:
 
 .. code-block:: python

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -56,7 +56,14 @@ from .hooks import GLOBAL_HOOK_DISPATCHER, HookContext, HookDispatcher
 from .parameters import Parameter, ParameterSet, PayloadAlternatives
 from .serializers import Serializer, SerializerContext
 from .types import Body, Cookies, FormData, Headers, NotSet, PathParameters, Query
-from .utils import NOT_SET, GenericResponse, WSGIResponse, deprecated_property, get_response_payload
+from .utils import (
+    NOT_SET,
+    GenericResponse,
+    WSGIResponse,
+    deprecated_property,
+    get_response_payload,
+    maybe_set_assertion_message,
+)
 
 if TYPE_CHECKING:
     from .schemas import BaseSchema
@@ -404,7 +411,8 @@ class Case:  # pylint: disable=too-many-public-methods
         for check in chain(checks, additional_checks):
             try:
                 check(response, self)
-            except CheckFailed as exc:
+            except AssertionError as exc:
+                maybe_set_assertion_message(exc, check.__name__)
                 errors.append(exc)
         if errors:
             exception_cls = get_grouped_exception(self.operation.verbose_name, *errors)

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -38,7 +38,14 @@ from ...schemas import BaseSchema
 from ...stateful import Feedback, Stateful
 from ...targets import Target, TargetContext
 from ...types import RawAuth
-from ...utils import GenericResponse, Ok, WSGIResponse, capture_hypothesis_output, format_exception
+from ...utils import (
+    GenericResponse,
+    Ok,
+    WSGIResponse,
+    capture_hypothesis_output,
+    format_exception,
+    maybe_set_assertion_message,
+)
 from ..serialization import SerializedTestResult
 
 
@@ -377,10 +384,7 @@ def run_checks(
                 check_result = result.add_success(check_name, case, response, elapsed_time)
                 check_results.append(check_result)
         except AssertionError as exc:
-            message = str(exc)
-            if not message:
-                message = f"Check '{check_name}' failed"
-                exc.args = (message,)
+            message = maybe_set_assertion_message(exc, check_name)
             errors.append(exc)
             if isinstance(exc, CheckFailed):
                 context = exc.context

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -415,3 +415,11 @@ def compose(*functions: Callable) -> Callable:
         return x
 
     return functools.reduce(lambda f, g: lambda x: f(g(x)), functions, noop)
+
+
+def maybe_set_assertion_message(exc: AssertionError, check_name: str) -> str:
+    message = str(exc)
+    if not message:
+        message = f"Check '{check_name}' failed"
+        exc.args = (message,)
+    return message


### PR DESCRIPTION
Also resolves #1244 