### PR TITLE
Filters on API operations

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,8 @@ Changelog
 **Added**
 
 - ``DataGenerationMethod.all`` shortcut to get all possible enum variants.
+- A flexible way to select API operations for testing. It is now possible to exclude or include them by arbitrary
+  predicates. `#703`_, `#819`_, `#1006`_
 
 **Fixed**
 
@@ -2204,6 +2206,7 @@ Deprecated
 .. _#1013: https://github.com/schemathesis/schemathesis/issues/1013
 .. _#1010: https://github.com/schemathesis/schemathesis/issues/1010
 .. _#1007: https://github.com/schemathesis/schemathesis/issues/1007
+.. _#1006: https://github.com/schemathesis/schemathesis/issues/1006
 .. _#1003: https://github.com/schemathesis/schemathesis/issues/1003
 .. _#999: https://github.com/schemathesis/schemathesis/issues/999
 .. _#994: https://github.com/schemathesis/schemathesis/issues/994
@@ -2259,6 +2262,7 @@ Deprecated
 .. _#830: https://github.com/schemathesis/schemathesis/issues/830
 .. _#824: https://github.com/schemathesis/schemathesis/issues/824
 .. _#822: https://github.com/schemathesis/schemathesis/issues/822
+.. _#819: https://github.com/schemathesis/schemathesis/issues/819
 .. _#816: https://github.com/schemathesis/schemathesis/issues/816
 .. _#814: https://github.com/schemathesis/schemathesis/issues/814
 .. _#812: https://github.com/schemathesis/schemathesis/issues/812
@@ -2285,6 +2289,7 @@ Deprecated
 .. _#708: https://github.com/schemathesis/schemathesis/issues/708
 .. _#706: https://github.com/schemathesis/schemathesis/issues/706
 .. _#705: https://github.com/schemathesis/schemathesis/issues/705
+.. _#703: https://github.com/schemathesis/schemathesis/issues/703
 .. _#702: https://github.com/schemathesis/schemathesis/issues/702
 .. _#700: https://github.com/schemathesis/schemathesis/issues/700
 .. _#695: https://github.com/schemathesis/schemathesis/issues/695

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,11 +4,67 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Added**
+
+- A flexible way to select API operations for testing. It is now possible to exclude or include them by commonly
+  used fields like ``method`` or ``tag``, and by arbitrary predicates as well. `#703`_, `#819`_, `#1006`_
+
 **Changed**
 
 - Show ``cURL`` code samples by default instead of Python. `#1269`_
 - Improve reporting of ``jsonschema`` errors which are caused by non-string object keys.
 - Store ``data_generation_method`` in ```BeforeExecution``.
+
+**Deprecated**
+
+``method``, ``endpoint``, ``tag``, ``operation_id`` and ``skip_deprecated_operations`` arguments to all Open API
+loaders (e.g. ``schemathesis.from_dict``) and the ``parametrize`` method. They were used to select what API operations
+should be tested. From this release, you need to use ``include`` / ``exclude`` methods instead.
+
+Before:
+
+.. code:: python
+
+    schema = schemathesis.from_uri("...", method="GET")
+
+
+    @schema.parametrize(endpoint="/users/")
+    def test(case):
+        ...
+
+After:
+
+.. code:: python
+
+    schema = schemathesis.from_uri("...").include(method="GET")
+
+    # Python 3.9+
+    @schema.include(path="/users/").parametrize()
+    def test(case):
+        ...
+
+
+    # Python <=3.8
+    users_schema = schema.include(path="/users/")
+
+
+    @users_schema.parametrize()
+    def test(case):
+        ...
+
+The new approach is not that ergonomic on Python <=3.8, as it doesn't support complex expressions as decorators.
+However, it brings much more flexibility into the ways you could select what is going to be tested.
+
+Similarly, some CLI options are deprecated too:
+- ``--endpoint``. Replaced with ``--include-path``.
+- ``--method``. Replaced with ``--include-method``.
+- ``--tag``. Replaced with ``--include-tag``.
+- ``--operation-id``. Replaced with ``--include-operation-id``.
+- ``--skip-deprecated-operations``. Replaced with ``--exclude-deprecated-operations``.
+
+Each ``--include`` prefixed option has its ``--exclude`` counterpart.
+
+See full description of new possibilities in the :ref:`Selecting API operations to test <selecting-api-operations-to-test>` chapter of the documentation.
 
 `3.10.1`_ - 2021-10-04
 ----------------------
@@ -16,8 +72,6 @@ Changelog
 **Added**
 
 - ``DataGenerationMethod.all`` shortcut to get all possible enum variants.
-- A flexible way to select API operations for testing. It is now possible to exclude or include them by arbitrary
-  predicates. `#703`_, `#819`_, `#1006`_
 
 **Fixed**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ User's Guide
    introduction
    cli
    python
+   what_to_test
    stateful
    service
    how

--- a/docs/what_to_test.rst
+++ b/docs/what_to_test.rst
@@ -1,0 +1,12 @@
+.. _selecting-api-operations-to-test:
+
+Selecting API operations to test
+================================
+
+TODO.
+
+You could also use simple jq-like expressions in ``--include-by`` to filter by arbitrary schema field:
+
+.. code-block:: text
+
+    schemathesis run http://example.com/spec.json --include-by="x-groupName == Verification"

--- a/src/schemathesis/filters.py
+++ b/src/schemathesis/filters.py
@@ -34,16 +34,23 @@ class FilterResult(enum.Enum):
         return self
 
 
-@attr.s(slots=True)
+@attr.s(slots=True, repr=False)
 class BaseFilter:
     func: Callable[..., bool] = attr.ib()
+    # A short description of a filter. Primarily exists for debugging purposes
+    label: str = attr.ib(default="custom")
+    # This ID denotes a filter group that is used to override filters for the same locations
+    group_id: Optional[int] = attr.ib(default=None)
     scope: Optional[str] = attr.ib(default=DEFAULT_SCOPE)
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: {self.label}>"
 
     def apply(self, item: Any) -> FilterResult:
         raise NotImplementedError
 
 
-@attr.s(slots=True)
+@attr.s(slots=True, repr=False)
 class Include(BaseFilter):
     def apply(self, item: Any) -> FilterResult:
         if self.func(item):
@@ -51,7 +58,7 @@ class Include(BaseFilter):
         return FilterResult.EXCLUDED
 
 
-@attr.s(slots=True)
+@attr.s(slots=True, repr=False)
 class Exclude(BaseFilter):
     def apply(self, item: Any) -> FilterResult:
         if self.func(item):

--- a/src/schemathesis/filters.py
+++ b/src/schemathesis/filters.py
@@ -1,0 +1,75 @@
+import enum
+from typing import Any, Callable, List, Optional
+
+import attr
+
+# Indicates the most common place where filters are applied.
+# Other scopes are spec-specific and their filters may be applied earlier to avoid expensive computations
+DEFAULT_SCOPE = None
+
+
+class FilterResult(enum.Enum):
+    """The result of a single filter call.
+
+    This functionality is implemented as a separate enum and not a simple boolean to provide a more descriptive API.
+    """
+
+    INCLUDED = enum.auto()
+    EXCLUDED = enum.auto()
+
+    @property
+    def is_included(self) -> bool:
+        return self == FilterResult.INCLUDED
+
+    @property
+    def is_excluded(self) -> bool:
+        return self == FilterResult.EXCLUDED
+
+    def __bool__(self) -> bool:
+        return self.is_included
+
+    def __and__(self, other: "FilterResult") -> "FilterResult":
+        if self.is_excluded or other.is_excluded:
+            return FilterResult.EXCLUDED
+        return self
+
+
+@attr.s(slots=True)
+class BaseFilter:
+    func: Callable[..., bool] = attr.ib()
+    scope: Optional[str] = attr.ib(default=DEFAULT_SCOPE)
+
+    def apply(self, item: Any) -> FilterResult:
+        raise NotImplementedError
+
+
+@attr.s(slots=True)
+class Include(BaseFilter):
+    def apply(self, item: Any) -> FilterResult:
+        if self.func(item):
+            return FilterResult.INCLUDED
+        return FilterResult.EXCLUDED
+
+
+@attr.s(slots=True)
+class Exclude(BaseFilter):
+    def apply(self, item: Any) -> FilterResult:
+        if self.func(item):
+            return FilterResult.EXCLUDED
+        return FilterResult.INCLUDED
+
+
+def evaluate_filters(filters: List[BaseFilter], item: Any, scope: Optional[str] = DEFAULT_SCOPE) -> FilterResult:
+    """Decide whether the given item passes the filters."""
+    # Lazily apply filters that match the given scope
+    matching_filters = filter(lambda f: f.scope == scope, filters)
+    outcomes = map(lambda f: f.apply(item), matching_filters)
+    # If any filter will exclude the item, then the process short-circuits without evaluating all filters
+    if all(outcomes):
+        return FilterResult.INCLUDED
+    return FilterResult.EXCLUDED
+
+
+def is_excluded(filters: List[BaseFilter], item: Any, scope: Optional[str] = DEFAULT_SCOPE) -> bool:
+    """Whether the given filters exclude the item."""
+    return evaluate_filters(filters, item, scope).is_excluded

--- a/src/schemathesis/hooks.py
+++ b/src/schemathesis/hooks.py
@@ -36,7 +36,7 @@ class HookContext:
 
     operation: Optional["APIOperation"] = attr.ib(default=None)  # pragma: no mutate
 
-    @deprecated_property(removed_in="4.0", replacement="operation")
+    @deprecated_property(removed_in="4.0", replacement="`operation`")
     def endpoint(self) -> Optional["APIOperation"]:
         return self.operation
 

--- a/src/schemathesis/lazy.py
+++ b/src/schemathesis/lazy.py
@@ -37,7 +37,7 @@ class LazySchema:
     app: Any = attr.ib(default=NOT_SET)  # pragma: no mutate
     hooks: HookDispatcher = attr.ib(factory=lambda: HookDispatcher(scope=HookScope.SCHEMA))  # pragma: no mutate
     validate_schema: bool = attr.ib(default=True)  # pragma: no mutate
-    skip_deprecated_operations: bool = attr.ib(default=False)  # pragma: no mutate
+    skip_deprecated_operations: Optional[bool] = attr.ib(default=None)  # pragma: no mutate
     data_generation_methods: Iterable[DataGenerationMethod] = attr.ib(default=DEFAULT_DATA_GENERATION_METHODS)
     code_sample_style: CodeSampleStyle = attr.ib(default=CodeSampleStyle.default())  # pragma: no mutate
 
@@ -57,6 +57,7 @@ class LazySchema:
             value = locals()[name]
             if value is not NOT_SET:
                 warn_filtration_arguments(name)
+                # TODO. create filters
         if method is NOT_SET:
             method = self.method
         if endpoint is NOT_SET:

--- a/src/schemathesis/lazy.py
+++ b/src/schemathesis/lazy.py
@@ -22,6 +22,7 @@ from .utils import (
     is_given_applied,
     merge_given_args,
     validate_given_args,
+    warn_filtration_arguments,
 )
 
 
@@ -51,6 +52,11 @@ class LazySchema:
         data_generation_methods: Union[Iterable[DataGenerationMethod], NotSet] = NOT_SET,
         code_sample_style: Union[str, NotSet] = NOT_SET,
     ) -> Callable:
+        # pylint: disable=too-many-statements
+        for name in ("method", "endpoint", "tag", "operation_id", "skip_deprecated_operations"):
+            value = locals()[name]
+            if value is not NOT_SET:
+                warn_filtration_arguments(name)
         if method is NOT_SET:
             method = self.method
         if endpoint is NOT_SET:

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -118,7 +118,7 @@ class Case:  # pylint: disable=too-many-public-methods
                 parts.extend((name, "=", repr(value)))
         return "".join(parts) + ")"
 
-    @deprecated_property(removed_in="4.0", replacement="operation")
+    @deprecated_property(removed_in="4.0", replacement="`operation`")
     def endpoint(self) -> "APIOperation":
         return self.operation
 

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -31,7 +31,7 @@ from .impl import (
 )
 
 
-@deprecated(removed_in="4.0", replacement="schemathesis.runner.from_schema")
+@deprecated(removed_in="4.0", replacement="`schemathesis.runner.from_schema`")
 def prepare(
     schema_uri: Union[str, Dict[str, Any]],
     *,

--- a/src/schemathesis/specs/openapi/loaders.py
+++ b/src/schemathesis/specs/openapi/loaders.py
@@ -177,7 +177,7 @@ def from_dict(
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
     operation_id: Optional[Filter] = None,
-    skip_deprecated_operations: bool = False,
+    skip_deprecated_operations: Optional[bool] = None,
     validate_schema: bool = True,
     force_schema_version: Optional[str] = None,
     data_generation_methods: DataGenerationMethodInput = DEFAULT_DATA_GENERATION_METHODS,
@@ -188,12 +188,10 @@ def from_dict(
 
     :param dict raw_schema: A schema to load.
     """
-    for name in ("method", "endpoint", "tag", "operation_id"):
+    for name in ("method", "endpoint", "tag", "operation_id", "skip_deprecated_operations"):
         value = locals()[name]
         if value is not None:
             warn_filtration_arguments(name)
-    if skip_deprecated_operations is True:
-        warn_filtration_arguments("skip_deprecated_operations")
     _code_sample_style = CodeSampleStyle.from_str(code_sample_style)
     dispatch("before_load_schema", HookContext(), raw_schema)
 
@@ -203,17 +201,12 @@ def from_dict(
             raw_schema,
             app=app,
             base_url=base_url,
-            method=method,
-            endpoint=endpoint,
-            tag=tag,
-            operation_id=operation_id,
-            skip_deprecated_operations=skip_deprecated_operations,
             validate_schema=validate_schema,
             data_generation_methods=_prepare_data_generation_methods(data_generation_methods),
             code_sample_style=_code_sample_style,
             location=location,
         )
-        return schema.include(method, endpoint)
+        return schema.include(method, endpoint, tag, operation_id, skip_deprecated_operations)
 
     def init_openapi_3() -> OpenApi30:
         _maybe_validate_schema(raw_schema, definitions.OPENAPI_30_VALIDATOR, validate_schema)
@@ -221,17 +214,12 @@ def from_dict(
             raw_schema,
             app=app,
             base_url=base_url,
-            method=method,
-            endpoint=endpoint,
-            tag=tag,
-            operation_id=operation_id,
-            skip_deprecated_operations=skip_deprecated_operations,
             validate_schema=validate_schema,
             data_generation_methods=_prepare_data_generation_methods(data_generation_methods),
             code_sample_style=_code_sample_style,
             location=location,
         )
-        return schema.include(method, endpoint)
+        return schema.include(method, endpoint, tag, operation_id, skip_deprecated_operations)
 
     if force_schema_version == "20":
         return init_openapi_2()

--- a/src/schemathesis/specs/openapi/loaders.py
+++ b/src/schemathesis/specs/openapi/loaders.py
@@ -41,7 +41,7 @@ def from_path(
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
     operation_id: Optional[Filter] = None,
-    skip_deprecated_operations: bool = False,
+    skip_deprecated_operations: Optional[bool] = None,
     validate_schema: bool = True,
     force_schema_version: Optional[str] = None,
     data_generation_methods: DataGenerationMethodInput = DEFAULT_DATA_GENERATION_METHODS,
@@ -81,7 +81,7 @@ def from_uri(
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
     operation_id: Optional[Filter] = None,
-    skip_deprecated_operations: bool = False,
+    skip_deprecated_operations: Optional[bool] = None,
     validate_schema: bool = True,
     force_schema_version: Optional[str] = None,
     data_generation_methods: DataGenerationMethodInput = DEFAULT_DATA_GENERATION_METHODS,
@@ -135,7 +135,7 @@ def from_file(
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
     operation_id: Optional[Filter] = None,
-    skip_deprecated_operations: bool = False,
+    skip_deprecated_operations: Optional[bool] = None,
     validate_schema: bool = True,
     force_schema_version: Optional[str] = None,
     data_generation_methods: DataGenerationMethodInput = DEFAULT_DATA_GENERATION_METHODS,
@@ -288,7 +288,7 @@ def from_pytest_fixture(
     endpoint: Optional[Filter] = NOT_SET,
     tag: Optional[Filter] = NOT_SET,
     operation_id: Optional[Filter] = NOT_SET,
-    skip_deprecated_operations: bool = False,
+    skip_deprecated_operations: Optional[bool] = None,
     validate_schema: bool = True,
     data_generation_methods: DataGenerationMethodInput = DEFAULT_DATA_GENERATION_METHODS,
     code_sample_style: str = CodeSampleStyle.default().name,
@@ -303,6 +303,10 @@ def from_pytest_fixture(
     :param str fixture_name: The name of a fixture to load.
     """
     _code_sample_style = CodeSampleStyle.from_str(code_sample_style)
+    for name in ("method", "endpoint", "tag", "operation_id", "skip_deprecated_operations"):
+        value = locals()[name]
+        if value is not None:
+            warn_filtration_arguments(name)
     return LazySchema(
         fixture_name,
         app=app,
@@ -327,7 +331,7 @@ def from_wsgi(
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
     operation_id: Optional[Filter] = None,
-    skip_deprecated_operations: bool = False,
+    skip_deprecated_operations: Optional[bool] = None,
     validate_schema: bool = True,
     force_schema_version: Optional[str] = None,
     data_generation_methods: DataGenerationMethodInput = DEFAULT_DATA_GENERATION_METHODS,
@@ -378,7 +382,7 @@ def from_aiohttp(
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
     operation_id: Optional[Filter] = None,
-    skip_deprecated_operations: bool = False,
+    skip_deprecated_operations: Optional[bool] = None,
     validate_schema: bool = True,
     force_schema_version: Optional[str] = None,
     data_generation_methods: DataGenerationMethodInput = DEFAULT_DATA_GENERATION_METHODS,
@@ -420,7 +424,7 @@ def from_asgi(
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
     operation_id: Optional[Filter] = None,
-    skip_deprecated_operations: bool = False,
+    skip_deprecated_operations: Optional[bool] = None,
     validate_schema: bool = True,
     force_schema_version: Optional[str] = None,
     data_generation_methods: DataGenerationMethodInput = DEFAULT_DATA_GENERATION_METHODS,

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -284,10 +284,13 @@ def traverse_schema(schema: Schema, callback: Callable[..., Dict[str, Any]], *ar
     return schema
 
 
-def _warn_deprecation(*, thing: str, removed_in: str, replacement: str) -> None:
+def warn_filtration_arguments(name: str) -> None:
+    warn_deprecation(thing=f"Argument `{name}`", removed_in="4.0", replacement="`include` or `exclude` methods")
+
+
+def warn_deprecation(*, thing: str, removed_in: str, replacement: str) -> None:
     warnings.warn(
-        f"Property `{thing}` is deprecated and will be removed in Schemathesis {removed_in}. "
-        f"Use `{replacement}` instead.",
+        f"{thing} is deprecated and will be removed in Schemathesis {removed_in}. " f"Use {replacement} instead.",
         DeprecationWarning,
     )
 
@@ -296,7 +299,7 @@ def deprecated_property(*, removed_in: str, replacement: str) -> Callable:
     def wrapper(prop: Callable) -> Callable:
         @property  # type: ignore
         def inner(self: Any) -> Any:
-            _warn_deprecation(thing=prop.__name__, removed_in=removed_in, replacement=replacement)
+            warn_deprecation(thing=f"Property `{prop.__name__}`", removed_in=removed_in, replacement=replacement)
             return prop(self)
 
         return inner
@@ -307,7 +310,7 @@ def deprecated_property(*, removed_in: str, replacement: str) -> Callable:
 def deprecated(*, removed_in: str, replacement: str) -> Callable:
     def wrapper(func: Callable) -> Callable:
         def inner(*args: Any, **kwargs: Any) -> Any:
-            _warn_deprecation(thing=func.__name__, removed_in=removed_in, replacement=replacement)
+            warn_deprecation(thing=f"Function `{func.__name__}`", removed_in=removed_in, replacement=replacement)
             return func(*args, **kwargs)
 
         return inner

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -510,7 +510,7 @@ def testdir(testdir):
     def maker(
         content,
         method=None,
-        endpoint=None,
+        path=None,
         tag=None,
         pytest_plugins=("aiohttp.pytest_plugin",),
         validate_schema=True,
@@ -535,11 +535,13 @@ def testdir(testdir):
         def simple_schema():
             return schema
 
-        schema = schemathesis.from_dict(raw_schema, method={method}, endpoint={endpoint}, tag={tag}, validate_schema={validate_schema})
+        schema = schemathesis.from_dict(raw_schema, validate_schema={validate_schema}).include(
+            method={method}, path={path}, tag={tag}
+        )
         """.format(
                 schema=schema,
                 method=repr(method),
-                endpoint=repr(endpoint),
+                path=repr(path),
                 tag=repr(tag),
                 validate_schema=repr(validate_schema),
             )

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -240,7 +240,7 @@ def test_execute_with_headers(any_app, any_app_schema):
 
 
 def test_execute_filter_endpoint(app, schema_url):
-    schema = oas_loaders.from_uri(schema_url, endpoint=["success"])
+    schema = oas_loaders.from_uri(schema_url).include(path=["success"])
     # When `endpoint` is passed in the `execute` call
     execute(schema)
 
@@ -657,7 +657,7 @@ def test_url_joining(request, server, get_schema_path, schema_path):
     else:
         base_url = request.getfixturevalue("openapi3_base_url")
     path = get_schema_path(schema_path)
-    schema = oas_loaders.from_path(path, base_url=f"{base_url}/v3", endpoint="/pet/findByStatus")
+    schema = oas_loaders.from_path(path, base_url=f"{base_url}/v3").include(path="/pet/findByStatus")
     *_, after_execution, _ = from_schema(
         schema, hypothesis_settings=hypothesis.settings(max_examples=1, deadline=None)
     ).execute()

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -198,7 +198,7 @@ def test_c(request, case):
             },
         },
         method="POST",
-        endpoint="/first",
+        path="/first",
         tag="foo",
     )
     result = testdir.runpytest("-v", "-s")
@@ -267,7 +267,7 @@ def test_b(request, case):
             },
         },
         method="GET",
-        endpoint="/first",
+        path="/first",
     )
     result = testdir.runpytest("-v", "-s")
     # Then the filters should be applied to the generated tests


### PR DESCRIPTION
Resolves #703 
Resolves #819
Resolves #1006 

TODO:
- [x] Deprecation docs
- [x] Deprecate passing filters to loaders
- [x] Deprecate passing filters to `parametrize`
- [ ] Use `include` in tests
- [ ] Deprecate using old CLI arguments for filtration
- [ ] Make CLI use `include` / `exclude`
- [ ] CLI support for custom filters. It could be some simple `jq`-like filter - `--include-by="x-foo == 42"`, where the expression is of form "JSONPath Operator Value"
- [ ] CLI support for new filters - `--include-method`, `--exclude-method`, etc.
- [ ] How to remove filters?
- [x] Implement `exclude`
- [ ] Add `include` / `exclude` for GraphQL schemas
- [ ] Add relevant methods on "lazy" schemas
- [ ] Docs (CLI & Python) & comments
- [x] Use `path` instead `endpoint`?
- [ ] Separate method for regular expressions?
- [x] How to deal with lists of strings?
- [x] Better repr for filter functions
- [x] Deal with filters overriding

In Schemathesis 4.0 it will be nice to remove those arguments & attributes
