### PR TITLE
chore: Show `cURL` code samples by default instead of Python

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,10 @@ Changelog
 
 - ``DataGenerationMethod.all`` shortcut to get all possible enum variants.
 
+**Changed**
+
+- Show ``cURL`` code samples by default instead of Python. `#1269`_
+
 `3.10.0`_ - 2021-09-13
 ----------------------
 
@@ -2144,6 +2148,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1269: https://github.com/schemathesis/schemathesis/issues/1269
 .. _#1262: https://github.com/schemathesis/schemathesis/issues/1262
 .. _#1260: https://github.com/schemathesis/schemathesis/issues/1260
 .. _#1233: https://github.com/schemathesis/schemathesis/issues/1233

--- a/src/schemathesis/constants.py
+++ b/src/schemathesis/constants.py
@@ -61,7 +61,7 @@ class CodeSampleStyle(str, Enum):
 
     @classmethod
     def default(cls) -> "CodeSampleStyle":
-        return cls.python
+        return cls.curl
 
     @classmethod
     def from_str(cls, value: str) -> "CodeSampleStyle":

--- a/test/cli/output/test_default.py
+++ b/test/cli/output/test_default.py
@@ -338,9 +338,9 @@ def test_display_failures(swagger_20, capsys, execution_context, results_set, ve
     # And operation with a failure is displayed as a subsection
     assert " GET /v1/api/failure " in out
     assert "Message" in out
-    assert "Run this Python code to reproduce this failure: " in out
-    headers = f"{{'User-Agent': '{USER_AGENT}', 'Content-Type': 'application/json', 'Content-Length': '0'}}"
-    assert f"requests.get('http://127.0.0.1:8080/api/failure', headers={headers})" in out
+    assert "Run this cURL command to reproduce this failure:" in out
+    headers = f"-H 'Content-Length: 0' -H 'Content-Type: application/json' -H 'User-Agent: {USER_AGENT}'"
+    assert f"curl -X GET {headers} http://127.0.0.1:8080/api/failure" in out
 
 
 @pytest.mark.parametrize("show_errors_tracebacks", (True, False))

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -1847,9 +1847,8 @@ def test_auth_override_on_protected_operation(cli, base_url, schema_url, extra):
     )
     # And code sample as well
     assert (
-        lines[26] == f"    requests.get('{base_url}/basic', headers={{'Authorization': 'Basic J3Rlc3Q6d3Jvbmcn', "
-        f"'User-Agent': '{USER_AGENT}', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', "
-        f"'Connection': 'keep-alive'}})"
+        lines[26]
+        == f"    curl -X GET -H 'Accept: */*' -H 'Accept-Encoding: gzip, deflate' -H 'Authorization: Basic J3Rlc3Q6d3Jvbmcn' -H 'Connection: keep-alive' -H 'User-Agent: {USER_AGENT}' {base_url}/basic"
     )
 
 
@@ -1866,8 +1865,7 @@ def test_explicit_headers_in_output_on_errors(cli, base_url, schema_url, openapi
     assert lines[17] == f"Headers         : {{'Authorization': '{auth}', 'User-Agent': '{USER_AGENT}'}}"
     # And code sample as well
     assert lines[22].startswith(
-        f"    requests.get('{base_url}/flaky', headers={{'User-Agent': '{USER_AGENT}', "
-        f"'Authorization': '{auth}'}}, params={{'id': "
+        f"    curl -X GET -H 'Authorization: {auth}' -H 'User-Agent: {USER_AGENT}' '{base_url}/flaky?id=0'"
     )
 
 

--- a/test/runner/test_checks.py
+++ b/test/runner/test_checks.py
@@ -33,6 +33,8 @@ def make_response(
     response.status_code = status_code
     if content_type:
         response.headers["Content-Type"] = content_type
+    request = requests.Request(method="POST", url="http://127.0.0.1", headers={})
+    response.request = request.prepare()
     return response
 
 

--- a/test/specs/openapi/test_stateful.py
+++ b/test/specs/openapi/test_stateful.py
@@ -109,7 +109,7 @@ TestStateful.settings = settings(
     # Then it should be able to find a hidden error:
     result.assert_outcomes(failed=1)
     # And there should be Python code to reproduce the error in the GET call
-    result.stdout.re_match_lines([rf"E +requests\.get\('{openapi3_base_url}/users/\w+.+"])
+    result.stdout.re_match_lines([rf"E +curl -X GET .+ '{openapi3_base_url}/users/\w+.+"])
     # And the reproducing example should work
     first = result.outlines.index("Falsifying example:") + 1
     last = result.outlines.index("state.teardown()") + 1

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -234,13 +234,15 @@ def test_case_partial_deepcopy(swagger_20):
 def test_validate_response(testdir):
     testdir.make_test(
         fr"""
-from requests import Response
+from requests import Response, Request
 
 @schema.parametrize()
 def test_(case):
     response = Response()
     response.headers["Content-Type"] = "application/json"
     response.status_code = 418
+    request = Request(method="GET", url="http://localhost/v1/users", headers={{}})
+    response.request = request.prepare()
     try:
         case.validate_response(response)
     except AssertionError as exc:
@@ -255,9 +257,9 @@ def test_(case):
           "",
           "Response payload: ``",
           "",
-          "Run this Python code to reproduce this response: ",
+          "Run this cURL command to reproduce this response: ",
           "",
-          "    requests.get('http://localhost/v1/users', headers={{'User-Agent': '{USER_AGENT}'}})",
+          "    curl -X GET -H 'User-Agent: {USER_AGENT}' http://localhost/v1/users",
           "",
     ]
 """


### PR DESCRIPTION
Resolves #1269