### PR TITLE
chore: Improve reporting of `jsonschema` errors which are caused by non-string object keys

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 **Changed**
 
 - Show ``cURL`` code samples by default instead of Python. `#1269`_
+- Improve reporting of ``jsonschema`` errors which are caused by non-string object keys.
 
 `3.10.1`_ - 2021-10-04
 ----------------------

--- a/src/schemathesis/cli/output/default.py
+++ b/src/schemathesis/cli/output/default.py
@@ -408,7 +408,7 @@ def display_internal_error(context: ExecutionContext, event: events.InternalErro
             f"Error: {message}\n"
             f"Add this option to your command line parameters to see full tracebacks: --show-errors-tracebacks"
         )
-        if event.exception_type == "jsonschema.exceptions.ValidationError":
+        if event.exception_type == "schemathesis.exceptions.SchemaLoadingError":
             message += "\n" + DISABLE_SCHEMA_VALIDATION_MESSAGE
         click.secho(message, fg="red")
 

--- a/src/schemathesis/specs/openapi/validation.py
+++ b/src/schemathesis/specs/openapi/validation.py
@@ -1,0 +1,17 @@
+from typing import Any, Dict, List, Tuple, Union
+
+
+def is_pattern_error(exception: TypeError) -> bool:
+    """Detect whether the input exception was caused by invalid type passed to `re.search`."""
+    # This is intentionally simplistic and do not involve any traceback analysis
+    return str(exception) == "expected string or bytes-like object"
+
+
+def find_numeric_http_status_codes(schema: Dict[str, Any]) -> List[Tuple[int, List[Union[str, int]]]]:
+    found = []
+    for path, methods in schema.get("paths", {}).items():
+        for method, definition in methods.items():
+            for key in definition.get("responses", {}):
+                if isinstance(key, int):
+                    found.append((key, [path, method]))
+    return found

--- a/test/test_schemas.py
+++ b/test/test_schemas.py
@@ -2,7 +2,7 @@ import pytest
 from jsonschema import ValidationError
 
 import schemathesis
-from schemathesis.exceptions import InvalidSchema
+from schemathesis.exceptions import InvalidSchema, SchemaLoadingError
 from schemathesis.specs.openapi.parameters import OpenAPI20Body
 from schemathesis.specs.openapi.schemas import InliningResolver
 from schemathesis.utils import Err, Ok
@@ -126,7 +126,7 @@ def test_schema_parsing_error(simple_schema):
     assert oks[0].method == "post"
 
 
-@pytest.mark.parametrize("validate_schema, expected_exception", ((False, InvalidSchema), (True, ValidationError)))
+@pytest.mark.parametrize("validate_schema, expected_exception", ((False, InvalidSchema), (True, SchemaLoadingError)))
 def test_not_recoverable_schema_error(simple_schema, validate_schema, expected_exception):
     # When there is an error in the API schema that leads to inability to generate any tests
     del simple_schema["paths"]
@@ -140,7 +140,7 @@ def test_schema_error_on_path(simple_schema):
     # When there is an error that affects only a subset of paths
     simple_schema["paths"] = {None: "", "/foo": {"post": RESPONSES}}
     # Then it should be rejected during loading if schema validation is enabled
-    with pytest.raises(ValidationError):
+    with pytest.raises(SchemaLoadingError):
         schemathesis.from_dict(simple_schema)
     # And should produce an `Err` instance on operation parsing
     schema = schemathesis.from_dict(simple_schema, validate_schema=False)


### PR DESCRIPTION
This is a frequent problem reported by users. This change will provide a much better error message for such cases