### PR TITLE
chore: Add `AfterExecution.verbose_name`

### DIFF
--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -115,6 +115,8 @@ class AfterExecution(CurrentOperationMixin, ExecutionEvent):
     method: str = attr.ib()  # pragma: no mutate
     path: str = attr.ib()  # pragma: no mutate
     relative_path: str = attr.ib()  # pragma: no mutate
+    # Specification-specific operation name
+    verbose_name: str = attr.ib()  # pragma: no mutate
 
     # APIOperation test status - success / failure / error
     status: Status = attr.ib()  # pragma: no mutate
@@ -140,6 +142,7 @@ class AfterExecution(CurrentOperationMixin, ExecutionEvent):
             method=operation.method.upper(),
             path=operation.full_path,
             relative_path=operation.path,
+            verbose_name=operation.verbose_name,
             result=SerializedTestResult.from_test_result(result),
             status=status,
             elapsed_time=elapsed_time,

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -210,6 +210,7 @@ def handle_schema_error(
             method=method,
             path=error.full_path,
             relative_path=error.path,
+            verbose_name=verbose_name,
             status=Status.error,
             result=SerializedTestResult.from_test_result(result),
             elapsed_time=0.0,


### PR DESCRIPTION
To have parity with `BeforeExecution`
