### PR TITLE
perf: Use sets during negative testing data generation

### DIFF
--- a/src/schemathesis/specs/openapi/negative/mutations.py
+++ b/src/schemathesis/specs/openapi/negative/mutations.py
@@ -48,7 +48,7 @@ class MutationResult(enum.Enum):
 
 
 Mutation = Callable[["MutationContext", Draw, Schema], MutationResult]
-ALL_KEYWORDS = (
+ALL_KEYWORDS = {
     "additionalItems",
     "additionalProperties",
     "allOf",
@@ -85,8 +85,8 @@ ALL_KEYWORDS = (
     "then",
     "type",
     "uniqueItems",
-)
-ANY_TYPE_KEYS = ("$ref", "allOf", "anyOf", "const", "else", "enum", "if", "not", "oneOf", "then", "type")
+}
+ANY_TYPE_KEYS = {"$ref", "allOf", "anyOf", "const", "else", "enum", "if", "not", "oneOf", "then", "type"}
 TYPE_SPECIFIC_KEYS = {
     "number": ("multipleOf", "maximum", "exclusiveMaximum", "minimum", "exclusiveMinimum"),
     "integer": ("multipleOf", "maximum", "exclusiveMaximum", "minimum", "exclusiveMinimum"),


### PR DESCRIPTION
It gives ~30% improvement for `ANY_TYPE_KEYS` and >320% for `ALL_KEYWORDS` on my test data. Though, the improvement is limited only to `split_schema` and `drop_not_type_specific_keywords` which are called pretty often