### PR TITLE
fix: Unescaped quotes in generated Python code samples on some schemas

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Changelog
 
 - Pass ``data_generation_method`` to ``Case`` for GraphQL schemas.
 - Generation of invalid headers in some cases. `#1142`_
+- Unescaped quotes in generated Python code samples on some schemas. `#1030`_
 
 **Performance**
 
@@ -2209,6 +2210,7 @@ Deprecated
 .. _#1039: https://github.com/schemathesis/schemathesis/issues/1039
 .. _#1036: https://github.com/schemathesis/schemathesis/issues/1036
 .. _#1033: https://github.com/schemathesis/schemathesis/issues/1033
+.. _#1030: https://github.com/schemathesis/schemathesis/issues/1030
 .. _#1028: https://github.com/schemathesis/schemathesis/issues/1028
 .. _#1022: https://github.com/schemathesis/schemathesis/issues/1022
 .. _#1020: https://github.com/schemathesis/schemathesis/issues/1020

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -220,7 +220,8 @@ class Case:  # pylint: disable=too-many-public-methods
         printed_kwargs = ", ".join(
             f"{key}={repr(value)}" for key, value in kwargs.items() if should_display(key, value)
         )
-        args_repr = f"'{kwargs['url']}'"
+        url = kwargs["url"].replace("'", "\\'")
+        args_repr = f"'{url}'"
         if printed_kwargs:
             args_repr += f", {printed_kwargs}"
         return f"requests.{method}({args_repr})"


### PR DESCRIPTION
Fixes #1030