### PR TITLE
chore: update release notary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,6 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Release Notary Action
-      uses: docker://outillage/release-notary
+      uses: docker://aevea/release-notary
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
Changed the Docker image for release-notary. 
Reasoning:
Outillage has been deprecated in favour of aevea. There is full compatibility as until now the outillage branch has been released as well.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Added a changelog entry
- [ ] Extended the README / documentation, if necessary
