### PR TITLE
fix: Handle `KeyboardInterrupt` that happens outside of the main test loop inside the runner

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,11 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Handle ``KeyboardInterrupt`` that happens outside of the main test loop inside the runner.
+  It makes interrupt handling consistent, independent at what point it happens. `#1325`_
+
 `3.11.1`_ - 2021-11-20
 ----------------------
 
@@ -2181,7 +2186,8 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
-.. _#1328: https://github.com/schemathesis/schemathesis/issues/1228
+.. _#1328: https://github.com/schemathesis/schemathesis/issues/1328
+.. _#1325: https://github.com/schemathesis/schemathesis/issues/1325
 .. _#1290: https://github.com/schemathesis/schemathesis/issues/1290
 .. _#1287: https://github.com/schemathesis/schemathesis/issues/1287
 .. _#1280: https://github.com/schemathesis/schemathesis/issues/1280

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -91,8 +91,11 @@ class BaseRunner:
             yield _finish()
             return
 
-        for event in self._execute(results, stop_event):
-            yield event
+        try:
+            for event in self._execute(results, stop_event):
+                yield event
+        except KeyboardInterrupt:
+            yield events.Interrupted()
 
         yield _finish()
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -149,6 +149,11 @@ def openapi3_schema_url(server, openapi_3_app):
     return f"http://127.0.0.1:{server['port']}/schema.yaml"
 
 
+@pytest.fixture()
+def openapi3_schema(openapi3_schema_url):
+    return oas_loaders.from_uri(openapi3_schema_url)
+
+
 @pytest.fixture
 def graphql_path():
     return "/graphql"


### PR DESCRIPTION
Resolves #1325