### PR TITLE
fix: Respect the `data_generation_methods` config option defined on a schema instance when it is loaded via `from_pytest_fixture`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 
 - Handle ``KeyboardInterrupt`` that happens outside of the main test loop inside the runner.
   It makes interrupt handling consistent, independent at what point it happens. `#1325`_
+- Respect the ``data_generation_methods`` config option defined on a schema instance when it is loaded via ``from_pytest_fixture``. `#1331`_
 
 `3.11.1`_ - 2021-11-20
 ----------------------
@@ -2186,6 +2187,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1331: https://github.com/schemathesis/schemathesis/issues/1331
 .. _#1328: https://github.com/schemathesis/schemathesis/issues/1328
 .. _#1325: https://github.com/schemathesis/schemathesis/issues/1325
 .. _#1290: https://github.com/schemathesis/schemathesis/issues/1290

--- a/src/schemathesis/lazy.py
+++ b/src/schemathesis/lazy.py
@@ -1,17 +1,17 @@
 from inspect import signature
-from typing import Any, Callable, Dict, Iterable, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import attr
 import pytest
 from _pytest.fixtures import FixtureRequest
 from pytest_subtests import SubTests, nullcontext
 
-from .constants import DEFAULT_DATA_GENERATION_METHODS, CodeSampleStyle, DataGenerationMethod
+from .constants import CodeSampleStyle, DataGenerationMethod
 from .exceptions import InvalidSchema
 from .hooks import HookDispatcher, HookScope
 from .models import APIOperation
 from .schemas import BaseSchema
-from .types import Filter, GenericTest, NotSet
+from .types import DataGenerationMethodInput, Filter, GenericTest, NotSet
 from .utils import (
     NOT_SET,
     GivenInput,
@@ -37,7 +37,7 @@ class LazySchema:
     hooks: HookDispatcher = attr.ib(factory=lambda: HookDispatcher(scope=HookScope.SCHEMA))  # pragma: no mutate
     validate_schema: bool = attr.ib(default=True)  # pragma: no mutate
     skip_deprecated_operations: bool = attr.ib(default=False)  # pragma: no mutate
-    data_generation_methods: Iterable[DataGenerationMethod] = attr.ib(default=DEFAULT_DATA_GENERATION_METHODS)
+    data_generation_methods: Union[DataGenerationMethodInput, NotSet] = attr.ib(default=NOT_SET)
     code_sample_style: CodeSampleStyle = attr.ib(default=CodeSampleStyle.default())  # pragma: no mutate
 
     def parametrize(
@@ -48,7 +48,7 @@ class LazySchema:
         operation_id: Optional[Filter] = NOT_SET,
         validate_schema: Union[bool, NotSet] = NOT_SET,
         skip_deprecated_operations: Union[bool, NotSet] = NOT_SET,
-        data_generation_methods: Union[Iterable[DataGenerationMethod], NotSet] = NOT_SET,
+        data_generation_methods: Union[DataGenerationMethodInput, NotSet] = NOT_SET,
         code_sample_style: Union[str, NotSet] = NOT_SET,
     ) -> Callable:
         if method is NOT_SET:
@@ -185,7 +185,7 @@ def get_schema(
     hooks: HookDispatcher,
     validate_schema: Union[bool, NotSet] = NOT_SET,
     skip_deprecated_operations: Union[bool, NotSet] = NOT_SET,
-    data_generation_methods: Union[Iterable[DataGenerationMethod], NotSet] = NOT_SET,
+    data_generation_methods: Union[DataGenerationMethodInput, NotSet] = NOT_SET,
     code_sample_style: CodeSampleStyle,
 ) -> BaseSchema:
     """Loads a schema from the fixture."""

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -38,7 +38,18 @@ from .exceptions import InvalidSchema, UsageError
 from .hooks import HookContext, HookDispatcher, HookScope, dispatch
 from .models import APIOperation, Case
 from .stateful import APIStateMachine, Stateful, StatefulTest
-from .types import Body, Cookies, Filter, FormData, GenericTest, Headers, NotSet, PathParameters, Query
+from .types import (
+    Body,
+    Cookies,
+    DataGenerationMethodInput,
+    Filter,
+    FormData,
+    GenericTest,
+    Headers,
+    NotSet,
+    PathParameters,
+    Query,
+)
 from .utils import NOT_SET, PARAMETRIZE_MARKER, GenericResponse, GivenInput, Ok, Result, given_proxy
 
 
@@ -248,7 +259,7 @@ class BaseSchema(Mapping):
         hooks: Union[HookDispatcher, NotSet] = NOT_SET,
         validate_schema: Union[bool, NotSet] = NOT_SET,
         skip_deprecated_operations: Union[bool, NotSet] = NOT_SET,
-        data_generation_methods: Union[Iterable[DataGenerationMethod], NotSet] = NOT_SET,
+        data_generation_methods: Union[DataGenerationMethodInput, NotSet] = NOT_SET,
         code_sample_style: Union[CodeSampleStyle, NotSet] = NOT_SET,
     ) -> "BaseSchema":
         if base_url is NOT_SET:

--- a/src/schemathesis/specs/openapi/loaders.py
+++ b/src/schemathesis/specs/openapi/loaders.py
@@ -1,7 +1,7 @@
 import io
 import pathlib
 from contextlib import suppress
-from typing import IO, Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import IO, Any, Callable, Dict, List, Optional, Tuple, Union, cast
 from urllib.parse import urljoin
 
 import jsonschema
@@ -286,7 +286,7 @@ def from_pytest_fixture(
     operation_id: Optional[Filter] = NOT_SET,
     skip_deprecated_operations: bool = False,
     validate_schema: bool = True,
-    data_generation_methods: DataGenerationMethodInput = DEFAULT_DATA_GENERATION_METHODS,
+    data_generation_methods: Union[DataGenerationMethodInput, NotSet] = NOT_SET,
     code_sample_style: str = CodeSampleStyle.default().name,
 ) -> LazySchema:
     """Load schema from a ``pytest`` fixture.
@@ -299,6 +299,12 @@ def from_pytest_fixture(
     :param str fixture_name: The name of a fixture to load.
     """
     _code_sample_style = CodeSampleStyle.from_str(code_sample_style)
+    _data_generation_methods: Union[DataGenerationMethodInput, NotSet]
+    if data_generation_methods is not NOT_SET:
+        data_generation_methods = cast(DataGenerationMethodInput, data_generation_methods)
+        _data_generation_methods = prepare_data_generation_methods(data_generation_methods)
+    else:
+        _data_generation_methods = data_generation_methods
     return LazySchema(
         fixture_name,
         app=app,
@@ -309,7 +315,7 @@ def from_pytest_fixture(
         operation_id=operation_id,
         skip_deprecated_operations=skip_deprecated_operations,
         validate_schema=validate_schema,
-        data_generation_methods=prepare_data_generation_methods(data_generation_methods),
+        data_generation_methods=_data_generation_methods,
         code_sample_style=_code_sample_style,
     )
 


### PR DESCRIPTION
Fixes #1331