### PR TITLE
fix: Ignored hooks defined on a schema instance when it is loaded via `from_pytest_fixture`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
 - Handle ``KeyboardInterrupt`` that happens outside of the main test loop inside the runner.
   It makes interrupt handling consistent, independent at what point it happens. `#1325`_
 - Respect the ``data_generation_methods`` config option defined on a schema instance when it is loaded via ``from_pytest_fixture``. `#1331`_
+- Ignored hooks defined on a schema instance when it is loaded via ``from_pytest_fixture``. `#1340`_
 
 `3.11.1`_ - 2021-11-20
 ----------------------
@@ -2195,6 +2196,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1340: https://github.com/schemathesis/schemathesis/issues/1340
 .. _#1336: https://github.com/schemathesis/schemathesis/issues/1336
 .. _#1331: https://github.com/schemathesis/schemathesis/issues/1331
 .. _#1328: https://github.com/schemathesis/schemathesis/issues/1328

--- a/src/schemathesis/hooks.py
+++ b/src/schemathesis/hooks.py
@@ -1,5 +1,6 @@
 import inspect
 from collections import defaultdict
+from copy import deepcopy
 from enum import Enum, unique
 from typing import TYPE_CHECKING, Any, Callable, DefaultDict, Dict, List, Optional, Union, cast
 
@@ -82,6 +83,18 @@ class HookDispatcher:
 
             return decorator
         return self.register_hook_with_name(hook, hook.__name__)
+
+    def merge(self, other: "HookDispatcher") -> "HookDispatcher":
+        """Merge two dispatches together.
+
+        The resulting dispatcher will call the `self` hooks first.
+        """
+        all_hooks = deepcopy(self._hooks)
+        for name, hooks in other._hooks.items():
+            all_hooks[name].extend(hooks)
+        instance = self.__class__(scope=self.scope)
+        instance._hooks = all_hooks
+        return instance
 
     def apply(self, hook: Callable, *, name: Optional[str] = None) -> Callable[[Callable], Callable]:
         """Register hook to run only on one test function.

--- a/src/schemathesis/lazy.py
+++ b/src/schemathesis/lazy.py
@@ -208,7 +208,7 @@ def get_schema(
         operation_id=operation_id,
         app=app,
         test_function=test_function,
-        hooks=hooks,
+        hooks=schema.hooks.merge(hooks),
         validate_schema=validate_schema,
         skip_deprecated_operations=skip_deprecated_operations,
         data_generation_methods=data_generation_methods,


### PR DESCRIPTION
Fixes #1340