### PR TITLE
fix: Silently failing to detect numeric status codes when the schema contains a shared `parameters` key

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Silently failing to detect numeric status codes when the schema contains a shared ``parameters`` key. `#1343`_
+
 `3.11.2`_ - 2021-11-30
 ----------------------
 
@@ -2200,6 +2204,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1343: https://github.com/schemathesis/schemathesis/issues/1343
 .. _#1340: https://github.com/schemathesis/schemathesis/issues/1340
 .. _#1336: https://github.com/schemathesis/schemathesis/issues/1336
 .. _#1331: https://github.com/schemathesis/schemathesis/issues/1331

--- a/src/schemathesis/specs/openapi/validation.py
+++ b/src/schemathesis/specs/openapi/validation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Set, Tuple, Union
 
 
 def is_pattern_error(exception: TypeError) -> bool:
@@ -7,11 +7,18 @@ def is_pattern_error(exception: TypeError) -> bool:
     return str(exception) == "expected string or bytes-like object"
 
 
-def find_numeric_http_status_codes(schema: Dict[str, Any]) -> List[Tuple[int, List[Union[str, int]]]]:
+def find_numeric_http_status_codes(
+    schema: Dict[str, Any], allowed_http_methods: Set[str]
+) -> List[Tuple[int, List[Union[str, int]]]]:
+    if not isinstance(schema, dict):
+        return []
     found = []
     for path, methods in schema.get("paths", {}).items():
-        for method, definition in methods.items():
-            for key in definition.get("responses", {}):
-                if isinstance(key, int):
-                    found.append((key, [path, method]))
+        if isinstance(methods, dict):
+            for method, definition in methods.items():
+                if method not in allowed_http_methods or not isinstance(definition, dict):
+                    continue
+                for key in definition.get("responses", {}):
+                    if isinstance(key, int):
+                        found.append((key, [path, method]))
     return found

--- a/test/loaders/test_openapi.py
+++ b/test/loaders/test_openapi.py
@@ -116,6 +116,7 @@ def test_numeric_status_codes(empty_open_api_3_schema):
     # When the API schema contains a numeric status code, which is not allowed by the spec
     empty_open_api_3_schema["paths"] = {
         "/foo": {
+            "parameters": [],
             "get": {
                 "responses": {200: {"description": "OK"}},
             },


### PR DESCRIPTION
Fixes #1343
