### PR TITLE
fix: Improper handling of `base_url` in `call_asgi`, when the base URL has a non-empty base path

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Improper handling of ``base_url`` in ``call_asgi``, when the base URL has a non-empty base path. `#1366`_
+
 `3.12.0`_ - 2021-12-29
 ----------------------
 
@@ -2261,6 +2265,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1366: https://github.com/schemathesis/schemathesis/issues/1366
 .. _#1350: https://github.com/schemathesis/schemathesis/issues/1350
 .. _#1343: https://github.com/schemathesis/schemathesis/issues/1343
 .. _#1342: https://github.com/schemathesis/schemathesis/issues/1342

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -374,7 +374,7 @@ class Case:  # pylint: disable=too-many-public-methods
     def call_asgi(
         self,
         app: Any = None,
-        base_url: Optional[str] = "http://testserver",
+        base_url: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
         **kwargs: Any,
     ) -> requests.Response:
@@ -384,6 +384,8 @@ class Case:  # pylint: disable=too-many-public-methods
                 "ASGI application instance is required. "
                 "Please, set `app` argument in the schema constructor or pass it to `call_asgi`"
             )
+        if base_url is None:
+            base_url = self.get_full_base_url()
         client = ASGIClient(application)
 
         return self.call(base_url=base_url, session=client, headers=headers, **kwargs)

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -172,7 +172,7 @@ def test_asgi_interactions(fastapi_app):
     init, *ev, finished = from_schema(schema, store_interactions=True).execute()
     interaction = ev[1].result.interactions[0]
     assert interaction.status == Status.success
-    assert interaction.request.uri == "http://testserver/users"
+    assert interaction.request.uri == "http://localhost/users"
 
 
 @pytest.mark.operations("empty")


### PR DESCRIPTION
Fixes #1366 