### PR TITLE
fix: Generating illegal unicode surrogates in queries #1370

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2277,6 +2277,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1370: https://github.com/schemathesis/schemathesis/issues/1370
 .. _#1366: https://github.com/schemathesis/schemathesis/issues/1366
 .. _#1359: https://github.com/schemathesis/schemathesis/issues/1359
 .. _#1350: https://github.com/schemathesis/schemathesis/issues/1350

--- a/src/schemathesis/specs/openapi/_hypothesis.py
+++ b/src/schemathesis/specs/openapi/_hypothesis.py
@@ -87,7 +87,7 @@ def is_illegal_surrogate(item: Any) -> bool:
         return isinstance(value, str) and bool(re.search(r"[\ud800-\udfff]", value))
 
     if isinstance(item, list):
-        return any([check(item_) for item_ in item])
+        return any(check(item_) for item_ in item)
     return check(item)
 
 

--- a/src/schemathesis/specs/openapi/_hypothesis.py
+++ b/src/schemathesis/specs/openapi/_hypothesis.py
@@ -83,7 +83,12 @@ def is_valid_header(headers: Dict[str, Any]) -> bool:
 
 
 def is_illegal_surrogate(item: Any) -> bool:
-    return isinstance(item, str) and bool(re.search(r"[\ud800-\udfff]", item))
+    def check(value: Any) -> bool:
+        return isinstance(value, str) and bool(re.search(r"[\ud800-\udfff]", value))
+
+    if isinstance(item, list):
+        return any([check(item_) for item_ in item])
+    return check(item)
 
 
 def is_valid_query(query: Dict[str, Any]) -> bool:

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -358,7 +358,10 @@ def test_optional_form_data(openapi3_base_url, empty_open_api_3_schema):
     inner()
 
 
-@pytest.mark.parametrize("value, expected", (({"key": "1"}, True), ({"key": 1}, True), ({"key": "\udcff"}, False)))
+@pytest.mark.parametrize(
+    "value, expected",
+    (({"key": "1"}, True), ({"key": 1}, True), ({"key": "\udcff"}, False), ({"key": ["1", "abc", "\udcff"]}, False)),
+)
 def test_is_valid_query(value, expected):
     assert is_valid_query(value) == expected
 


### PR DESCRIPTION
fixes #1370 