### PR TITLE
Update example docker files

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -10,8 +10,3 @@ RUN apt-get update \
     && apt -y autoremove \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
-
-COPY test/ /example/test/
-COPY main.py /example
-
-CMD [ "python", "/example/main.py" ]

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,12 +1,4 @@
 FROM python:3.8.7-slim
 
 COPY requirements.txt ./
-
-RUN apt-get update \
-    # Can't find wheels for asyncpg for some reason :(
-    && apt-get install --no-install-recommends -y libpq-dev gcc \
-    && pip install -r requirements.txt \
-    && apt remove -y libpq-dev gcc \
-    && apt -y autoremove \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+RUN pip install -r requirements.txt

--- a/example/README.rst
+++ b/example/README.rst
@@ -18,7 +18,7 @@ Start the application via `docker-compose`:
 
     docker-compose up
 
-It will spin up a web server available at ``http://0.0.0.0:5000``. You can take a look at API documentation at ``http://0.0.0.0:5000/api/ui/``.
+It will spin up a web server available at ``http://127.0.0.1:5000``. You can take a look at API documentation at ``http://127.0.0.1:5000/api/ui/``.
 Note, the app will run in the current terminal.
 
 Install ``schemathesis`` via ``pip`` to a virtual environment:
@@ -57,7 +57,7 @@ Here are examples of how you can run Schemathesis CLI:
 
 .. code:: bash
 
-    export SCHEMA_URL="http://0.0.0.0:5000/api/openapi.json"
+    export SCHEMA_URL="http://127.0.0.1:5000/api/openapi.json"
     export PYTHONPATH=$(pwd)
 
     # Default config. Runs unit tests for all API operations with `not_a_server_error` check

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -14,7 +14,10 @@ services:
       - db
     working_dir: /example
     volumes:
-      - ./app:/example/app/
+      - ./app/:/example/app/
+      - ./main.py:/example/main.py
+    entrypoint: python /example/main.py
+
   db:
     image: postgres
     environment:

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     entrypoint: python /example/main.py
 
   db:
-    image: postgres
+    image: postgres:14
     environment:
       POSTGRES_PASSWORD: test
       POSTGRES_USER: test

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -2,6 +2,9 @@ version: '3.1'
 
 services:
   web:
+    deploy:
+      restart_policy:
+        condition: on-failure
     build: .
     ports:
       - "127.0.0.1:5000:5000"

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   web:
     build: .
     ports:
-      - "5000:5000"
+      - "127.0.0.1:5000:5000"
     environment:
       - PYTHONUNBUFFERED=0
     depends_on:

--- a/example/test/test_app.py
+++ b/example/test/test_app.py
@@ -3,7 +3,7 @@ from hypothesis import settings
 
 import schemathesis
 
-schema = schemathesis.from_uri("http://0.0.0.0:5000/api/openapi.json")
+schema = schemathesis.from_uri("http://127.0.0.1:5000/api/openapi.json")
 
 
 @pytest.fixture


### PR DESCRIPTION
### Description

Simplified and stabilized docker-related stuff in `example` dir:

1. removed unused deb-packages which were needed to build some old `asyng` wheels
2. binded web app port to `127.0.0.1` instead of `0.0.0.0` , it's more secure
3. added option to recreate web app container on failure, it helps to start web app in robust way
4. fixed depended docker image version to `postgres:14`, the current one
5. mounted `main.py` to containter (run-time dependency) instead of copying it (build-time dependency)