### PR TITLE
chore: Validate `requests` kwargs to catch cases when the ASGI integration is used, but the proper ASGI client is not supplied

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Changed**
+
+- Validate ``requests`` kwargs to catch cases when the ASGI integration is used, but the proper ASGI client is not supplied. `#1335`_
+
 `3.13.3`_ - 2022-02-20
 ----------------------
 
@@ -2339,6 +2343,7 @@ Deprecated
 .. _#1342: https://github.com/schemathesis/schemathesis/issues/1342
 .. _#1340: https://github.com/schemathesis/schemathesis/issues/1340
 .. _#1336: https://github.com/schemathesis/schemathesis/issues/1336
+.. _#1335: https://github.com/schemathesis/schemathesis/issues/1335
 .. _#1331: https://github.com/schemathesis/schemathesis/issues/1331
 .. _#1328: https://github.com/schemathesis/schemathesis/issues/1328
 .. _#1325: https://github.com/schemathesis/schemathesis/issues/1325

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -401,6 +401,24 @@ in this case, the test execution will go much faster.
         response = case.call_wsgi()
         case.validate_response(response)
 
+If you don't supply the ``app`` argument to the loader, make sure you pass your test client when running tests:
+
+.. code-block:: python
+
+    @pytest.fixture()
+    def app_schema(client):
+        openapi = client.app.openapi()
+        return schemathesis.from_dict(openapi)
+
+
+    schema = schemathesis.from_pytest_fixture("app_schema")
+
+
+    @schema.parametrize()
+    def test_api(case, client):
+        # The `session` argument must be supplied.
+        case.call_and_validate(session=client)
+
 Unittest support
 ----------------
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -204,6 +204,19 @@ def test_call_and_validate(openapi3_schema_url):
     test()
 
 
+@pytest.mark.operations("success")
+def test_call_asgi_and_validate(fastapi_app):
+    api_schema = schemathesis.from_dict(fastapi_app.openapi())
+
+    @given(case=api_schema["/users"]["GET"].as_strategy())
+    @settings(max_examples=1)
+    def test(case):
+        with pytest.raises(RuntimeError, match="The URL should be absolute"):
+            case.call_and_validate()
+
+    test()
+
+
 def test_case_partial_deepcopy(swagger_20):
     operation = APIOperation("/example/path", "GET", {}, swagger_20)
     original_case = Case(


### PR DESCRIPTION
Resolves #1335 