### PR TITLE
dependency: change werkzeug version range to < 2.1.0 to fix error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ pytest-subtests = ">=0.2.1,<1.0"
 requests = "^2.22"
 click = "^8.0"
 importlib_metadata = { version = ">=1.1,!=3.8", python = "<3.8" }
-werkzeug = ">=0.16.0"
+werkzeug = ">=0.16.0,<2.1.0"
 junit-xml = "^1.9"
 starlette = ">=0.13,<1"
 yarl = "^1.5"


### PR DESCRIPTION


🚨Please review the [guidelines for contributing](https://github.com/schemathesis/schemathesis/blob/master/CONTRIBUTING.rst) to this repository.

### Description
change werkzeug version range to < 2.1.0 to fix ModuleNotFoundError

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Added a changelog entry
- [ ] Extended the README / documentation, if necessary
