### PR TITLE
fix: Missing `source` attribute in the `Case.partial_deepcopy` implementation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,10 @@ Changelog
 - Do not validate API schema by default. To enable it back, use `--validate-schema=true`.
 - Add the ``api_slug`` CLI argument to upload data to Schemathesis.io.
 
+**Fixed**
+
+- Missing ``source`` attribute in the ``Case.partial_deepcopy`` implementation. `#1429`
+
 `3.13.8`_ - 2022-04-05
 ----------------------
 
@@ -2385,6 +2389,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1429: https://github.com/schemathesis/schemathesis/issues/1429
 .. _#1425: https://github.com/schemathesis/schemathesis/issues/1425
 .. _#1410: https://github.com/schemathesis/schemathesis/issues/1410
 .. _#1395: https://github.com/schemathesis/schemathesis/issues/1395

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -62,6 +62,7 @@ from .utils import (
     NOT_SET,
     GenericResponse,
     WSGIResponse,
+    copy_response,
     deprecated_property,
     get_response_payload,
     maybe_set_assertion_message,
@@ -78,6 +79,9 @@ class CaseSource:
 
     case: "Case" = attr.ib()  # pragma: no mutate
     response: GenericResponse = attr.ib()  # pragma: no mutate
+
+    def partial_deepcopy(self) -> "CaseSource":
+        return self.__class__(case=self.case.partial_deepcopy(), response=copy_response(self.response))
 
 
 def cant_serialize(media_type: str) -> NoReturn:  # type: ignore
@@ -468,6 +472,7 @@ class Case:  # pylint: disable=too-many-public-methods
             operation=self.operation.partial_deepcopy(),
             data_generation_method=self.data_generation_method,
             media_type=self.media_type,
+            source=self.source if self.source is None else self.source.partial_deepcopy(),
             path_parameters=deepcopy(self.path_parameters),
             headers=deepcopy(self.headers),
             cookies=deepcopy(self.cookies),

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -8,7 +8,7 @@ from hypothesis import given, settings
 import schemathesis
 from schemathesis.constants import USER_AGENT, DataGenerationMethod
 from schemathesis.exceptions import CheckFailed, UsageError
-from schemathesis.models import APIOperation, Case, Request, Response
+from schemathesis.models import APIOperation, Case, CaseSource, Request, Response
 
 
 @pytest.fixture
@@ -259,6 +259,17 @@ def test_case_partial_deepcopy_same_generated_code(swagger_20):
         body={"b": 1},
     )
     assert original_case.as_curl_command() == original_case.partial_deepcopy().as_curl_command()
+
+
+def test_case_partial_deepcopy_source(swagger_20):
+    operation = APIOperation("/example/path", "GET", {}, swagger_20)
+    original_case = Case(operation=operation)
+    response = requests.Response()
+    response.status_code = 500
+    original_case.source = CaseSource(case=Case(operation=operation, query={"first": 1}), response=response)
+    copied_case = original_case.partial_deepcopy()
+    assert copied_case.source.case.query == original_case.source.case.query
+    assert copied_case.source.response.status_code == original_case.source.response.status_code
 
 
 def test_validate_response(testdir):


### PR DESCRIPTION
Resolves #1429 