### PR TITLE
fix: Duplicated failure message from `content_type_conformance` and `response_schema_conformance` checks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ Changelog
 **Fixed**
 
 - Missing ``source`` attribute in the ``Case.partial_deepcopy`` implementation. `#1429`
+- Duplicated failure message from ``content_type_conformance`` and ``response_schema_conformance`` checks when the checked response has no ``Content-Type`` header. `#1394`_
 
 `3.13.8`_ - 2022-04-05
 ----------------------
@@ -2396,6 +2397,7 @@ Deprecated
 .. _#1425: https://github.com/schemathesis/schemathesis/issues/1425
 .. _#1410: https://github.com/schemathesis/schemathesis/issues/1410
 .. _#1395: https://github.com/schemathesis/schemathesis/issues/1395
+.. _#1394: https://github.com/schemathesis/schemathesis/issues/1394
 .. _#1370: https://github.com/schemathesis/schemathesis/issues/1370
 .. _#1366: https://github.com/schemathesis/schemathesis/issues/1366
 .. _#1359: https://github.com/schemathesis/schemathesis/issues/1359

--- a/src/schemathesis/failures.py
+++ b/src/schemathesis/failures.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import attr
 
@@ -13,6 +13,10 @@ class FailureContext:
     message: str
     type: str
 
+    def unique_by_key(self, check_message: Optional[str]) -> Tuple[str, ...]:
+        """A key to distinguish different failure contexts."""
+        return (check_message or self.message,)
+
 
 @attr.s(slots=True, repr=False)
 class ValidationErrorContext(FailureContext):
@@ -26,6 +30,10 @@ class ValidationErrorContext(FailureContext):
     title: str = attr.ib(default="Non-conforming response payload")
     message: str = attr.ib(default="Response does not conform to the defined schema")
     type: str = attr.ib(default="json_schema")
+
+    def unique_by_key(self, check_message: Optional[str]) -> Tuple[str, ...]:
+        # Deduplicate by JSON Schema path. All errors that happened on this sub-schema will be deduplicated
+        return ("/".join(map(str, self.schema_path)),)
 
 
 @attr.s(slots=True, repr=False)

--- a/src/schemathesis/specs/openapi/checks.py
+++ b/src/schemathesis/specs/openapi/checks.py
@@ -56,8 +56,10 @@ def content_type_conformance(response: GenericResponse, case: "Case") -> Optiona
         return None
     content_type = response.headers.get("Content-Type")
     if not content_type:
+        formatted_media_types = "\n    ".join(defined_content_types)
         raise get_missing_content_type_error()(
-            "Response is missing the `Content-Type` header",
+            "The response is missing the `Content-Type` header. The schema defines the following media types:\n\n"
+            f"    {formatted_media_types}",
             context=failures.MissingContentType(defined_content_types),
         )
     for option in defined_content_types:


### PR DESCRIPTION
Fixes #1394 