### PR TITLE
feat: Do not encode payloads in cassettes as base64 by default

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,11 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Changed**
+
+- Do not encode payloads in cassettes as base64 by default. This change makes Schemathesis match the default Ruby's VCR behavior and
+  leads to more human-readable cassettes. Use ``--cassette-preserve-exact-body-bytes`` to restore the old behavior. `#1413`_
+
 `3.14.2`_ - 2022-04-21
 ----------------------
 
@@ -2435,6 +2440,7 @@ Deprecated
 .. _#1445: https://github.com/schemathesis/schemathesis/issues/1445
 .. _#1429: https://github.com/schemathesis/schemathesis/issues/1429
 .. _#1425: https://github.com/schemathesis/schemathesis/issues/1425
+.. _#1413: https://github.com/schemathesis/schemathesis/issues/1413
 .. _#1410: https://github.com/schemathesis/schemathesis/issues/1410
 .. _#1395: https://github.com/schemathesis/schemathesis/issues/1395
 .. _#1394: https://github.com/schemathesis/schemathesis/issues/1394

--- a/src/schemathesis/cli/callbacks.py
+++ b/src/schemathesis/cli/callbacks.py
@@ -14,6 +14,9 @@ from ..constants import CodeSampleStyle, DataGenerationMethod
 from ..stateful import Stateful
 from .constants import DEFAULT_WORKERS
 
+MISSING_CASSETTE_PATH_ARGUMENT_MESSAGE = (
+    'Missing argument, "--cassette-path" should be specified as well if you use "--cassette-preserve-exact-body-bytes".'
+)
 INVALID_SCHEMA_MESSAGE = "Invalid SCHEMA, must be a valid URL, file path or an API slug from Schemathesis.io."
 
 
@@ -166,6 +169,12 @@ def validate_request_cert_key(
 ) -> Optional[str]:
     if raw_value is not None and "request_cert" not in ctx.params:
         raise click.UsageError('Missing argument, "--request-cert" should be specified as well.')
+    return raw_value
+
+
+def validate_preserve_exact_body_bytes(ctx: click.core.Context, param: click.core.Parameter, raw_value: bool) -> bool:
+    if raw_value and ctx.params["cassette_path"] is None:
+        raise click.UsageError(MISSING_CASSETTE_PATH_ARGUMENT_MESSAGE)
     return raw_value
 
 

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -826,7 +826,7 @@ class Request:
             uri=uri,
             method=method,
             headers={key: [value] for (key, value) in prepared.headers.items()},
-            body=base64.b64encode(body).decode() if body is not None else body,
+            body=serialize_payload(body) if body is not None else body,
         )
 
 

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -290,7 +290,10 @@ def test_commands_run_help(cli):
         "                                  reproduction.",
         "  --cassette-path FILENAME        Save test results as a VCR-compatible",
         "                                  cassette.",
-        "  --store-network-log FILENAME    Store requests and responses into a file.",
+        "  --cassette-preserve-exact-body-bytes",
+        "                                  Encode payloads in cassettes as base64.",
+        "  --store-network-log FILENAME    [DEPRECATED] Store requests and responses into",
+        "                                  a file.",
         "  --fixups [fast_api|all]         Install specified compatibility fixups.",
         "  --stateful [none|links]         Utilize stateful testing capabilities.",
         "  --stateful-recursion-limit INTEGER RANGE",
@@ -1490,7 +1493,7 @@ def test_multipart_upload(testdir, tmp_path, hypothesis_max_examples, openapi3_b
         request = cassette["http_interactions"][idx]["request"]
         if "body" not in request:
             return None
-        return base64.b64decode(request["body"]["base64_string"])
+        return request["body"]["string"].encode()
 
     first_decoded = decode(0)
     if first_decoded:
@@ -2041,6 +2044,7 @@ def assert_exit_code(event_stream, code):
             show_errors_tracebacks=False,
             validate_schema=False,
             cassette_path=None,
+            cassette_preserve_exact_body_bytes=False,
             junit_xml=None,
             verbosity=0,
             code_sample_style=CodeSampleStyle.default(),


### PR DESCRIPTION
Resolves #1413 

TODO:
- [x] Parametrize existing tests with "--cassette-preserve-exact-body-bytes"
- [x] Re-check coverage
- [x] Write docstrings & comments
- [x] Fix Windows issue
- [x] Test `validate_preserve_exact_body_bytes`
- [x] test empty content in body during replay