### PR TITLE
feat: Make the `SCHEMA` CLI argument accept API slug from Schemathesis.io

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Changelog
 - ``X-Schemathesis-TestCaseId`` header to help to distinguish test cases on the application side. `#1303`_
 - Support for comma separated lists in the ``--checks`` CLI option. `#1373`_
 - Hypothesis Database configuration for CLI via the ``--hypothesis-database`` option. `#1326`_
+- Make the ``SCHEMA`` CLI argument accept API slugs from Schemathesis.io.
 
 **Changed**
 

--- a/src/schemathesis/service/__init__.py
+++ b/src/schemathesis/service/__init__.py
@@ -15,3 +15,4 @@ from .constants import (
 )
 from .events import Completed, Error, Event, Timeout
 from .handler import ServiceReporter
+from .models import TestRun

--- a/src/schemathesis/service/client.py
+++ b/src/schemathesis/service/client.py
@@ -8,7 +8,7 @@ from requests.adapters import HTTPAdapter, Retry
 from ..constants import USER_AGENT
 from .constants import REQUEST_TIMEOUT
 from .metadata import Metadata
-from .models import AuthResponse, TestRun
+from .models import ApiConfig, AuthResponse, TestRun
 
 
 class ServiceClient(requests.Session):
@@ -37,7 +37,12 @@ class ServiceClient(requests.Session):
         """Create a new test run on the Schemathesis.io side."""
         response = self.post("/runs/", json={"api_slug": api_slug})
         data = response.json()
-        return TestRun(run_id=data["run_id"], short_url=data["short_url"])
+        config = data["config"]
+        return TestRun(
+            run_id=data["run_id"],
+            short_url=data["short_url"],
+            config=ApiConfig(location=config["location"], base_url=config["base_url"]),
+        )
 
     def finish_test_run(self, run_id: str) -> None:
         """Finish a test run on the Schemathesis.io side.

--- a/src/schemathesis/service/models.py
+++ b/src/schemathesis/service/models.py
@@ -1,10 +1,19 @@
+from typing import Optional
+
 import attr
+
+
+@attr.s(slots=True)
+class ApiConfig:
+    location: str = attr.ib()
+    base_url: Optional[str] = attr.ib()
 
 
 @attr.s(slots=True)
 class TestRun:
     run_id: str = attr.ib()
     short_url: str = attr.ib()
+    config: ApiConfig = attr.ib()
 
 
 @attr.s(slots=True)

--- a/test/cli/test_callbacks.py
+++ b/test/cli/test_callbacks.py
@@ -7,22 +7,23 @@ from hypothesis import strategies as st
 
 from schemathesis import utils
 from schemathesis.cli import callbacks
+from schemathesis.cli.callbacks import SchemaInputKind
 
 from ..utils import SIMPLE_PATH
 
 
-@given(value=st.text().filter(lambda x: "//" not in x))
-@example("0" * 1000)
-@example("//test")
-@example("//ÿ[")
-def test_validate_schema(value):
+@pytest.mark.parametrize("value", ("//test", "//ÿ["))
+def test_parse_schema_kind(value):
     with pytest.raises(click.UsageError):
-        callbacks.validate_schema(SimpleNamespace(params={}), None, value)
+        kind = callbacks.parse_schema_kind(value, app=None)
+        callbacks.validate_schema(value, kind, base_url=None, dry_run=False, app=None, api_slug=None)
 
 
 def test_validate_schema_path_without_base_url():
     with pytest.raises(click.UsageError):
-        callbacks.validate_schema(SimpleNamespace(params={}), None, SIMPLE_PATH)
+        callbacks.validate_schema(
+            SIMPLE_PATH, SchemaInputKind.PATH, base_url=None, dry_run=False, app=None, api_slug=None
+        )
 
 
 @given(value=st.text().filter(lambda x: x.count(":") != 1))

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -20,6 +20,7 @@ from hypothesis.database import DirectoryBasedExampleDatabase, InMemoryExampleDa
 from schemathesis import Case, DataGenerationMethod, fixups, service
 from schemathesis.checks import ALL_CHECKS, not_a_server_error
 from schemathesis.cli import LoaderConfig, execute, get_exit_code, reset_checks
+from schemathesis.cli.callbacks import INVALID_SCHEMA_MESSAGE
 from schemathesis.constants import DEFAULT_RESPONSE_TIMEOUT, SCHEMATHESIS_TEST_CASE_HEADER, USER_AGENT, CodeSampleStyle
 from schemathesis.hooks import unregister_all
 from schemathesis.models import APIOperation
@@ -65,7 +66,7 @@ def test_commands_version(cli):
     "args, error",
     (
         (("run",), "Error: Missing argument 'SCHEMA'."),
-        (("run", "not-url"), "Error: Invalid SCHEMA, must be a valid URL or file path."),
+        (("run", "not-url"), "See https://schemathesis.readthedocs.io/en/stable/service.html for more details"),
         (("run", SIMPLE_PATH), 'Error: Missing argument, "--base-url" is required for SCHEMA specified by file.'),
         (("run", SIMPLE_PATH, "--base-url=test"), "Error: Invalid base URL"),
         (("run", SIMPLE_PATH, "--base-url=127.0.0.1:8080"), "Error: Invalid base URL"),
@@ -134,7 +135,7 @@ def test_commands_version(cli):
             ("run", "http://127.0.0.1", "--header=test:тест"),
             "Error: Invalid value for '--header' / '-H': Header value should be latin-1 encodable",
         ),
-        (("run", "//test"), "Error: Invalid SCHEMA, must be a valid URL or file path."),
+        (("run", "//test"), f"Error: {INVALID_SCHEMA_MESSAGE}"),
         (
             ("run", "http://127.0.0.1", "--max-response-time=0"),
             "Error: Invalid value for '--max-response-time': 0 is not in the range x>=1.",
@@ -2047,9 +2048,9 @@ def assert_exit_code(event_stream, code):
             verbosity=0,
             code_sample_style=CodeSampleStyle.default(),
             debug_output_file=None,
-            schemathesis_io_token=None,
             schemathesis_io_url=service.DEFAULT_URL,
-            api_slug=None,
+            client=None,
+            test_run=None,
         )
     assert exc.value.code == code
 

--- a/test/service/conftest.py
+++ b/test/service/conftest.py
@@ -69,9 +69,18 @@ def create_event_url(setup_server, run_id):
 
 
 @pytest.fixture
-def start_run_url(setup_server, run_id):
+def start_run_url(setup_server, run_id, openapi3_schema_url):
     return setup_server(
-        lambda h: h.respond_with_json({"run_id": run_id, "short_url": "http://127.0.0.1"}, status=201), "POST", "/runs/"
+        lambda h: h.respond_with_json(
+            {
+                "run_id": run_id,
+                "short_url": "http://127.0.0.1",
+                "config": {"location": openapi3_schema_url, "base_url": None},
+            },
+            status=201,
+        ),
+        "POST",
+        "/runs/",
     )
 
 


### PR DESCRIPTION
The main idea is to enable people to run `st run slug` where "slug" is a shortcut name for an API in Schemathesis.io, so the actual schema address could be loaded from there.

It would be nice to avoid calling the service for API config before validating the "api_slug" argument - maybe assume that if `SCHEMA` is not an URL / path, then it is always a slug, then just throw an error if `api_slug` is present?

TODO:
- [ ] Update the docs
- [ ] docstrings
- [x] Write the tests
- [x] Validate `api_slug`
- [x] Load config from Schemathesis.io & merge it