### PR TITLE
fix: Compatibility with `pytest>=7.0`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,12 +111,44 @@ jobs:
         with:
           file: ./coverage.xml
 
-  pytest-legacy:
+  pytest-5:
     strategy:
       matrix:
         os: [ubuntu-20.04]
         tox_job:
           - py3-pytest53
+
+    name: ${{ matrix.os }}/tests_${{ matrix.tox_job }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3.0.0
+      with:
+        fetch-depth: 1
+
+    - uses: actions/setup-python@v3.1.0
+      with:
+        python-version: 3.7
+
+    - run: pip install tox coverage poetry
+
+    - name: Run ${{ matrix.tox_job }} tox job
+      run: tox -e ${{ matrix.tox_job }}
+
+    - run: coverage combine
+    - run: coverage report
+    - run: coverage xml -i
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3.0.0
+      with:
+        file: ./coverage.xml
+
+  pytest-6:
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        tox_job:
+          - py3-pytest6
 
     name: ${{ matrix.os }}/tests_${{ matrix.tox_job }}
     runs-on: ${{ matrix.os }}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Using ``@schema.parametrize`` with test methods on ``pytest>=7.0``.
+
 `3.14.0`_ - 2022-04-17
 ----------------------
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -593,11 +593,11 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "pytest"
-version = "6.2.5"
+version = "7.1.1"
 description = "pytest: simple powerful testing with Python"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
@@ -608,10 +608,10 @@ iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
 py = ">=1.8.2"
-toml = "*"
+tomli = ">=1.0.0"
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
@@ -882,14 +882,6 @@ typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 full = ["itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests", "graphene"]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
-category = "main"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -977,7 +969,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "d07ab6df799d143855d92728aba2010f4efa57f8ba40fc615628eb6e11a870f1"
+content-hash = "9e5c4a36c03ff73179bebed9d807d764fb259c8710b7f0f99f75ee2ee65eb8ee"
 
 [metadata.files]
 aiohttp = [
@@ -1606,8 +1598,8 @@ pyrsistent = [
     {file = "pyrsistent-0.18.0.tar.gz", hash = "sha256:773c781216f8c2900b42a7b638d5b517bb134ae1acbebe4d1e8f1f41ea60eb4b"},
 ]
 pytest = [
-    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
-    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+    {file = "pytest-7.1.1-py3-none-any.whl", hash = "sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea"},
+    {file = "pytest-7.1.1.tar.gz", hash = "sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63"},
 ]
 pytest-asyncio = [
     {file = "pytest-asyncio-0.17.2.tar.gz", hash = "sha256:6d895b02432c028e6957d25fc936494e78c6305736e785d9fee408b1efbc7ff4"},
@@ -1723,10 +1715,6 @@ sphinxcontrib-serializinghtml = [
 starlette = [
     {file = "starlette-0.16.0-py3-none-any.whl", hash = "sha256:38eb24bf705a2c317e15868e384c1b8a12ca396e5a3c3a003db7e667c43f939f"},
     {file = "starlette-0.16.0.tar.gz", hash = "sha256:e1904b5d0007aee24bdd3c43994be9b3b729f4f58e740200de1d623f8c3a8870"},
-]
-toml = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ tomli-w = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 coverage = "^5"
-pytest = "^6.0"
 aiohttp = "^3.6"
 graphene = "^3.0b3"
 graphql-server = "^3.0.0b4"

--- a/src/schemathesis/constants.py
+++ b/src/schemathesis/constants.py
@@ -13,6 +13,7 @@ except metadata.PackageNotFoundError:
     __version__ = "dev"
 
 IS_PYTEST_ABOVE_54 = version.parse(pytest.__version__) >= version.parse("5.4.0")
+IS_PYTEST_ABOVE_7 = version.parse(pytest.__version__) >= version.parse("7.0.0")
 
 USER_AGENT = f"schemathesis/{__version__}"
 SCHEMATHESIS_TEST_CASE_HEADER = "X-Schemathesis-TestCaseId"

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -3,7 +3,17 @@ import sys
 from pathlib import Path
 
 import pytest
-from _pytest import pytester
+
+from schemathesis.constants import IS_PYTEST_ABOVE_7
+
+if IS_PYTEST_ABOVE_7:
+    from _pytest.pytester import Pytester
+
+    TimeoutExpired = Pytester.TimeoutExpired
+else:
+    from _pytest import pytester
+
+    TimeoutExpired = pytester.Testdir.TimeoutExpired
 
 HERE = Path(__file__).absolute().parent
 
@@ -27,7 +37,7 @@ def test_app(testdir, aiohttp_unused_port, framework, expected):
         timeout = 4.0
     else:
         timeout = 2.0
-    with pytest.raises(pytester.Testdir.TimeoutExpired):
+    with pytest.raises(TimeoutExpired):
         testdir.run(
             sys.executable, str(HERE / "apps/__init__.py"), str(port), f"--framework={framework}", timeout=timeout
         )

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -13,6 +13,9 @@ def test_pytest_parametrize_fixture(testdir):
     # When `pytest_generate_tests` is used on a module level for fixture parametrization
     testdir.make_test(
         """
+from hypothesis import settings, HealthCheck
+
+
 def pytest_generate_tests(metafunc):
     metafunc.parametrize("inner", ("A", "B"))
 
@@ -21,6 +24,7 @@ def param(inner):
     return inner * 2
 
 @schema.parametrize()
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_(request, param, case):
     request.config.HYPOTHESIS_CASES += 1
     assert case.full_path == "/v1/users"
@@ -53,6 +57,9 @@ def test_pytest_parametrize_class_fixture(testdir):
     # When `pytest_generate_tests` is used on a class level for fixture parametrization
     testdir.make_test(
         """
+from hypothesis import settings, HealthCheck
+
+
 class TestAPI:
 
     def pytest_generate_tests(self, metafunc):
@@ -63,6 +70,7 @@ class TestAPI:
         return inner * 2
 
     @schema.parametrize()
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
     def test_(self, request, param, case):
         request.config.HYPOTHESIS_CASES += 1
         assert case.full_path == "/v1/users"

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 isolated_build = true
 envlist =
   py{36,37,38,39,310},
-  py3-pytest53
+  py3-pytest53,
+  py3-pytest6,
   coverage-report
 
 [testenv]
@@ -17,6 +18,12 @@ allowlist_externals =
 commands =
   poetry install -v
   poetry run pip install "pytest<5.4" "pytest-asyncio<0.11.0"
+  coverage run --source=schemathesis -m pytest {posargs:} test
+
+[testenv:py3-pytest6]
+commands =
+  poetry install -v
+  poetry run pip install "pytest<7"
   coverage run --source=schemathesis -m pytest {posargs:} test
 
 [testenv:coverage-report]


### PR DESCRIPTION
That is an ugly hack for now :(

TODO:
- [x] Add a separate job for pytest 6
- [x] Make the tests pass under pytest 5, 6, 7
- [ ] Avoid using `_is_pytest`
- [x] Fix fails on class-based tests