### PR TITLE
fix: Internal error inside `BaseOpenAPISchema.validate_response` on `requests>=2.27` when response body contains malformed JSON

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,7 @@ Changelog
 **Fixed**
 
 - **GraphQL**: Semantically invalid queries without aliases.
+- Internal error inside ``BaseOpenAPISchema.validate_response`` on ``requests>=2.27`` when response body contains malformed JSON. `#1485`_
 
 **Performance**
 
@@ -2851,6 +2852,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1485: https://github.com/schemathesis/schemathesis/issues/1485
 .. _#1452: https://github.com/schemathesis/schemathesis/issues/1452
 .. _#1445: https://github.com/schemathesis/schemathesis/issues/1445
 .. _#1429: https://github.com/schemathesis/schemathesis/issues/1429

--- a/poetry.lock
+++ b/poetry.lock
@@ -688,7 +688,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "requests"
-version = "2.26.0"
+version = "2.27.1"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
@@ -972,7 +972,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "81be765c346a39c1b02e9deab99e8240dfc6436faca24e1b6e0e2af44b846d03"
+content-hash = "adbe53a2ee80ac7064102623dedc9382613b5bbc62fa77dc6d71c01bc84cf41f"
 
 [metadata.files]
 aiohttp = [
@@ -1624,8 +1624,8 @@ pyyaml = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 requests = [
-    {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
-    {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
+    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ jsonschema = "^4.3.2"
 pytest = ">4.6.4"
 PyYAML = ">=5.1,<7.0"
 pytest-subtests = ">=0.2.1,<0.6.0"
-requests = ">=2.22,<2.27.0"
+requests = ">=2.22,<2.28.0"
 click = ">=7.0,<9.0"
 importlib_metadata = { version = ">=1.1,!=3.8", python = "<3.8" }
 werkzeug = ">=0.16.0,<2.2"

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -1,5 +1,6 @@
 # pylint: disable=too-many-ancestors
 import itertools
+import json
 from collections import defaultdict
 from contextlib import ExitStack, contextmanager
 from copy import deepcopy
@@ -474,7 +475,7 @@ class BaseOpenAPISchema(BaseSchema):
             return
         try:
             if isinstance(response, requests.Response):
-                data = response.json()
+                data = json.loads(response.text)
             else:
                 data = response.json
         except JSONDecodeError as exc:


### PR DESCRIPTION
Fixes #1485