### PR TITLE
Fix editable installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,5 +90,5 @@ known_first_party = "schemathesis"
 known_third_party = ["_pytest", "aiohttp", "attr", "click", "curlify", "fastapi", "flask", "graphene", "graphql", "graphql_server", "hypothesis", "hypothesis_graphql", "hypothesis_jsonschema", "jsonschema", "junit_xml", "packaging", "pydantic", "pytest", "pytest_subtests", "requests", "schemathesis", "starlette", "typing_extensions", "urllib3", "werkzeug", "yaml", "yarl"]
 
 [build-system]
-requires = ["poetry>=0.12", "setuptools"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.8"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
### Description
This pr fixes schemathesis editable installation via pip. Quite useful for local hacking i believe. :) 

Poetry-core implements PEP660 from version 1.0.8.

For more info see:
- https://github.com/python-poetry/poetry/issues/34#issuecomment-1054626460
- https://github.com/python-poetry/poetry/issues/5056
- https://github.com/python-poetry/poetry-core/pull/257

