### PR TITLE
fix: Do not re-raise `InvalidArgument` exception as `InvalidSchema` in non-Schemathesis tests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 **Fixed**
 
 - Deduplication of failures caused by malformed JSON payload. `#1518`_
+- Do not re-raise ``InvalidArgument`` exception as ``InvalidSchema`` in non-Schemathesis tests. `#1514`_
 
 .. _v3.15.2:
 
@@ -2901,6 +2902,7 @@ Deprecated
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
 .. _#1518: https://github.com/schemathesis/schemathesis/issues/1518
+.. _#1514: https://github.com/schemathesis/schemathesis/issues/1514
 .. _#1485: https://github.com/schemathesis/schemathesis/issues/1485
 .. _#1463: https://github.com/schemathesis/schemathesis/issues/1463
 .. _#1452: https://github.com/schemathesis/schemathesis/issues/1452

--- a/src/schemathesis/extra/pytest_plugin.py
+++ b/src/schemathesis/extra/pytest_plugin.py
@@ -238,13 +238,14 @@ def pytest_pyfunc_call(pyfuncitem):  # type:ignore
     if isinstance(pyfuncitem, SchemathesisFunction):
         with skip_unnecessary_hypothesis_output():
             outcome = yield
+        try:
+            outcome.get_result()
+        except InvalidArgument as exc:
+            raise InvalidSchema(exc.args[0]) from None
+        except HypothesisRefResolutionError:
+            pytest.skip(RECURSIVE_REFERENCE_ERROR_MESSAGE)
+        except SkipTest as exc:
+            pytest.skip(exc.args[0])
     else:
         outcome = yield
-    try:
         outcome.get_result()
-    except InvalidArgument as exc:
-        raise InvalidSchema(exc.args[0]) from None
-    except HypothesisRefResolutionError:
-        pytest.skip(RECURSIVE_REFERENCE_ERROR_MESSAGE)
-    except SkipTest as exc:
-        pytest.skip(exc.args[0])

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -517,3 +517,17 @@ def test_b(v):
     assert "Falsifying example: test_a(" not in stdout
     # And regular Hypothesis tests have it
     assert "Falsifying example: test_b(" in stdout
+
+
+def test_invalid_schema_reraising(testdir):
+    # When there is a non-Schemathesis test failing because of Hypothesis' `InvalidArgument` error
+    testdir.make_test(
+        """
+@given(st.integers(min_value=5, max_value=4))
+def test(value):
+    pass""",
+    )
+    # Then it should not be re-raised as `InvalidSchema`
+    result = testdir.runpytest()
+    result.assert_outcomes(failed=1)
+    assert "InvalidSchema: Cannot have" not in result.stdout.str()


### PR DESCRIPTION
Resolves #1514