### PR TITLE
fix: Do not discard dots in OpenAPI expressions during parsing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Do not discard dots (``.``) in OpenAPI expressions during parsing.
+
 .. _v3.15.5:
 
 `3.15.5`_ - 2022-06-21

--- a/src/schemathesis/specs/openapi/expressions/parser.py
+++ b/src/schemathesis/specs/openapi/expressions/parser.py
@@ -15,7 +15,7 @@ def _parse(expr: str) -> Generator[nodes.Node, None, None]:
     tokens = lexer.tokenize(expr)
     brackets_stack: List[str] = []
     for token in tokens:
-        if token.is_string:
+        if token.is_string or token.is_dot:
             yield nodes.String(token.value)
         elif token.is_variable:
             yield from _parse_variable(tokens, token, expr)

--- a/test/specs/openapi/test_expressions.py
+++ b/test/specs/openapi/test_expressions.py
@@ -73,6 +73,7 @@ def context(case, response):
         ("$response.body", DOCUMENT),
         ("ID_{$response.body#/g|h}", "ID_4"),
         ("ID_{$response.body#/g|h}_{$response.body#/a~1b}", "ID_4_1"),
+        ("eq.{$response.body#/g|h}", "eq.4"),
     ),
 )
 def test_evaluate(context, expr, expected):


### PR DESCRIPTION
### Description

Allow dots in OpenAPI expressions outside variable definitions. Currently, the parser discards these dots. With this PR, the parser outputs dots as strings.

#### Motivating example

[Postgrest horizontal filtering via query parameters](https://postgrest.org/en/stable/api.html#horizontal-filtering-rows):
```
GET /people?age=lt.13
GET /people?age=gte.18&student=is.true
GET /users?id=eq.42
```
OpenAPI links to these operations require the dot. E.g., `eq.{$response.body#/0/id}`. Currently, schemathesis outputs `id=eq42` that fails because of the missing dot. With this PR, the same expression outputs `id=eq.42` that works.

### Checklist
- [Y] Created tests which fail without the change (if possible)
- [Y] All tests passing
- [Y] Added a changelog entry
- [N/A] Extended the README / documentation, if necessary
