### PR TITLE
fix: Do not report optional headers as missing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Changelog
 
 **Fixed**
 
+- Do not report optional headers as missing.
 - Compatibility with ``hypothesis>=6.49``. `#1538`_
 - Handling of ``unittest.case.SkipTest`` emitted by newer Hypothesis versions.
 - Generating invalid headers when their schema has ``array`` or ``object`` types.

--- a/src/schemathesis/specs/openapi/checks.py
+++ b/src/schemathesis/specs/openapi/checks.py
@@ -99,7 +99,11 @@ def response_headers_conformance(response: GenericResponse, case: "Case") -> Opt
     if not defined_headers:
         return None
 
-    missing_headers = [header for header in defined_headers if header not in response.headers]
+    missing_headers = [
+        header
+        for header, definition in defined_headers.items()
+        if header not in response.headers and definition.get(case.operation.schema.header_required_field, False)
+    ]
     if not missing_headers:
         return None
     message = ",".join(missing_headers)

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -87,6 +87,7 @@ SCHEMA_PARSING_ERRORS = (KeyError, AttributeError, jsonschema.exceptions.RefReso
 class BaseOpenAPISchema(BaseSchema):
     nullable_name: str
     links_field: str
+    header_required_field: str
     security: BaseSecurityProcessor
     component_locations: ClassVar[Tuple[Tuple[str, ...], ...]] = ()
     _operations_by_id: Dict[str, APIOperation]
@@ -620,6 +621,7 @@ class SwaggerV20(BaseOpenAPISchema):
     nullable_name = "x-nullable"
     example_field = "x-example"
     examples_field = "x-examples"
+    header_required_field = "x-required"
     security = SwaggerSecurityProcessor()
     component_locations: ClassVar[Tuple[Tuple[str, ...], ...]] = (("definitions",),)
     links_field = "x-links"
@@ -787,6 +789,7 @@ class OpenApi30(SwaggerV20):  # pylint: disable=too-many-ancestors
     nullable_name = "nullable"
     example_field = "example"
     examples_field = "examples"
+    header_required_field = "required"
     security = OpenAPISecurityProcessor()
     component_locations = (("components", "schemas"),)
     links_field = "links"

--- a/test/apps/openapi/schema.py
+++ b/test/apps/openapi/schema.py
@@ -253,7 +253,9 @@ def _make_openapi_2_schema(operations: Tuple[str, ...]) -> Dict:
                     "200": {
                         "description": "OK",
                         "schema": {"type": "object"},
-                        "headers": {"X-Custom-Header": {"description": "Custom header", "type": "integer"}},
+                        "headers": {
+                            "X-Custom-Header": {"description": "Custom header", "type": "integer", "x-required": True}
+                        },
                     },
                     "default": {"description": "Default response"},
                 },
@@ -640,7 +642,13 @@ def _make_openapi_3_schema(operations: Tuple[str, ...]) -> Dict:
                     "200": {
                         "description": "OK",
                         "content": {"application/json": {"schema": {"type": "object"}}},
-                        "headers": {"X-Custom-Header": {"description": "Custom header", "schema": {"type": "integer"}}},
+                        "headers": {
+                            "X-Custom-Header": {
+                                "description": "Custom header",
+                                "schema": {"type": "integer"},
+                                "required": True,
+                            }
+                        },
                     },
                     "default": {"description": "Default response"},
                 },


### PR DESCRIPTION
Open API 2.0 headers do not support `required`, so use `x-required` instead (as this approach is already used for other cases like `nullable` & `example`)