### PR TITLE
misc: use black profile for isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,11 +81,9 @@ line-length = 120
 target_version = ["py37"]
 
 [tool.isort]
-# config compatible with Black
+profile = "black"
 line_length = 120
-multi_line_output = 3
 default_section = "THIRDPARTY"
-include_trailing_comma = true
 known_first_party = "schemathesis"
 known_third_party = ["_pytest", "aiohttp", "attr", "click", "curlify", "fastapi", "flask", "graphene", "graphql", "graphql_server", "hypothesis", "hypothesis_graphql", "hypothesis_jsonschema", "jsonschema", "junit_xml", "packaging", "pydantic", "pytest", "pytest_subtests", "requests", "schemathesis", "starlette", "typing_extensions", "urllib3", "werkzeug", "yaml", "yarl"]
 

--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -90,7 +90,7 @@ class BeforeExecution(CurrentOperationMixin, ExecutionEvent):
     recursion_level: int = attr.ib()  # pragma: no mutate
     # The way data will be generated
     data_generation_method: DataGenerationMethod = attr.ib()  # pragma: no mutate
-    # An unique ID which connects events that happen during testing of the same API operation
+    # A unique ID which connects events that happen during testing of the same API operation
     # It may be useful when multiple threads are involved where incoming events are not ordered
     correlation_id: str = attr.ib()  # pragma: no mutate
     thread_id: int = attr.ib(factory=threading.get_ident)  # pragma: no mutate


### PR DESCRIPTION
### Description
Hi,
this PR replaces manually configured options for `isort` with `profile=black` clause which does the same automatically, see https://pycqa.github.io/isort/docs/configuration/black_compatibility.html

There's also a typo fixed, but it didnt feel like it's worth creating a separate commit for it.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Added a changelog entry
- [ ] Extended the README / documentation, if necessary
