### PR TITLE
fix: verbosity help message

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Description of ``-v`` or ``--verbosity`` option for CLI.
+
 .. _v3.16.1:
 
 `3.16.1`_ - 2022-07-29

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -561,7 +561,7 @@ REPORT_TO_SERVICE = object()
     envvar=service.TELEMETRY_ENV_VAR,
 )
 @with_hosts_file
-@click.option("--verbosity", "-v", help="Increase verbosity of error output.", count=True)
+@click.option("--verbosity", "-v", help="Increase verbosity of the output.", count=True)
 @click.pass_context
 def run(
     ctx: click.Context,

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -561,7 +561,7 @@ REPORT_TO_SERVICE = object()
     envvar=service.TELEMETRY_ENV_VAR,
 )
 @with_hosts_file
-@click.option("--verbosity", "-v", help="Reduce verbosity of error output.", count=True)
+@click.option("--verbosity", "-v", help="Increase verbosity of error output.", count=True)
 @click.pass_context
 def run(
     ctx: click.Context,

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -325,7 +325,7 @@ def test_commands_run_help(cli):
         "                                  report.  [default: true]",
         "  --hosts-file FILE               Path to a file to store the Schemathesis.io",
         "                                  auth configuration.",
-        "  -v, --verbosity                 Increase verbosity of error output.",
+        "  -v, --verbosity                 Increase verbosity of the output.",
         "  -h, --help                      Show this message and exit.",
     ]
 

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -325,7 +325,7 @@ def test_commands_run_help(cli):
         "                                  report.  [default: true]",
         "  --hosts-file FILE               Path to a file to store the Schemathesis.io",
         "                                  auth configuration.",
-        "  -v, --verbosity                 Reduce verbosity of error output.",
+        "  -v, --verbosity                 Increase verbosity of error output.",
         "  -h, --help                      Show this message and exit.",
     ]
 


### PR DESCRIPTION
### Description
I've noticed this line in the docs (generated from the help message)
```
 -v, --verbosity Reduce verbosity of error output.
```
because usually it works the other way. After a brief check, I see that indeed MORE information is displayed when `-v` option is provided.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Added a changelog entry
- [ ] Extended the README / documentation, if necessary
