### PR TITLE
chore: Execute `before_call` / `after_call` hooks inside the `call_*` methods

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,10 @@ Changelog
 
 - Description of ``-v`` or ``--verbosity`` option for CLI.
 
+**Changed**
+
+- Execute ``before_call`` / ``after_call`` hooks inside the ``call_*`` methods. It makes them available for the ``pytest`` integration.
+
 .. _v3.16.1:
 
 `3.16.1`_ - 2022-07-29

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -39,7 +39,7 @@ from ..specs.openapi import loaders as oas_loaders
 from ..stateful import Stateful
 from ..targets import Target
 from ..types import Filter, PathLike, RequestCert
-from ..utils import GenericResponse, current_datetime, file_exists, get_requests_auth, import_app
+from ..utils import current_datetime, file_exists, get_requests_auth, import_app
 from . import callbacks, cassettes, output
 from .constants import DEFAULT_WORKERS, MAX_WORKERS, MIN_WORKERS
 from .context import ExecutionContext, FileReportContext, ServiceReportContext
@@ -1265,28 +1265,6 @@ def after_init_cli_run_handlers(
     """Called after CLI hooks are initialized.
 
     Might be used to add extra event handlers.
-    """
-
-
-@HookDispatcher.register_spec([HookScope.GLOBAL])
-def before_call(context: HookContext, case: Case) -> None:
-    """Called before every network call in CLI tests.
-
-    Use cases:
-     - Modification of `case`. For example, adding some pre-determined value to its query string.
-     - Logging
-    """
-
-
-@HookDispatcher.register_spec([HookScope.GLOBAL])
-def after_call(context: HookContext, case: Case, response: GenericResponse) -> None:
-    """Called after every network call in CLI tests.
-
-    Note that you need to modify the response in-place.
-
-    Use cases:
-     - Response post-processing, like modifying its payload.
-     - Logging
     """
 
 

--- a/src/schemathesis/hooks.py
+++ b/src/schemathesis/hooks.py
@@ -270,6 +270,28 @@ def add_case(context: HookContext, case: "Case", response: GenericResponse) -> O
     """
 
 
+@HookDispatcher.register_spec([HookScope.GLOBAL])
+def before_call(context: HookContext, case: "Case") -> None:
+    """Called before every network call in CLI tests.
+
+    Use cases:
+     - Modification of `case`. For example, adding some pre-determined value to its query string.
+     - Logging
+    """
+
+
+@HookDispatcher.register_spec([HookScope.GLOBAL])
+def after_call(context: HookContext, case: "Case", response: GenericResponse) -> None:
+    """Called after every network call in CLI tests.
+
+    Note that you need to modify the response in-place.
+
+    Use cases:
+     - Response post-processing, like modifying its payload.
+     - Logging
+    """
+
+
 GLOBAL_HOOK_DISPATCHER = HookDispatcher(scope=HookScope.GLOBAL)
 dispatch = GLOBAL_HOOK_DISPATCHER.dispatch
 get_all_by_name = GLOBAL_HOOK_DISPATCHER.get_all_by_name

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -610,7 +610,6 @@ def _network_test(
     check_results: List[Check] = []
     try:
         hook_context = HookContext(operation=case.operation)
-        hooks.dispatch("before_call", hook_context, case)
         kwargs: Dict[str, Any] = {
             "session": session,
             "headers": headers,
@@ -620,7 +619,6 @@ def _network_test(
         }
         hooks.dispatch("process_call_kwargs", hook_context, case, kwargs)
         response = case.call(**kwargs)
-        hooks.dispatch("after_call", hook_context, case, response)
     except CheckFailed as exc:
         check_name = "request_timeout"
         requests_kwargs = case.as_requests_kwargs(base_url=case.get_full_base_url(), headers=headers)
@@ -710,11 +708,9 @@ def _wsgi_test(
     with catching_logs(LogCaptureHandler(), level=logging.DEBUG) as recorded:
         start = time.monotonic()
         hook_context = HookContext(operation=case.operation)
-        hooks.dispatch("before_call", hook_context, case)
         kwargs = {"headers": headers}
         hooks.dispatch("process_call_kwargs", hook_context, case, kwargs)
         response = case.call_wsgi(**kwargs)
-        hooks.dispatch("after_call", hook_context, case, response)
         elapsed = time.monotonic() - start
     context = TargetContext(case=case, response=response, response_time=elapsed)
     run_targets(targets, context)
@@ -799,11 +795,9 @@ def _asgi_test(
     max_response_time: Optional[int],
 ) -> requests.Response:
     hook_context = HookContext(operation=case.operation)
-    hooks.dispatch("before_call", hook_context, case)
     kwargs: Dict[str, Any] = {"headers": headers}
     hooks.dispatch("process_call_kwargs", hook_context, case, kwargs)
     response = case.call_asgi(**kwargs)
-    hooks.dispatch("after_call", hook_context, case, response)
     context = TargetContext(case=case, response=response, response_time=response.elapsed.total_seconds())
     run_targets(targets, context)
     status = Status.success

--- a/test/cli/test_hooks.py
+++ b/test/cli/test_hooks.py
@@ -1,8 +1,9 @@
 import pytest
+import requests
+import werkzeug
 from _pytest.main import ExitCode
 
 import schemathesis
-from schemathesis import models
 
 
 @pytest.fixture(autouse=True)
@@ -111,9 +112,9 @@ def process_call_kwargs(context, case, kwargs):
         """
     )
     if app_type == "real":
-        spy = mocker.spy(models.Case, "call")
+        spy = mocker.spy(requests.Session, "request")
     else:
-        spy = mocker.spy(models.Case, "call_wsgi")
+        spy = mocker.spy(werkzeug.Client, "open")
     result = cli.main("--pre-run", module.purebasename, "run", *cli_args)
     assert result.exit_code == ExitCode.OK, result.stdout
     if app_type == "real":


### PR DESCRIPTION
It makes them available for the `pytest` integration