### PR TITLE
fix: Internal error when GraphQL schema has its root types renamed

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 **Fixed**
 
 - CLI: Hanging on ``CTRL-C`` when ``--report`` is enabled.
+- Internal error when GraphQL schema has its root types renamed. `#1591`_
 
 .. _v3.16.4:
 
@@ -3045,6 +3046,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1591: https://github.com/schemathesis/schemathesis/issues/1591
 .. _#1584: https://github.com/schemathesis/schemathesis/issues/1584
 .. _#1582: https://github.com/schemathesis/schemathesis/issues/1582
 .. _#1580: https://github.com/schemathesis/schemathesis/issues/1580

--- a/test/specs/graphql/test_basic.py
+++ b/test/specs/graphql/test_basic.py
@@ -83,3 +83,30 @@ def test_operations_count(graphql_url):
     raw_schema = decoded["data"]
     schema = schemathesis.graphql.from_dict(raw_schema)
     assert schema.operations_count == 4
+
+
+def test_type_names():
+    # When the user gives custom names to query types
+    raw_schema = """
+    schema {
+       query: MyQuery
+       mutation: MyMutation
+    }
+
+    type MyQuery {
+       v: String
+    }
+    type MyMutation {
+       v(i: Int): String
+    }
+    """
+    # Then the schema should be loaded without errors
+    schema = schemathesis.graphql.from_file(raw_schema)
+    # And requests should be properly generated
+
+    @given(case=schema[b""]["POST"].as_strategy())
+    @settings(max_examples=1, deadline=None)
+    def test(case):
+        pass
+
+    test()


### PR DESCRIPTION
Fixes #1591