### PR TITLE
test: Install schemathesis before running tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 isolated_build = true
 envlist =
-  py{36,37,38,39,310},
+  py{37,38,39,310},
   py3-pytest53,
   py3-pytest6,
   py3-hypothesis-6-48,
@@ -10,6 +10,7 @@ envlist =
 [testenv]
 commands =
   poetry install -v
+  pip install -e .
   coverage run --source=schemathesis -m pytest {posargs:} test
 allowlist_externals =
   poetry
@@ -38,7 +39,7 @@ description = Report coverage over all measured test runs.
 basepython = python3.7
 deps = coverage
 skip_install = true
-depends = py{36,37,38,39}
+depends = py{37,38,39}
 commands =
     coverage combine
     coverage report


### PR DESCRIPTION
Otherwise, `schemathesis` is not found on Windows
