### PR TITLE
API consistency improvements

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,14 +20,14 @@ Fixups
 Authentication
 ~~~~~~~~~~~~~~
 
-.. automodule:: schemathesis.auth
+.. automodule:: schemathesis.auths
 
-.. autofunction:: schemathesis.auth.register
+.. autofunction:: schemathesis.auth
 
-.. autoclass:: schemathesis.auth.AuthProvider
+.. autoclass:: schemathesis.auths.AuthProvider
    :members:
 
-.. autoclass:: schemathesis.auth.AuthContext
+.. autoclass:: schemathesis.auths.AuthContext
    :members:
 
 Hooks

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -84,7 +84,7 @@ Targeted testing
 Custom strategies for Open API "format" keyword
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: schemathesis.register_string_format
+.. autofunction:: schemathesis.openapi.format
 
 
 Custom scalars for GraphQL

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,7 +4,7 @@ Public API reference
 Checks
 ~~~~~~
 
-.. autofunction:: schemathesis.register_check
+.. autofunction:: schemathesis.checks.register
 
 Fixups
 ~~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -79,7 +79,7 @@ Targeted testing
 
 .. autoclass:: schemathesis.targets.TargetContext
    :members:
-.. autofunction:: schemathesis.register_target
+.. autofunction:: schemathesis.targets.register
 
 Custom strategies for Open API "format" keyword
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,7 +4,7 @@ Public API reference
 Checks
 ~~~~~~
 
-.. autofunction:: schemathesis.checks.register
+.. autofunction:: schemathesis.check
 
 Fixups
 ~~~~~~
@@ -38,7 +38,7 @@ Hooks
 
 These functions affect Schemathesis behavior globally:
 
-.. autofunction:: schemathesis.hooks.register
+.. autofunction:: schemathesis.hook
 .. autofunction:: schemathesis.hooks.unregister
 .. autofunction:: schemathesis.hooks.unregister_all
 
@@ -71,7 +71,7 @@ Serializers
 
 .. autoclass:: schemathesis.serializers.SerializerContext
    :members:
-.. autofunction:: schemathesis.serializers.register
+.. autofunction:: schemathesis.serializer
 .. autofunction:: schemathesis.serializers.unregister
 
 Targeted testing
@@ -79,7 +79,7 @@ Targeted testing
 
 .. autoclass:: schemathesis.targets.TargetContext
    :members:
-.. autofunction:: schemathesis.targets.register
+.. autofunction:: schemathesis.target
 
 Custom strategies for Open API "format" keyword
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -90,7 +90,7 @@ Custom strategies for Open API "format" keyword
 Custom scalars for GraphQL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: schemathesis.graphql.register_scalar
+.. autofunction:: schemathesis.graphql.scalar
 
 Loaders
 ~~~~~~~

--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -98,7 +98,7 @@ Depending on the level of granularity you need in your tests, you use this class
     import schemathesis
 
 
-    @schemathesis.auth.register()
+    @schemathesis.auth()
     class Auth:
         ...
 
@@ -155,7 +155,7 @@ It expects the number of seconds for which the results will be cached after a no
     import schemathesis
 
 
-    @schemathesis.auth.register(refresh_interval=600)
+    @schemathesis.auth(refresh_interval=600)
     class Auth:
         ...
 
@@ -225,7 +225,7 @@ For example, you can use refresh tokens for authentication.
     import schemathesis
 
 
-    @schemathesis.auth.register()
+    @schemathesis.auth()
     class TokenAuth:
         def __init__(self):
             self.refresh_token = None

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 - Extra information to VCR cassettes.
 - The ``--data-generation-unique`` CLI option that forces Schemathesis to generate unique test cases only.
   This feature is also available as a hook in ``schemathesis.contrib.unique_data``.
+- ``schemathesis.checks.register`` as a new way to register checks.
 
 **Changed**
 
@@ -16,6 +17,10 @@ Changelog
 - Set ``starlette>=0.13,<0.21``.
 - Relax requirements for ``attrs``. `#1643`_
 - Avoid occasional empty lines in cassettes.
+
+**Deprecated**
+
+- ``schemathesis.register_check`` in favor of ``schemathesis.checks.register``.
 
 **Fixed**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,11 +9,14 @@ Changelog
 - Extra information to VCR cassettes.
 - The ``--data-generation-unique`` CLI option that forces Schemathesis to generate unique test cases only.
   This feature is also available as a hook in ``schemathesis.contrib.unique_data``.
-- ``schemathesis.checks.register`` as a new way to register checks.
-- ``schemathesis.targets.register`` as a new way to register targets.
-- ``schemathesis.openapi.format`` as a new way to register custom formats for OpenAPI.
-- ``schemathesis.graphql.scalar`` as a new way to register custom scalars for GraphQL.
-- ``schemathesis.auth()`` as a new way to register custom authentication providers.
+- A few decorators & functions that provide a simpler API to extend Schemathesis:
+    - ``schemathesis.auth()`` for authentication providers;
+    - ``schemathesis.check`` for checks;
+    - ``schemathesis.hook`` & ``BaseSchema.hook`` for hooks;
+    - ``schemathesis.serializer`` for serializers;
+    - ``schemathesis.target`` for targets;
+    - ``schemathesis.openapi.format`` for custom OpenAPI formats.
+    - ``schemathesis.graphql.scalar`` for GraphQL scalars.
 
 **Changed**
 
@@ -24,8 +27,8 @@ Changelog
 
 **Deprecated**
 
-- ``schemathesis.register_check`` in favor of ``schemathesis.checks.register``.
-- ``schemathesis.register_target`` in favor of ``schemathesis.targets.register``.
+- ``schemathesis.register_check`` in favor of ``schemathesis.check``.
+- ``schemathesis.register_target`` in favor of ``schemathesis.target``.
 - ``schemathesis.register_string_format`` in favor of ``schemathesis.openapi.format``.
 - ``schemathesis.graphql.register_scalar`` in favor of ``schemathesis.graphql.scalar``.
 - ``schemathesis.auth.register`` in favor of ``schemathesis.auth``.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,8 @@ Changelog
   This feature is also available as a hook in ``schemathesis.contrib.unique_data``.
 - ``schemathesis.checks.register`` as a new way to register checks.
 - ``schemathesis.targets.register`` as a new way to register targets.
-- ``schemathesis.openapi.format`` as a new way to register custom formats for Open API.
+- ``schemathesis.openapi.format`` as a new way to register custom formats for OpenAPI.
+- ``schemathesis.graphql.scalar`` as a new way to register custom scalars for GraphQL.
 
 **Changed**
 
@@ -25,6 +26,7 @@ Changelog
 - ``schemathesis.register_check`` in favor of ``schemathesis.checks.register``.
 - ``schemathesis.register_target`` in favor of ``schemathesis.targets.register``.
 - ``schemathesis.register_string_format`` in favor of ``schemathesis.openapi.format``.
+- ``schemathesis.graphql.register_scalar`` in favor of ``schemathesis.graphql.scalar``.
 
 **Fixed**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Changelog
   This feature is also available as a hook in ``schemathesis.contrib.unique_data``.
 - ``schemathesis.checks.register`` as a new way to register checks.
 - ``schemathesis.targets.register`` as a new way to register targets.
+- ``schemathesis.openapi.format`` as a new way to register custom formats for Open API.
 
 **Changed**
 
@@ -23,6 +24,7 @@ Changelog
 
 - ``schemathesis.register_check`` in favor of ``schemathesis.checks.register``.
 - ``schemathesis.register_target`` in favor of ``schemathesis.targets.register``.
+- ``schemathesis.register_string_format`` in favor of ``schemathesis.openapi.format``.
 
 **Fixed**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Changelog
 - ``schemathesis.targets.register`` as a new way to register targets.
 - ``schemathesis.openapi.format`` as a new way to register custom formats for OpenAPI.
 - ``schemathesis.graphql.scalar`` as a new way to register custom scalars for GraphQL.
+- ``schemathesis.auth()`` as a new way to register custom authentication providers.
 
 **Changed**
 
@@ -27,6 +28,7 @@ Changelog
 - ``schemathesis.register_target`` in favor of ``schemathesis.targets.register``.
 - ``schemathesis.register_string_format`` in favor of ``schemathesis.openapi.format``.
 - ``schemathesis.graphql.register_scalar`` in favor of ``schemathesis.graphql.scalar``.
+- ``schemathesis.auth.register`` in favor of ``schemathesis.auth``.
 
 **Fixed**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 - The ``--data-generation-unique`` CLI option that forces Schemathesis to generate unique test cases only.
   This feature is also available as a hook in ``schemathesis.contrib.unique_data``.
 - ``schemathesis.checks.register`` as a new way to register checks.
+- ``schemathesis.targets.register`` as a new way to register targets.
 
 **Changed**
 
@@ -21,6 +22,7 @@ Changelog
 **Deprecated**
 
 - ``schemathesis.register_check`` in favor of ``schemathesis.checks.register``.
+- ``schemathesis.register_target`` in favor of ``schemathesis.targets.register``.
 
 **Fixed**
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -444,14 +444,14 @@ The passed value will be treated as an importable Python path and imported befor
 Registering custom checks
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To use your custom checks with Schemathesis CLI, you need to register them via the ``schemathesis.checks.register`` decorator:
+To use your custom checks with Schemathesis CLI, you need to register them via the ``schemathesis.check`` decorator:
 
 .. code:: python
 
     import schemathesis
 
 
-    @schemathesis.checks.register
+    @schemathesis.check
     def new_check(response, case):
         # some awesome assertions!
         pass
@@ -474,7 +474,7 @@ response code is ``200``.
     import schemathesis
 
 
-    @schemathesis.checks.register
+    @schemathesis.check
     def conditional_check(response, case):
         if response.status_code == 200:
             ...  # some awesome assertions!

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -444,14 +444,14 @@ The passed value will be treated as an importable Python path and imported befor
 Registering custom checks
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To use your custom checks with Schemathesis CLI, you need to register them via the ``register_check`` decorator:
+To use your custom checks with Schemathesis CLI, you need to register them via the ``schemathesis.checks.register`` decorator:
 
 .. code:: python
 
     import schemathesis
 
 
-    @schemathesis.register_check
+    @schemathesis.checks.register
     def new_check(response, case):
         # some awesome assertions!
         pass
@@ -474,7 +474,7 @@ response code is ``200``.
     import schemathesis
 
 
-    @schemathesis.register_check
+    @schemathesis.checks.register
     def conditional_check(response, case):
         if response.status_code == 200:
             ...  # some awesome assertions!

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -406,7 +406,7 @@ For example, you may use the ``card_number`` format and validate input with the 
 You can teach Schemathesis to generate values that fit this format by registering a custom Hypothesis strategy:
 
 1. Create a Hypothesis strategy that generates valid string values
-2. Register it via ``schemathesis.register_string_format``
+2. Register it via ``schemathesis.openapi.format``
 
 .. code-block:: python
 
@@ -414,7 +414,7 @@ You can teach Schemathesis to generate values that fit this format by registerin
     import schemathesis
 
     strategy = st.from_regex(r"\A4[0-9]{15}\Z").filter(luhn_validator)
-    schemathesis.register_string_format("visa_cards", strategy)
+    schemathesis.openapi.format("visa_cards", strategy)
 
 Schemathesis test runner
 ------------------------

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -20,7 +20,7 @@ To register a new hook function, you need to use special decorators - ``register
     import schemathesis
 
 
-    @schemathesis.hooks.register
+    @schemathesis.hook
     def before_generate_query(context, strategy):
         return strategy.filter(lambda x: x["id"].isdigit())
 
@@ -28,7 +28,7 @@ To register a new hook function, you need to use special decorators - ``register
     schema = schemathesis.from_uri("http://0.0.0.0:8080/swagger.json")
 
 
-    @schema.hooks.register("before_generate_query")
+    @schema.hook("before_generate_query")
     def schema_hook(context, strategy):
         return strategy.filter(lambda x: int(x["id"]) % 2 == 0)
 
@@ -249,7 +249,7 @@ This hook allows you to extend or redefine a list of CLI handlers that will be u
                 click.echo("Done!")
 
 
-    @schemathesis.hooks.register
+    @schemathesis.hook
     def after_init_cli_run_handlers(
         context: HookContext,
         handlers: List[EventHandler],
@@ -320,7 +320,7 @@ Called right before any test request during CLI runs. With this hook, you can mo
     import schemathesis
 
 
-    @schemathesis.hooks.register
+    @schemathesis.hook
     def before_call(context, case):
         case.query = {"q": "42"}
 
@@ -335,7 +335,7 @@ Called right after any successful test request during CLI runs. With this hook, 
     import schemathesis
 
 
-    @schemathesis.hooks.register
+    @schemathesis.hook
     def after_call(context, case, response):
         parsed = response.json()
         response._content = json.dumps({"my-wrapper": parsed}).encode()
@@ -355,7 +355,7 @@ If you want to modify what keyword arguments will be given to ``case.call`` / ``
     import schemathesis
 
 
-    @schemathesis.hooks.register
+    @schemathesis.hook
     def process_call_kwargs(context, case, kwargs):
         kwargs["allow_redirects"] = False
 

--- a/docs/graphql.rst
+++ b/docs/graphql.rst
@@ -43,7 +43,7 @@ Standard scalars work out of the box, for custom ones you need to pass custom st
     import schemathesis
     from schemathesis.graphql import nodes
 
-    schemathesis.graphql.register_scalar("Date", st.dates().map(nodes.String))
+    schemathesis.graphql.scalar("Date", st.dates().map(nodes.String))
 
 Such a strategy generates valid dates as strings, for example:
 

--- a/docs/how.rst
+++ b/docs/how.rst
@@ -148,7 +148,7 @@ First, let's define a function that will transform lists of dictionaries to CSV 
 
     You can take a look at the official `csv module documentation <https://docs.python.org/3/library/csv.html>`_ for more examples of CSV serialization.
 
-Second, register a serializer class via the ``schemathesis.serializers.register`` decorator:
+Second, register a serializer class via the ``schemathesis.serializer`` decorator:
 
 .. code-block:: python
    :emphasize-lines: 4
@@ -156,7 +156,7 @@ Second, register a serializer class via the ``schemathesis.serializers.register`
     import schemathesis
 
 
-    @schemathesis.serializers.register("text/csv")
+    @schemathesis.serializer("text/csv")
     class CSVSerializer:
         ...
 

--- a/docs/targeted.rst
+++ b/docs/targeted.rst
@@ -80,14 +80,14 @@ Hypothesis `documentation <https://hypothesis.readthedocs.io/en/latest/details.h
 Custom targets
 ~~~~~~~~~~~~~~
 
-You can register your own targets with the ``schemathesis.register_target`` decorator. The function should accept ``schemathesis.targets.TargetContext`` and return a float value:
+You can register your own targets with the ``schemathesis.targets.register`` decorator. The function should accept ``schemathesis.targets.TargetContext`` and return a float value:
 
 .. code:: python
 
     import schemathesis
 
 
-    @schemathesis.register_target
+    @schemathesis.targets.register
     def new_target(context) -> float:
         return float(len(context.response.content))
 

--- a/docs/targeted.rst
+++ b/docs/targeted.rst
@@ -80,14 +80,14 @@ Hypothesis `documentation <https://hypothesis.readthedocs.io/en/latest/details.h
 Custom targets
 ~~~~~~~~~~~~~~
 
-You can register your own targets with the ``schemathesis.targets.register`` decorator. The function should accept ``schemathesis.targets.TargetContext`` and return a float value:
+You can register your own targets with the ``schemathesis.target`` decorator. The function should accept ``schemathesis.targets.TargetContext`` and return a float value:
 
 .. code:: python
 
     import schemathesis
 
 
-    @schemathesis.targets.register
+    @schemathesis.target
     def new_target(context) -> float:
         return float(len(context.response.content))
 

--- a/example/test/hooks.py
+++ b/example/test/hooks.py
@@ -22,7 +22,7 @@ def before_generate_body(context, strategy):
     return strategy.filter(lambda x: x.get("id", 10001) > 10000)
 
 
-@schemathesis.register_check
+@schemathesis.checks.register
 def not_so_slow(response, case):
     """Custom response check."""
     assert response.elapsed < timedelta(milliseconds=100), "Response is slow!"

--- a/example/test/hooks.py
+++ b/example/test/hooks.py
@@ -16,19 +16,19 @@ def fullname(draw):
 schemathesis.openapi.format("fullname", fullname())
 
 
-@schemathesis.hooks.register
+@schemathesis.hook
 def before_generate_body(context, strategy):
     """Modification over the default strategy for payload generation."""
     return strategy.filter(lambda x: x.get("id", 10001) > 10000)
 
 
-@schemathesis.checks.register
+@schemathesis.check
 def not_so_slow(response, case):
     """Custom response check."""
     assert response.elapsed < timedelta(milliseconds=100), "Response is slow!"
 
 
-@schemathesis.targets.register
+@schemathesis.target
 def big_response(context):
     """Custom data generation target."""
     return float(len(context.response.content))

--- a/example/test/hooks.py
+++ b/example/test/hooks.py
@@ -13,7 +13,7 @@ def fullname(draw):
     return f"{first} {last}"
 
 
-schemathesis.register_string_format("fullname", fullname())
+schemathesis.openapi.format("fullname", fullname())
 
 
 @schemathesis.hooks.register

--- a/example/test/hooks.py
+++ b/example/test/hooks.py
@@ -28,7 +28,7 @@ def not_so_slow(response, case):
     assert response.elapsed < timedelta(milliseconds=100), "Response is slow!"
 
 
-@schemathesis.register_target
+@schemathesis.targets.register
 def big_response(context):
     """Custom data generation target."""
     return float(len(context.response.content))

--- a/src/schemathesis/__init__.py
+++ b/src/schemathesis/__init__.py
@@ -8,7 +8,7 @@ from . import auth, checks, contrib, fixups, graphql, hooks, runner, serializers
 from .constants import DataGenerationMethod, __version__
 from .models import Case
 from .specs import openapi
-from .specs.openapi._hypothesis import init_default_strategies, register_string_format
+from .specs.openapi._hypothesis import init_default_strategies
 from .utils import GenericResponse
 
 init_default_strategies()
@@ -29,3 +29,4 @@ from_wsgi = openapi.from_wsgi
 # Backward compatibility
 register_check = checks.register
 register_target = targets.register
+register_string_format = openapi.format

--- a/src/schemathesis/__init__.py
+++ b/src/schemathesis/__init__.py
@@ -4,8 +4,8 @@ _install_hypothesis_jsonschema_compatibility_shim()
 
 del _install_hypothesis_jsonschema_compatibility_shim
 
-from . import auth, contrib, fixups, graphql, hooks, runner, serializers, targets
-from .cli import register_check, register_target
+from . import auth, checks, contrib, fixups, graphql, hooks, runner, serializers, targets
+from .cli import register_target
 from .constants import DataGenerationMethod, __version__
 from .models import Case
 from .specs import openapi
@@ -26,3 +26,6 @@ from_path = openapi.from_path
 from_pytest_fixture = openapi.from_pytest_fixture
 from_uri = openapi.from_uri
 from_wsgi = openapi.from_wsgi
+
+# Backward compatibility
+register_check = checks.register

--- a/src/schemathesis/__init__.py
+++ b/src/schemathesis/__init__.py
@@ -28,6 +28,10 @@ from_wsgi = openapi.from_wsgi
 
 # Public API
 auth = auths.register
+check = checks.register
+hook = hooks.register
+serializer = serializers.register
+target = targets.register
 
 # Backward compatibility
 register_check = checks.register

--- a/src/schemathesis/__init__.py
+++ b/src/schemathesis/__init__.py
@@ -5,7 +5,6 @@ _install_hypothesis_jsonschema_compatibility_shim()
 del _install_hypothesis_jsonschema_compatibility_shim
 
 from . import auth, checks, contrib, fixups, graphql, hooks, runner, serializers, targets
-from .cli import register_target
 from .constants import DataGenerationMethod, __version__
 from .models import Case
 from .specs import openapi
@@ -29,3 +28,4 @@ from_wsgi = openapi.from_wsgi
 
 # Backward compatibility
 register_check = checks.register
+register_target = targets.register

--- a/src/schemathesis/__init__.py
+++ b/src/schemathesis/__init__.py
@@ -4,7 +4,7 @@ _install_hypothesis_jsonschema_compatibility_shim()
 
 del _install_hypothesis_jsonschema_compatibility_shim
 
-from . import auth, checks, contrib, fixups, graphql, hooks, runner, serializers, targets
+from . import auths, checks, contrib, fixups, graphql, hooks, runner, serializers, targets
 from .constants import DataGenerationMethod, __version__
 from .models import Case
 from .specs import openapi
@@ -26,7 +26,12 @@ from_pytest_fixture = openapi.from_pytest_fixture
 from_uri = openapi.from_uri
 from_wsgi = openapi.from_wsgi
 
+# Public API
+auth = auths.register
+
 # Backward compatibility
 register_check = checks.register
 register_target = targets.register
 register_string_format = openapi.format
+
+auth.__dict__["register"] = auths.register

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -10,7 +10,7 @@ from hypothesis.errors import HypothesisWarning, Unsatisfiable
 from hypothesis.internal.reflection import proxies
 from hypothesis_jsonschema._canonicalise import HypothesisRefResolutionError
 
-from .auth import get_auth_storage_from_test
+from .auths import get_auth_storage_from_test
 from .constants import DEFAULT_DEADLINE, DataGenerationMethod
 from .exceptions import InvalidSchema
 from .hooks import GLOBAL_HOOK_DISPATCHER, HookContext, HookDispatcher

--- a/src/schemathesis/auths.py
+++ b/src/schemathesis/auths.py
@@ -106,7 +106,7 @@ class AuthStorage(Generic[Auth]):
 
         .. code-block:: python
 
-            @schemathesis.auth.register()
+            @schemathesis.auth()
             class TokenAuth:
                 def get(self, context):
                     # This is a real endpoint, try it out!
@@ -126,7 +126,7 @@ class AuthStorage(Generic[Auth]):
             if not issubclass(provider_class, AuthProvider):
                 raise TypeError(
                     f"`{provider_class.__name__}` is not a valid auth provider. "
-                    f"Check `schemathesis.auth.AuthProvider` documentation for examples."
+                    f"Check `schemathesis.auths.AuthProvider` documentation for examples."
                 )
             # Apply caching if desired
             if refresh_interval is not None:

--- a/src/schemathesis/checks.py
+++ b/src/schemathesis/checks.py
@@ -42,7 +42,7 @@ def register(check: "CheckFunction") -> "CheckFunction":
 
     .. code-block:: python
 
-        @schemathesis.checks.register
+        @schemathesis.check
         def new_check(response, case):
             # some awesome assertions!
             ...

--- a/src/schemathesis/checks.py
+++ b/src/schemathesis/checks.py
@@ -33,3 +33,24 @@ OPTIONAL_CHECKS = (
     response_schema_conformance,
 )
 ALL_CHECKS: Tuple["CheckFunction", ...] = DEFAULT_CHECKS + OPTIONAL_CHECKS
+
+
+def register(check: "CheckFunction") -> "CheckFunction":
+    """Register a new check for schemathesis CLI.
+
+    :param check: A function to validate API responses.
+
+    .. code-block:: python
+
+        @schemathesis.checks.register
+        def new_check(response, case):
+            # some awesome assertions!
+            ...
+    """
+    from . import cli  # pylint: disable=import-outside-toplevel
+
+    global ALL_CHECKS  # pylint: disable=global-statement
+
+    ALL_CHECKS += (check,)
+    cli.CHECKS_TYPE.choices += (check.__name__,)  # type: ignore
+    return check

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -93,23 +93,6 @@ def register_target(function: Target) -> Target:
     return function
 
 
-def register_check(function: CheckFunction) -> CheckFunction:
-    """Register a new check for schemathesis CLI.
-
-    :param function: A function to validate API responses.
-
-    .. code-block:: python
-
-        @schemathesis.register_check
-        def new_check(response, case):
-            # some awesome assertions!
-            ...
-    """
-    checks_module.ALL_CHECKS += (function,)
-    CHECKS_TYPE.choices += (function.__name__,)  # type: ignore
-    return function
-
-
 def reset_checks() -> None:
     """Get checks list to their default state."""
     # Useful in tests

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -83,16 +83,6 @@ DEPRECATED_CASSETTE_PATH_OPTION_WARNING = (
 CASSETTES_PATH_INVALID_USAGE_MESSAGE = "Can't use `--store-network-log` and `--cassette-path` simultaneously"
 
 
-def register_target(function: Target) -> Target:
-    """Register a new testing target for schemathesis CLI.
-
-    :param function: A function that will be called to calculate a metric passed to ``hypothesis.target``.
-    """
-    targets_module.ALL_TARGETS += (function,)
-    TARGETS_TYPE.choices += (function.__name__,)  # type: ignore
-    return function
-
-
 def reset_checks() -> None:
     """Get checks list to their default state."""
     # Useful in tests

--- a/src/schemathesis/constants.py
+++ b/src/schemathesis/constants.py
@@ -30,7 +30,7 @@ RECURSIVE_REFERENCE_ERROR_MESSAGE = (
     "this issue - https://github.com/schemathesis/schemathesis/issues/947"
 )
 SERIALIZERS_SUGGESTION_MESSAGE = (
-    "You can register your own serializer with `schemathesis.serializers.register` "
+    "You can register your own serializer with `schemathesis.serializer` "
     "and Schemathesis will be able to make API calls with this media type. \n"
     "See https://schemathesis.readthedocs.io/en/stable/how.html#payload-serialization for more information."
 )

--- a/src/schemathesis/graphql.py
+++ b/src/schemathesis/graphql.py
@@ -2,4 +2,4 @@
 # Public API
 from .specs.graphql import nodes
 from .specs.graphql.loaders import from_asgi, from_dict, from_file, from_path, from_url, from_wsgi
-from .specs.graphql.scalars import register_scalar
+from .specs.graphql.scalars import scalar

--- a/src/schemathesis/hooks.py
+++ b/src/schemathesis/hooks.py
@@ -64,7 +64,7 @@ class HookDispatcher:
 
         .. code-block:: python
 
-            @schemathesis.hooks.register
+            @schemathesis.hook
             def before_generate_query(context, strategy):
                 ...
 
@@ -72,7 +72,7 @@ class HookDispatcher:
 
         .. code-block:: python
 
-            @schemathesis.hooks.register("before_generate_query")
+            @schemathesis.hook("before_generate_query")
             def hook(context, strategy):
                 ...
         """

--- a/src/schemathesis/lazy.py
+++ b/src/schemathesis/lazy.py
@@ -48,6 +48,9 @@ class LazySchema:
     data_generation_methods: Union[DataGenerationMethodInput, NotSet] = attr.ib(default=NOT_SET)
     code_sample_style: CodeSampleStyle = attr.ib(default=CodeSampleStyle.default())  # pragma: no mutate
 
+    def hook(self, hook: Union[str, Callable]) -> Callable:
+        return self.hooks.register(hook)
+
     def parametrize(
         self,
         method: Optional[Filter] = NOT_SET,

--- a/src/schemathesis/lazy.py
+++ b/src/schemathesis/lazy.py
@@ -11,7 +11,7 @@ from hypothesis.internal.reflection import impersonate
 from pytest_subtests import SubTests, nullcontext
 
 from ._compat import MultipleFailures
-from .auth import AuthStorage
+from .auths import AuthStorage
 from .constants import FLAKY_FAILURE_MESSAGE, CodeSampleStyle
 from .exceptions import CheckFailed, InvalidSchema, SkipTest, get_grouped_exception
 from .hooks import HookDispatcher, HookScope

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -41,7 +41,7 @@ from requests.structures import CaseInsensitiveDict
 from starlette.testclient import TestClient as ASGIClient
 
 from . import failures, serializers
-from .auth import AuthStorage
+from .auths import AuthStorage
 from .constants import (
     DEFAULT_RESPONSE_TIMEOUT,
     SCHEMATHESIS_TEST_CASE_HEADER,

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -19,7 +19,7 @@ from requests.auth import HTTPDigestAuth, _basic_auth_str
 
 from ... import failures, hooks
 from ..._compat import MultipleFailures
-from ...auth import unregister as unregister_auth
+from ...auths import unregister as unregister_auth
 from ...constants import (
     DEFAULT_STATEFUL_RECURSION_LIMIT,
     RECURSIVE_REFERENCE_ERROR_MESSAGE,

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -33,7 +33,7 @@ from hypothesis.strategies import SearchStrategy
 from requests.structures import CaseInsensitiveDict
 
 from ._hypothesis import create_test
-from .auth import AuthStorage
+from .auths import AuthStorage
 from .constants import DEFAULT_DATA_GENERATION_METHODS, CodeSampleStyle, DataGenerationMethod
 from .exceptions import InvalidSchema, UsageError
 from .hooks import HookContext, HookDispatcher, HookScope, dispatch

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -113,6 +113,9 @@ class BaseSchema(Mapping):
     def __len__(self) -> int:
         return len(self.operations)
 
+    def hook(self, hook: Union[str, Callable]) -> Callable:
+        return self.hooks.register(hook)
+
     @property  # pragma: no mutate
     def verbose_name(self) -> str:
         raise NotImplementedError

--- a/src/schemathesis/specs/graphql/scalars.py
+++ b/src/schemathesis/specs/graphql/scalars.py
@@ -8,7 +8,7 @@ from ...exceptions import UsageError
 CUSTOM_SCALARS: Dict[str, st.SearchStrategy[graphql.ValueNode]] = {}
 
 
-def register_scalar(name: str, strategy: st.SearchStrategy[graphql.ValueNode]) -> None:
+def scalar(name: str, strategy: st.SearchStrategy[graphql.ValueNode]) -> None:
     """Register a new strategy for generating custom scalars.
 
     :param str name: Scalar name. It should correspond the one used in the schema.

--- a/src/schemathesis/specs/graphql/schemas.py
+++ b/src/schemathesis/specs/graphql/schemas.py
@@ -13,8 +13,8 @@ from hypothesis.strategies import SearchStrategy
 from hypothesis_graphql import strategies as gql_st
 from requests.structures import CaseInsensitiveDict
 
-from ... import auth
-from ...auth import AuthStorage
+from ... import auths
+from ...auths import AuthStorage
 from ...checks import not_a_server_error
 from ...constants import DataGenerationMethod
 from ...exceptions import InvalidSchema
@@ -227,9 +227,9 @@ def get_case_strategy(
     }[definition.root_type]
     body = draw(strategy(client_schema, fields=[definition.field_name], custom_scalars=CUSTOM_SCALARS))
     instance = GraphQLCase(body=body, operation=operation, data_generation_method=data_generation_method)  # type: ignore
-    context = auth.AuthContext(
+    context = auths.AuthContext(
         operation=operation,
         app=operation.app,
     )
-    auth.set_on_case(instance, context, auth_storage)
+    auths.set_on_case(instance, context, auth_storage)
     return instance

--- a/src/schemathesis/specs/openapi/__init__.py
+++ b/src/schemathesis/specs/openapi/__init__.py
@@ -1,1 +1,2 @@
+from ._hypothesis import register_string_format as format  # pylint: disable=redefined-builtin
 from .loaders import from_aiohttp, from_asgi, from_dict, from_file, from_path, from_pytest_fixture, from_uri, from_wsgi

--- a/src/schemathesis/specs/openapi/_hypothesis.py
+++ b/src/schemathesis/specs/openapi/_hypothesis.py
@@ -12,7 +12,7 @@ from hypothesis_jsonschema import from_schema
 from requests.auth import _basic_auth_str
 from requests.structures import CaseInsensitiveDict
 
-from ... import auth, serializers, utils
+from ... import auths, serializers, utils
 from ...constants import DataGenerationMethod
 from ...exceptions import InvalidSchema, SerializationNotPossible
 from ...hooks import GLOBAL_HOOK_DISPATCHER, HookContext, HookDispatcher
@@ -107,7 +107,7 @@ def get_case_strategy(  # pylint: disable=too-many-locals
     draw: Callable,
     operation: APIOperation,
     hooks: Optional[HookDispatcher] = None,
-    auth_storage: Optional[auth.AuthStorage] = None,
+    auth_storage: Optional[auths.AuthStorage] = None,
     data_generation_method: DataGenerationMethod = DataGenerationMethod.default(),
     path_parameters: Union[NotSet, Dict[str, Any]] = NOT_SET,
     headers: Union[NotSet, Dict[str, Any]] = NOT_SET,
@@ -198,11 +198,11 @@ def get_case_strategy(  # pylint: disable=too-many-locals
         body=body,
         data_generation_method=data_generation_method,
     )
-    auth_context = auth.AuthContext(
+    auth_context = auths.AuthContext(
         operation=operation,
         app=operation.app,
     )
-    auth.set_on_case(instance, auth_context, auth_storage)
+    auths.set_on_case(instance, auth_context, auth_storage)
     return instance
 
 

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -32,7 +32,7 @@ from hypothesis.strategies import SearchStrategy
 from requests.structures import CaseInsensitiveDict
 
 from ... import failures
-from ...auth import AuthStorage
+from ...auths import AuthStorage
 from ...constants import HTTP_METHODS, DataGenerationMethod
 from ...exceptions import (
     InvalidSchema,

--- a/src/schemathesis/targets.py
+++ b/src/schemathesis/targets.py
@@ -30,3 +30,17 @@ Target = Callable[[TargetContext], float]
 DEFAULT_TARGETS = ()
 OPTIONAL_TARGETS = (response_time,)
 ALL_TARGETS: Tuple[Target, ...] = DEFAULT_TARGETS + OPTIONAL_TARGETS
+
+
+def register(target: Target) -> Target:
+    """Register a new testing target for schemathesis CLI.
+
+    :param target: A function that will be called to calculate a metric passed to ``hypothesis.target``.
+    """
+    from . import cli  # pylint: disable=import-outside-toplevel
+
+    global ALL_TARGETS  # pylint: disable=global-statement
+
+    ALL_TARGETS += (target,)
+    cli.TARGETS_TYPE.choices += (target.__name__,)  # type: ignore
+    return target

--- a/test/auth/conftest.py
+++ b/test/auth/conftest.py
@@ -6,4 +6,4 @@ import schemathesis
 @pytest.fixture(autouse=True)
 def unregister_global():
     yield
-    schemathesis.auth.unregister()
+    schemathesis.auths.unregister()

--- a/test/auth/test_cli.py
+++ b/test/auth/test_cli.py
@@ -35,7 +35,7 @@ def test_custom_auth(testdir, cli, schema_url, app):
     module = testdir.make_importable_pyfile(
         hook=f"""
 {AUTH_PROVIDER_MODULE_CODE}
-@schemathesis.hooks.register
+@schemathesis.hook
 def after_call(context, case, response):
     assert case.headers["Authorization"] ==  f"Bearer {TOKEN}", case.headers["Authorization"]
     request_authorization = response.request.headers["Authorization"]
@@ -66,7 +66,7 @@ def test_explicit_auth_precedence(testdir, cli, schema_url, args, expected):
     module = testdir.make_importable_pyfile(
         hook=f"""
 {AUTH_PROVIDER_MODULE_CODE}
-@schemathesis.hooks.register
+@schemathesis.hook
 def after_call(context, case, response):
     request_authorization = response.request.headers["Authorization"]
     assert request_authorization == "{expected}", request_authorization
@@ -106,7 +106,7 @@ def test_multiple_threads(testdir, cli, schema_url):
         def set(self, case, data, context):
             case.headers = {{"Authorization": f"Bearer {{data}}"}}
 
-    @schemathesis.hooks.register
+    @schemathesis.hook
     def after_call(context, case, response):
         provider = schemathesis.auths.GLOBAL_AUTH_STORAGE.provider.provider
         assert provider.get_calls == 1, provider.get_calls

--- a/test/auth/test_cli.py
+++ b/test/auth/test_cli.py
@@ -18,7 +18,7 @@ TOKEN = "{TOKEN}"
 
 note = print
 
-@schemathesis.auth.register()
+@schemathesis.auth()
 class TokenAuth:
     def get(self, context):
         return TOKEN
@@ -92,7 +92,7 @@ def test_multiple_threads(testdir, cli, schema_url):
 
     TOKEN = "{TOKEN}"
 
-    @schemathesis.auth.register()
+    @schemathesis.auth()
     class TokenAuth:
 
         def __init__(self):
@@ -108,7 +108,7 @@ def test_multiple_threads(testdir, cli, schema_url):
 
     @schemathesis.hooks.register
     def after_call(context, case, response):
-        provider = schemathesis.auth.GLOBAL_AUTH_STORAGE.provider.provider
+        provider = schemathesis.auths.GLOBAL_AUTH_STORAGE.provider.provider
         assert provider.get_calls == 1, provider.get_calls
     """
     )

--- a/test/auth/test_provider.py
+++ b/test/auth/test_provider.py
@@ -1,7 +1,7 @@
 import pytest
 
 from schemathesis import Case
-from schemathesis.auth import AuthContext, AuthStorage, CachingAuthProvider
+from schemathesis.auths import AuthContext, AuthStorage, CachingAuthProvider
 from schemathesis.exceptions import UsageError
 
 TOKEN = "EXAMPLE-TOKEN"

--- a/test/auth/test_pytest.py
+++ b/test/auth/test_pytest.py
@@ -32,7 +32,7 @@ type Query {
 @pytest.mark.parametrize(
     "class_decorator, pre_parametrize_decorator, post_parametrize_decorator",
     (
-        ("@schemathesis.auth.register()", "", ""),
+        ("@schemathesis.auth()", "", ""),
         ("@schema.auth.register()", "", ""),
         ("", f"@schema.auth.apply({AUTH_CLASS_NAME})", ""),
         ("", "", f"@schema.auth.apply({AUTH_CLASS_NAME})"),

--- a/test/cli/test_checks.py
+++ b/test/cli/test_checks.py
@@ -6,7 +6,7 @@ from schemathesis.cli import reset_checks
 
 @pytest.fixture
 def new_check():
-    @schemathesis.checks.register
+    @schemathesis.check
     def check_function(response, case):
         pass
 
@@ -16,7 +16,7 @@ def new_check():
 
 
 def test_register_returns_a_value(new_check):
-    # When a function is registered via the `schemathesis.checks.register` decorator
+    # When a function is registered via the `schemathesis.check` decorator
     # Then this function should be available for further usage
     # See #721
     assert new_check is not None

--- a/test/cli/test_checks.py
+++ b/test/cli/test_checks.py
@@ -6,7 +6,7 @@ from schemathesis.cli import reset_checks
 
 @pytest.fixture
 def new_check():
-    @schemathesis.register_check
+    @schemathesis.checks.register
     def check_function(response, case):
         pass
 
@@ -16,7 +16,7 @@ def new_check():
 
 
 def test_register_returns_a_value(new_check):
-    # When a function is registered via the `register_check` decorator
+    # When a function is registered via the `schemathesis.checks.register` decorator
     # Then this function should be available for further usage
     # See #721
     assert new_check is not None

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -1063,7 +1063,7 @@ def test_conditional_checks(testdir, cli, hypothesis_max_examples, schema_url):
             import schemathesis
             import click
 
-            @schemathesis.checks.register
+            @schemathesis.check
             def conditional_check(response, case):
                 # skip this check
                 return True
@@ -1092,14 +1092,14 @@ def test_add_case(testdir, cli, hypothesis_max_examples, schema_url):
             import schemathesis
             import click
 
-            @schemathesis.hooks.register
+            @schemathesis.hook
             def add_case(context, case, response):
                 if not case.headers:
                     case.headers = {}
                 case.headers["copy"] = "this is a copied case"
                 return case
 
-            @schemathesis.checks.register
+            @schemathesis.check
             def add_case_check(response, case):
                 if case.headers and case.headers.get("copy") == "this is a copied case":
                     # we will look for this output
@@ -1130,11 +1130,11 @@ def test_add_case_returns_none(testdir, cli, hypothesis_max_examples, schema_url
             import schemathesis
             import click
 
-            @schemathesis.hooks.register
+            @schemathesis.hook
             def add_case(context, case, response):
                 return None
 
-            @schemathesis.checks.register
+            @schemathesis.check
             def add_case_check(response, case):
                 click.echo("Validating case.")
             """
@@ -1165,21 +1165,21 @@ def test_multiple_add_case_hooks(testdir, cli, hypothesis_max_examples, schema_u
             import schemathesis
             import click
 
-            @schemathesis.hooks.register("add_case")
+            @schemathesis.hook("add_case")
             def add_first_header(context, case, response):
                 if not case.headers:
                     case.headers = {}
                 case.headers["first"] = "first header"
                 return case
 
-            @schemathesis.hooks.register("add_case")
+            @schemathesis.hook("add_case")
             def add_second_header(context, case, response):
                 if not case.headers:
                     case.headers = {}
                 case.headers["second"] = "second header"
                 return case
 
-            @schemathesis.checks.register
+            @schemathesis.check
             def add_case_check(response, case):
                 if case.headers and case.headers.get("first") == "first header":
                     # we will look for this output
@@ -1213,21 +1213,21 @@ def test_add_case_output(testdir, cli, hypothesis_max_examples, schema_url):
             import schemathesis
             import click
 
-            @schemathesis.hooks.register("add_case")
+            @schemathesis.hook("add_case")
             def add_first_header(context, case, response):
                 if not case.headers:
                     case.headers = {}
                 case.headers["first"] = "first header"
                 return case
 
-            @schemathesis.hooks.register("add_case")
+            @schemathesis.hook("add_case")
             def add_second_header(context, case, response):
                 if not case.headers:
                     case.headers = {}
                 case.headers["second"] = "second header"
                 return case
 
-            @schemathesis.checks.register
+            @schemathesis.check
             def add_case_check(response, case):
                 if (
                     case.headers and
@@ -1269,7 +1269,7 @@ def new_check(request, testdir, cli):
         hook=f"""
             import schemathesis
 
-            @schemathesis.checks.register
+            @schemathesis.check
             def new_check(response, result):
                 raise {exception}
             """
@@ -2202,7 +2202,7 @@ import schemathesis
 
 note = print
 
-@schemathesis.checks.register
+@schemathesis.check
 def data_generation_check(response, case):
     if case.data_generation_method:
         note("METHOD: {}".format(case.data_generation_method.name))

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -1063,7 +1063,7 @@ def test_conditional_checks(testdir, cli, hypothesis_max_examples, schema_url):
             import schemathesis
             import click
 
-            @schemathesis.register_check
+            @schemathesis.checks.register
             def conditional_check(response, case):
                 # skip this check
                 return True
@@ -1099,7 +1099,7 @@ def test_add_case(testdir, cli, hypothesis_max_examples, schema_url):
                 case.headers["copy"] = "this is a copied case"
                 return case
 
-            @schemathesis.register_check
+            @schemathesis.checks.register
             def add_case_check(response, case):
                 if case.headers and case.headers.get("copy") == "this is a copied case":
                     # we will look for this output
@@ -1134,7 +1134,7 @@ def test_add_case_returns_none(testdir, cli, hypothesis_max_examples, schema_url
             def add_case(context, case, response):
                 return None
 
-            @schemathesis.register_check
+            @schemathesis.checks.register
             def add_case_check(response, case):
                 click.echo("Validating case.")
             """
@@ -1179,7 +1179,7 @@ def test_multiple_add_case_hooks(testdir, cli, hypothesis_max_examples, schema_u
                 case.headers["second"] = "second header"
                 return case
 
-            @schemathesis.register_check
+            @schemathesis.checks.register
             def add_case_check(response, case):
                 if case.headers and case.headers.get("first") == "first header":
                     # we will look for this output
@@ -1227,7 +1227,7 @@ def test_add_case_output(testdir, cli, hypothesis_max_examples, schema_url):
                 case.headers["second"] = "second header"
                 return case
 
-            @schemathesis.register_check
+            @schemathesis.checks.register
             def add_case_check(response, case):
                 if (
                     case.headers and
@@ -1269,7 +1269,7 @@ def new_check(request, testdir, cli):
         hook=f"""
             import schemathesis
 
-            @schemathesis.register_check
+            @schemathesis.checks.register
             def new_check(response, result):
                 raise {exception}
             """
@@ -2202,7 +2202,7 @@ import schemathesis
 
 note = print
 
-@schemathesis.register_check
+@schemathesis.checks.register
 def data_generation_check(response, case):
     if case.data_generation_method:
         note("METHOD: {}".format(case.data_generation_method.name))

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -994,7 +994,7 @@ def test_pre_run_hook_valid(testdir, cli, schema_url, app):
     import schemathesis
     from hypothesis import strategies as st
 
-    schemathesis.register_string_format(
+    schemathesis.openapi.format(
         "digits",
         st.text(
             min_size=1,

--- a/test/cli/test_hooks.py
+++ b/test/cli/test_hooks.py
@@ -28,7 +28,7 @@ def test_custom_cli_handlers(testdir, cli, schema_url, app):
             if isinstance(event, events.Finished):
                 click.echo("Done!")
 
-    @schemathesis.hooks.register
+    @schemathesis.hook
     def after_init_cli_run_handlers(
         context,
         handlers,
@@ -56,7 +56,7 @@ import schemathesis
 
 note = print  # To avoid linting error
 
-@schemathesis.hooks.register
+@schemathesis.hook
 def before_call(context, case):
     note("\\nBefore!")
     case.query = {"q": "42"}
@@ -78,7 +78,7 @@ def test_after_call(testdir, cli, cli_args):
 import schemathesis
 import requests
 
-@schemathesis.hooks.register
+@schemathesis.hook
 def after_call(context, case, response):
     data = b'{"wrong": 42}'
     if isinstance(response, requests.Response):
@@ -103,7 +103,7 @@ def test_process_call_kwargs(testdir, cli, cli_args, mocker, app_type):
 import schemathesis
 import requests
 
-@schemathesis.hooks.register
+@schemathesis.hook
 def process_call_kwargs(context, case, kwargs):
     if case.app is not None:
         kwargs["follow_redirects"] = False

--- a/test/cli/test_targeted.py
+++ b/test/cli/test_targeted.py
@@ -12,7 +12,7 @@ def new_target(testdir, cli):
             import schemathesis
             import click
 
-            @schemathesis.targets.register
+            @schemathesis.target
             def new_target(context) -> float:
                 click.echo("NEW TARGET IS CALLED")
                 assert context.case.data_generation_method is not None, "Empty data_generation_method"
@@ -62,7 +62,7 @@ def test_custom_target_graphql(cli, new_target, graphql_url):
 
 @pytest.fixture
 def target_function():
-    @schemathesis.targets.register
+    @schemathesis.target
     def new_target(context):
         return 0.5
 
@@ -72,7 +72,7 @@ def target_function():
 
 
 def test_register_returns_a_value(target_function):
-    # When a function is registered via the `schemathesis.targets.register` decorator
+    # When a function is registered via the `schemathesis.target` decorator
     # Then this function should be available for further usage
     # See #721
     assert target_function is not None

--- a/test/cli/test_targeted.py
+++ b/test/cli/test_targeted.py
@@ -12,7 +12,7 @@ def new_target(testdir, cli):
             import schemathesis
             import click
 
-            @schemathesis.register_target
+            @schemathesis.targets.register
             def new_target(context) -> float:
                 click.echo("NEW TARGET IS CALLED")
                 assert context.case.data_generation_method is not None, "Empty data_generation_method"
@@ -62,7 +62,7 @@ def test_custom_target_graphql(cli, new_target, graphql_url):
 
 @pytest.fixture
 def target_function():
-    @schemathesis.register_target
+    @schemathesis.targets.register
     def new_target(context):
         return 0.5
 
@@ -72,7 +72,7 @@ def target_function():
 
 
 def test_register_returns_a_value(target_function):
-    # When a function is registered via the `register_target` decorator
+    # When a function is registered via the `schemathesis.targets.register` decorator
     # Then this function should be available for further usage
     # See #721
     assert target_function is not None

--- a/test/contrib/test_unique_data.py
+++ b/test/contrib/test_unique_data.py
@@ -111,7 +111,7 @@ def unique_hook(testdir):
 
         seen = set()
 
-        @schemathesis.checks.register
+        @schemathesis.check
         def unique_test_cases(response, case):
             command = case.as_curl_command({**response.request.headers, "X-Schemathesis-TestCaseId": "0"})
             assert command not in seen, f"Test case already seen! {command}"

--- a/test/contrib/test_unique_data.py
+++ b/test/contrib/test_unique_data.py
@@ -111,7 +111,7 @@ def unique_hook(testdir):
 
         seen = set()
 
-        @schemathesis.register_check
+        @schemathesis.checks.register
         def unique_test_cases(response, case):
             command = case.as_curl_command({**response.request.headers, "X-Schemathesis-TestCaseId": "0"})
             assert command not in seen, f"Test case already seen! {command}"

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -515,7 +515,7 @@ def filter_path_parameters():
             lambda x: x["key"] not in ("..", ".", "", "/") and not (isinstance(x["key"], str) and "/" in x["key"])
         )
 
-    schemathesis.hooks.register(before_generate_path_parameters)
+    schemathesis.hook(before_generate_path_parameters)
     yield
     schemathesis.hooks.unregister_all()
 

--- a/test/service/test_cli.py
+++ b/test/service/test_cli.py
@@ -90,7 +90,7 @@ def test_error_in_another_handler(testdir, cli, schema_url, service):
             def handle_event(self, context, event):
                 1 / 0
 
-        @schemathesis.hooks.register
+        @schemathesis.hook
         def after_init_cli_run_handlers(
             context,
             handlers,

--- a/test/service/test_usage.py
+++ b/test/service/test_usage.py
@@ -82,7 +82,7 @@ def test_collect_out_of_cli_context():
 def test_collect_hooks():
     cli_runner = CliRunner()
 
-    @schemathesis.hooks.register
+    @schemathesis.hook
     def before_generate_query(context, strategy):
         # This is noop
         return strategy

--- a/test/specs/graphql/test_custom_scalars.py
+++ b/test/specs/graphql/test_custom_scalars.py
@@ -17,7 +17,7 @@ def clear_custom_scalars():
 def test_custom_scalar_graphql():
     # When a custom scalar strategy is registered
     expected = "2022-04-27"
-    schemathesis.graphql.register_scalar("Date", st.just(expected).map(nodes.String))
+    schemathesis.graphql.scalar("Date", st.just(expected).map(nodes.String))
     raw_schema = """
 scalar Date
 
@@ -44,4 +44,4 @@ type Query {
 )
 def test_invalid_strategy(name, value, expected):
     with pytest.raises(UsageError, match=expected):
-        schemathesis.graphql.register_scalar(name, value)
+        schemathesis.graphql.scalar(name, value)

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -6,7 +6,7 @@ from hypothesis import HealthCheck, assume, find, given, settings
 from hypothesis import strategies as st
 
 import schemathesis
-from schemathesis import Case, DataGenerationMethod, register_string_format
+from schemathesis import Case, DataGenerationMethod
 from schemathesis.exceptions import InvalidSchema
 from schemathesis.models import APIOperation, OperationDefinition
 from schemathesis.parameters import ParameterSet, PayloadAlternatives
@@ -153,7 +153,7 @@ def test_invalid_body_in_get_disable_validation(simple_schema):
 
 @pytest.mark.filterwarnings("ignore:.*method is good for exploring strategies.*")
 def test_custom_strategies(swagger_20):
-    register_string_format("even_4_digits", st.from_regex(r"\A[0-9]{4}\Z").filter(lambda x: int(x) % 2 == 0))
+    schemathesis.openapi.format("even_4_digits", st.from_regex(r"\A[0-9]{4}\Z").filter(lambda x: int(x) % 2 == 0))
     operation = make_operation(
         swagger_20,
         query=ParameterSet(
@@ -223,7 +223,7 @@ def test_default_strategies_bytes(swagger_20):
 )
 def test_invalid_custom_strategy(values, error):
     with pytest.raises(TypeError) as exc:
-        register_string_format(*values)
+        schemathesis.openapi.format(*values)
     assert error in str(exc.value)
 
 

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -406,7 +406,7 @@ def test_hooks_with_lazy_schema(testdir, simple_openapi, decorators):
         f"""
 lazy_schema = schemathesis.from_pytest_fixture("simple_schema")
 
-@lazy_schema.hooks.register
+@lazy_schema.hook
 def before_generate_query(context, strategy):
     return strategy.filter(lambda x: x["id"].isdigit())
 
@@ -650,7 +650,7 @@ def before_generate_case_first(ctx, strategy):
 @pytest.fixture()
 def api_schema():
     loaded = schemathesis.from_dict(raw_schema)
-    loaded.hooks.register("before_generate_case")(before_generate_case_first)
+    loaded.hook("before_generate_case")(before_generate_case_first)
     return loaded
 
 
@@ -668,7 +668,7 @@ def before_generate_case_second(ctx, strategy):
 
     return strategy.map(change)
 
-lazy_schema.hooks.register("before_generate_case")(before_generate_case_second)
+lazy_schema.hook("before_generate_case")(before_generate_case_second)
 
 @lazy_schema.parametrize()
 @settings(max_examples=1)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -23,7 +23,7 @@ def to_csv(data):
 
 @pytest.fixture
 def csv_serializer():
-    @schemathesis.serializers.register("text/csv", aliases=["text/tsv"])
+    @schemathesis.serializer("text/csv", aliases=["text/tsv"])
     class CSVSerializer:
         def as_requests(self, context, value):
             return {"data": to_csv(value)}
@@ -80,7 +80,7 @@ def test_register_incomplete_serializer():
     # Then you'll have a TypeError
     with pytest.raises(TypeError, match="`CSVSerializer` is not a valid serializer."):
 
-        @schemathesis.serializers.register("text/csv")
+        @schemathesis.serializer("text/csv")
         class CSVSerializer:
             def as_requests(self, context, value):
                 pass


### PR DESCRIPTION
This way it would be the same as `schemathesis.{hooks,serializers,auth}.register`.

Maybe the next step could look like this:

```python
import schemathesis

@schemathesis.check
def my_check(response, case):
    pass


@schemathesis.target
def big_response_size(context):
    pass


@schemathesis.hook
def before_call(context, case):
    pass


@schemathesis.serializer
class MessagePackSerializer:
    ...


@schemathesis.auth
class TokenAuth:
    ...


schemathesis.openapi.format("visa_cards", st.from_regex(r"\A4[0-9]{15}\Z").filter(luhn_validator))
```

\+ checks should receive `context` as well