### PR TITLE
fix: Properly display flaky deadline errors

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -38,6 +38,7 @@ Changelog
 - Remove recursive references from the last reference resolution level.
   It works on the best effort basis and does not cover all possible cases. `#947`_
 - Invalid cassettes when headers contain characters with a special meaning in YAML.
+- Properly display flaky deadline errors.
 
 .. _v3.17.5:
 

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -348,9 +348,13 @@ def run_test(  # pylint: disable=too-many-locals
         # Schemathesis may detect multiple errors that come from different check results
         # They raise different "grouped" exceptions
         status = Status.failure
-    except hypothesis.errors.Flaky:
-        status = Status.failure
-        result.mark_flaky()
+    except hypothesis.errors.Flaky as exc:
+        if isinstance(exc.__cause__, hypothesis.errors.DeadlineExceeded):
+            status = Status.error
+            result.add_error(DeadlineExceeded.from_exc(exc.__cause__))
+        else:
+            status = Status.failure
+            result.mark_flaky()
     except hypothesis.errors.Unsatisfiable:
         # We need more clear error message here
         status = Status.error

--- a/test/apps/openapi/_flask/__init__.py
+++ b/test/apps/openapi/_flask/__init__.py
@@ -31,6 +31,7 @@ def create_app(
     app.config["incoming_requests"] = []
     app.config["schema_requests"] = []
     app.config["internal_exception"] = False
+    app.config["random_delay"] = False
     app.config["users"] = {}
 
     @app.before_request
@@ -126,6 +127,9 @@ def create_app(
 
     @app.route("/api/path_variable/<key>", methods=["GET"])
     def path_variable(key):
+        if app.config["random_delay"]:
+            sleep(app.config["random_delay"])
+            app.config["random_delay"] = False
         return jsonify({"success": True})
 
     @app.route("/api/unsatisfiable", methods=["POST"])


### PR DESCRIPTION
It also fixes a rare test failure in `test_hypothesis_failed_event`