### PR TITLE
perf: Filter out less data during schema mutation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,7 @@ Changelog
 - Set ``starlette>=0.13,<0.21``.
 - Relax requirements for ``attrs``. `#1643`_
 - Avoid occasional empty lines in cassettes.
+- Performance: Running negative tests filters out less data.
 
 **Deprecated**
 


### PR DESCRIPTION
On the example API the number of rejected cases dropped on average from thousands to dozens (for `--max-examples=10`)