### PR TITLE
Allow mitigation of CVE-2023-25577

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Changed**
+
+- Support any Werkzeug 2.x in order to allow mitigation of CVE-2023-25577.
+
 .. _v3.18.3:
 
 `3.18.3`_ - 2023-02-12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "tomli-w>=1.0.0,<2.0",
     "tomli>=2.0.1,<3.0",
     "typing-extensions>=3.7,<5",
-    "werkzeug>=0.16.0,<=2.2.2",
+    "werkzeug>=0.16.0,<=3",
     "yarl>=1.5,<2.0"
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
### Description

Mitigation of CVE-2023-25577 requires upgrading Werkzeug to 2.2.3. This PR loosens the dependency requirement to allow any Werkzeug 2.x as there doesn't appear to be a reason to be stricter.

This resolves #1695.

### Checklist

- [x] Created tests which fail without the change (if possible)
  - n/a
- [x] All tests passing
- [x] Added a changelog entry
- [x] Extended the README / documentation, if necessary
  - n/a
