### PR TITLE
feat: Selective auth

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,18 @@ Changelog
 
     schemathesis.auth.set_from_requests(HttpNtlmAuth("domain\\username", "password"))
 
+- Ability to apply authentication conditionally to specific API operations using a combination of ``@schemathesis.auth.apply_to()`` and ``@schemathesis.auth.skip_for()`` decorators.
+
+.. code:: python
+
+    import schemathesis
+
+
+    # Apply auth only for operations that path starts with `/users/` but not the `POST` method
+    @schemathesis.auth().apply_to(path_regex="^/users/").skip_for(method="POST")
+    class MyAuth:
+        ...
+
 **Changed**
 
 - Unified Schemathesis custom authentication usage via the ``schema.auth`` decorator, replacing the previous ``schema.auth.register`` and ``schema.auth.apply`` methods:

--- a/src/schemathesis/filters.py
+++ b/src/schemathesis/filters.py
@@ -1,0 +1,269 @@
+"""Filtering system that allows users to filter API operations based on certain criteria."""
+import re
+from functools import partial
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Callable, List, Optional, Set, Tuple, Union
+
+import attr
+from typing_extensions import Protocol
+
+from .exceptions import UsageError
+
+if TYPE_CHECKING:
+    from .models import APIOperation
+
+
+class HasAPIOperation(Protocol):
+    operation: "APIOperation"
+
+
+MatcherFunc = Callable[[HasAPIOperation], bool]
+FilterValue = Union[str, List[str]]
+RegexValue = Union[str, re.Pattern]
+ERROR_EXPECTED_AND_REGEX = "Passing expected value and regex simultaneously is not allowed"
+ERROR_EMPTY_FILTER = "Filter can not be empty"
+ERROR_FILTER_EXISTS = "Filter already exists"
+
+
+@attr.s(slots=True, repr=False, frozen=True)
+class Matcher:
+    """Encapsulates matching logic by various criteria."""
+
+    func: Callable[..., bool] = attr.ib(hash=False, eq=False)
+    # A short description of a matcher. Primarily exists for debugging purposes
+    label: str = attr.ib(hash=False, eq=False)
+    # Compare & hash matchers by a pre-computed hash value
+    _hash: int = attr.ib()
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: {self.label}>"
+
+    @classmethod
+    def for_function(cls, func: MatcherFunc) -> "Matcher":
+        """Matcher that uses the given function for matching operations."""
+        return cls(func, label=func.__name__, hash=hash(func))
+
+    @classmethod
+    def for_value(cls, attribute: str, expected: FilterValue) -> "Matcher":
+        """Matcher that checks whether the specified attribute has the expected value."""
+        if isinstance(expected, list):
+            func = partial(by_value_list, attribute=attribute, expected=expected)
+        else:
+            func = partial(by_value, attribute=attribute, expected=expected)
+        label = f"{attribute}={repr(expected)}"
+        return cls(func, label=label, hash=hash(label))
+
+    @classmethod
+    def for_regex(cls, attribute: str, regex: RegexValue) -> "Matcher":
+        """Matcher that checks whether the specified attribute has the provided regex."""
+        if isinstance(regex, str):
+            regex = re.compile(regex)
+        func = partial(by_regex, attribute=attribute, regex=regex)
+        label = f"{attribute}_regex={repr(regex)}"
+        return cls(func, label=label, hash=hash(label))
+
+    def match(self, ctx: HasAPIOperation) -> bool:
+        """Whether matcher matches the given operation."""
+        return self.func(ctx)
+
+
+def get_operation_attribute(operation: "APIOperation", attribute: str) -> str:
+    # Just uppercase `method`
+    value = getattr(operation, attribute)
+    if attribute == "method":
+        value = value.upper()
+    return value
+
+
+def by_value(ctx: HasAPIOperation, attribute: str, expected: str) -> bool:
+    return get_operation_attribute(ctx.operation, attribute) == expected
+
+
+def by_value_list(ctx: HasAPIOperation, attribute: str, expected: List[str]) -> bool:
+    return get_operation_attribute(ctx.operation, attribute) in expected
+
+
+def by_regex(ctx: HasAPIOperation, attribute: str, regex: re.Pattern) -> bool:
+    value = get_operation_attribute(ctx.operation, attribute)
+    return bool(regex.match(value))
+
+
+@attr.s(slots=True, repr=False, frozen=True)
+class Filter:
+    """Match API operations against a list of matchers."""
+
+    matchers: Tuple[Matcher, ...] = attr.ib()
+
+    def __repr__(self) -> str:
+        inner = " && ".join(matcher.label for matcher in self.matchers)
+        return f"<{self.__class__.__name__}: [{inner}]>"
+
+    def match(self, ctx: HasAPIOperation) -> bool:
+        """Whether the operation matches the filter.
+
+        Returns `True` only if all matchers matched.
+        """
+        return all(matcher.match(ctx) for matcher in self.matchers)
+
+
+@attr.s(slots=True)
+class FilterSet:
+    """Combines multiple filters to apply inclusion and exclusion rules on API operations."""
+
+    _includes: Set[Filter] = attr.ib(factory=set)
+    _excludes: Set[Filter] = attr.ib(factory=set)
+
+    def apply_to(self, operations: List["APIOperation"]) -> List["APIOperation"]:
+        """Get a filtered list of the given operations that match the filters."""
+        return [operation for operation in operations if self.match(SimpleNamespace(operation=operation))]
+
+    def match(self, ctx: HasAPIOperation) -> bool:
+        """Determines whether the given operation should be included based on the defined filters.
+
+        Returns True if the operation:
+          - matches at least one INCLUDE filter OR no INCLUDE filters defined;
+          - does not match any EXCLUDE filter;
+        False otherwise.
+        """
+        # Exclude early if the operation is excluded by at least one EXCLUDE filter
+        for filter_ in self._excludes:
+            if filter_.match(ctx):
+                return False
+        if not self._includes:
+            # No includes - nothing to filter out, include the operation
+            return True
+        # Otherwise check if the operation is included by at least one INCLUDE filter
+        return any(filter_.match(ctx) for filter_ in self._includes)
+
+    def is_empty(self) -> bool:
+        """Whether the filter set does not contain any filters."""
+        return not self._includes and not self._excludes
+
+    def include(
+        self,
+        func: Optional[MatcherFunc] = None,
+        *,
+        name: Optional[FilterValue] = None,
+        name_regex: Optional[RegexValue] = None,
+        method: Optional[FilterValue] = None,
+        method_regex: Optional[RegexValue] = None,
+        path: Optional[FilterValue] = None,
+        path_regex: Optional[RegexValue] = None,
+    ) -> None:
+        """Add a new INCLUDE filter."""
+        self._add_filter(
+            True,
+            func=func,
+            name=name,
+            name_regex=name_regex,
+            method=method,
+            method_regex=method_regex,
+            path=path,
+            path_regex=path_regex,
+        )
+
+    def exclude(
+        self,
+        func: Optional[MatcherFunc] = None,
+        *,
+        name: Optional[FilterValue] = None,
+        name_regex: Optional[RegexValue] = None,
+        method: Optional[FilterValue] = None,
+        method_regex: Optional[RegexValue] = None,
+        path: Optional[FilterValue] = None,
+        path_regex: Optional[RegexValue] = None,
+    ) -> None:
+        """Add a new EXCLUDE filter."""
+        self._add_filter(
+            False,
+            func=func,
+            name=name,
+            name_regex=name_regex,
+            method=method,
+            method_regex=method_regex,
+            path=path,
+            path_regex=path_regex,
+        )
+
+    def _add_filter(
+        self,
+        include: bool,
+        *,
+        func: Optional[MatcherFunc] = None,
+        name: Optional[FilterValue] = None,
+        name_regex: Optional[RegexValue] = None,
+        method: Optional[FilterValue] = None,
+        method_regex: Optional[RegexValue] = None,
+        path: Optional[FilterValue] = None,
+        path_regex: Optional[RegexValue] = None,
+    ) -> None:
+        matchers = []
+        if func is not None:
+            matchers.append(Matcher.for_function(func))
+        for attribute, expected, regex in (
+            ("verbose_name", name, name_regex),
+            ("method", method, method_regex),
+            ("path", path, path_regex),
+        ):
+            if expected is not None and regex is not None:
+                # To match anything the regex should match the expected value, hence passing them together is useless
+                raise UsageError(ERROR_EXPECTED_AND_REGEX)
+            if expected is not None:
+                matchers.append(Matcher.for_value(attribute, expected))
+            if regex is not None:
+                matchers.append(Matcher.for_regex(attribute, regex))
+
+        if not matchers:
+            raise UsageError(ERROR_EMPTY_FILTER)
+        filter_ = Filter(matchers=tuple(matchers))
+        if filter_ in self._includes or filter_ in self._excludes:
+            raise UsageError(ERROR_FILTER_EXISTS)
+        if include:
+            self._includes.add(filter_)
+        else:
+            self._excludes.add(filter_)
+
+
+def attach_filter_chain(
+    target: Callable,
+    attribute: str,
+    filter_func: Callable[..., None],
+) -> None:
+    """Attach a filtering function to an object, which allows chaining of filter criteria.
+
+    For example:
+
+    >>> def auth(): ...
+    >>> filter_set = FilterSet()
+    >>> attach_filter_chain(auth, "apply_to", filter_set.include)
+    >>> auth.apply_to(method="GET", path="/users/")
+
+    This will add a new `apply_to` method to `auth` that matches only the `GET /users/` operation.
+    """
+
+    def proxy(
+        func: Optional[MatcherFunc] = None,
+        *,
+        name: Optional[FilterValue] = None,
+        name_regex: Optional[str] = None,
+        method: Optional[FilterValue] = None,
+        method_regex: Optional[str] = None,
+        path: Optional[FilterValue] = None,
+        path_regex: Optional[str] = None,
+    ) -> Callable:
+        __tracebackhide__ = True
+        filter_func(
+            func=func,
+            name=name,
+            name_regex=name_regex,
+            method=method,
+            method_regex=method_regex,
+            path=path,
+            path_regex=path_regex,
+        )
+        return target
+
+    proxy.__qualname__ = attribute
+    proxy.__name__ = attribute
+
+    setattr(target, attribute, proxy)

--- a/src/schemathesis/lazy.py
+++ b/src/schemathesis/lazy.py
@@ -105,7 +105,7 @@ class LazySchema:
                     tag=tag,
                     operation_id=operation_id,
                     hooks=self.hooks,
-                    auth=self.auth if self.auth.provider is not None else NOT_SET,
+                    auth=self.auth if self.auth.providers is not None else NOT_SET,
                     test_function=test,
                     validate_schema=validate_schema,
                     skip_deprecated_operations=skip_deprecated_operations,

--- a/test/auth/test_provider.py
+++ b/test/auth/test_provider.py
@@ -82,17 +82,17 @@ def test_register_valid(auth_storage, auth_provider_class):
     # When the class implementation is valid
     # Then it should be possible to register it without issues
     auth_storage.register(refresh_interval=None)(auth_provider_class)
-    assert auth_storage.provider is not None
-    assert isinstance(auth_storage.provider, auth_provider_class)
+    assert auth_storage.providers
+    assert isinstance(auth_storage.providers[0], auth_provider_class)
 
 
 def test_register_cached(auth_storage, auth_provider_class):
     # When the `refresh_interval` is not None
     auth_storage.register()(auth_provider_class)
     # Then the actual provider should be cached
-    assert auth_storage.provider is not None
-    assert isinstance(auth_storage.provider, CachingAuthProvider)
-    assert isinstance(auth_storage.provider.provider, auth_provider_class)
+    assert auth_storage.providers
+    assert isinstance(auth_storage.providers[0], CachingAuthProvider)
+    assert isinstance(auth_storage.providers[0].provider, auth_provider_class)
 
 
 def test_set_noop(auth_storage, mocker):

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -1065,7 +1065,6 @@ def test_hooks_module_not_found(cli):
     assert "ModuleNotFoundError" in result.stdout
 
 
-@pytest.mark.usefixtures("reset_hooks")
 def test_conditional_checks(testdir, cli, hypothesis_max_examples, schema_url):
     module = testdir.make_importable_pyfile(
         hook="""
@@ -1092,7 +1091,6 @@ def test_conditional_checks(testdir, cli, hypothesis_max_examples, schema_url):
     assert "No checks were performed." in result.stdout
 
 
-@pytest.mark.usefixtures("reset_hooks")
 def test_add_case(testdir, cli, hypothesis_max_examples, schema_url):
     module = testdir.make_importable_pyfile(
         hook="""
@@ -1128,7 +1126,6 @@ def test_add_case(testdir, cli, hypothesis_max_examples, schema_url):
     assert result.stdout.count("The case was added!") == 2
 
 
-@pytest.mark.usefixtures("reset_hooks")
 def test_add_case_returns_none(testdir, cli, hypothesis_max_examples, schema_url):
     """Tests that no additional test case created when the add_case hook returns None."""
     module = testdir.make_importable_pyfile(
@@ -1161,7 +1158,6 @@ def test_add_case_returns_none(testdir, cli, hypothesis_max_examples, schema_url
     assert result.stdout.count("Validating case.") == 2
 
 
-@pytest.mark.usefixtures("reset_hooks")
 def test_multiple_add_case_hooks(testdir, cli, hypothesis_max_examples, schema_url):
     """add_case hooks that mutate the case in place should not affect other cases."""
     module = testdir.make_importable_pyfile(
@@ -1209,7 +1205,6 @@ def test_multiple_add_case_hooks(testdir, cli, hypothesis_max_examples, schema_u
     assert result.stdout.count("Second case added!") == 2
 
 
-@pytest.mark.usefixtures("reset_hooks")
 def test_add_case_output(testdir, cli, hypothesis_max_examples, schema_url):
     module = testdir.make_importable_pyfile(
         hook="""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -19,7 +19,6 @@ from schemathesis.cli import reset_checks
 from schemathesis.constants import HOOKS_MODULE_ENV_VAR
 from schemathesis.extra._aiohttp import run_server as run_aiohttp_server
 from schemathesis.extra._flask import run_server as run_flask_server
-from schemathesis.hooks import unregister_all
 from schemathesis.service import HOSTS_PATH_ENV_VAR
 from schemathesis.specs.openapi import loaders as oas_loaders
 from schemathesis.utils import WSGIResponse
@@ -46,10 +45,11 @@ def setup(tmp_path_factory):
     os.environ[HOSTS_PATH_ENV_VAR] = str(hosts_path)
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def reset_hooks():
     yield
-    unregister_all()
+    schemathesis.hooks.unregister_all()
+    schemathesis.auth.unregister()
     reset_checks()
 
 

--- a/test/contrib/test_unique_data.py
+++ b/test/contrib/test_unique_data.py
@@ -137,14 +137,12 @@ def run(testdir, cli, unique_hook, schema, openapi3_base_url, hypothesis_max_exa
     )
 
 
-@pytest.mark.usefixtures("reset_hooks")
 def test_cli(testdir, unique_hook, raw_schema, cli, openapi3_base_url, hypothesis_max_examples):
     result = run(testdir, cli, unique_hook, raw_schema, openapi3_base_url, hypothesis_max_examples)
     assert result.exit_code == ExitCode.OK, result.stdout
 
 
 @pytest.mark.parametrize("workers", (1, 2))
-@pytest.mark.usefixtures("reset_hooks")
 def test_explicit_headers(
     testdir, unique_hook, empty_open_api_3_schema, cli, openapi3_base_url, hypothesis_max_examples, workers
 ):

--- a/test/filters/test_matching.py
+++ b/test/filters/test_matching.py
@@ -1,0 +1,212 @@
+import re
+
+import pytest
+
+import schemathesis
+from schemathesis import filters
+from schemathesis.exceptions import UsageError
+from schemathesis.models import APIOperation
+
+RAW_SCHEMA = {
+    "openapi": "3.0.2",
+    "info": {"title": "Test", "description": "Test", "version": "0.1.0"},
+    "paths": {
+        "/users/": {
+            "get": {
+                "responses": {"200": {"description": "OK"}},
+            },
+            "post": {
+                "deprecated": True,
+                "responses": {"200": {"description": "OK"}},
+            },
+        },
+        "/users/{user_id}/": {
+            "patch": {
+                "responses": {"200": {"description": "OK"}},
+            },
+        },
+        "/orders/": {
+            "get": {
+                "responses": {"200": {"description": "OK"}},
+            },
+            "post": {
+                "responses": {"200": {"description": "OK"}},
+            },
+        },
+    },
+}
+SCHEMA = schemathesis.from_dict(RAW_SCHEMA)
+USERS_GET = SCHEMA["/users/"]["GET"]
+USERS_POST = SCHEMA["/users/"]["POST"]
+USER_ID_PATCH = SCHEMA["/users/{user_id}/"]["PATCH"]
+ORDERS_GET = SCHEMA["/orders/"]["GET"]
+ORDERS_POST = SCHEMA["/orders/"]["POST"]
+OPERATIONS = [USERS_GET, USERS_POST, USER_ID_PATCH, ORDERS_GET, ORDERS_POST]
+NO_PATCH = [USERS_GET, USERS_POST, ORDERS_GET, ORDERS_POST]
+SINGLE_INCLUDE_CASES = (
+    ({"path": "/users/"}, [USERS_GET, USERS_POST]),
+    ({"path": ["/users/", "/orders/"]}, NO_PATCH),
+    ({"path_regex": "^/users/"}, [USERS_GET, USERS_POST, USER_ID_PATCH]),
+    ({"method": "GET"}, [USERS_GET, ORDERS_GET]),
+    ({"method": ["GET", "PATCH"]}, [USERS_GET, USER_ID_PATCH, ORDERS_GET]),
+    ({"method_regex": "^P"}, [USERS_POST, USER_ID_PATCH, ORDERS_POST]),
+    ({"name": "GET /users/"}, [USERS_GET]),
+    ({"name": ["GET /users/", "POST /orders/"]}, [USERS_GET, ORDERS_POST]),
+    ({"name_regex": "^P.+ /(users|orders)/"}, [USERS_POST, USER_ID_PATCH, ORDERS_POST]),
+    ({"name_regex": re.compile("^p.+ /(USERS|orders)/", re.IGNORECASE)}, [USERS_POST, USER_ID_PATCH, ORDERS_POST]),
+)
+MULTI_INCLUDE_CASES = [
+    (({"path": "/users/"}, {"path": "/orders/"}), NO_PATCH),
+    (({"path": ["/users/"]}, {"path": ["/orders/"]}), NO_PATCH),
+    (({"path_regex": "^/users/$"}, {"path_regex": "^/orders/"}), NO_PATCH),
+    (({"method": "POST"}, {"method": "GET"}), NO_PATCH),
+    (({"method": ["POST"]}, {"method": ["GET"]}), NO_PATCH),
+    (({"method_regex": "^P.+T$"}, {"method_regex": "^G"}), NO_PATCH),
+    (({"name": "GET /users/"}, {"name": "GET /orders/"}), [USERS_GET, ORDERS_GET]),
+    (({"name": ["GET /users/", "POST /users/"]}, {"name": ["GET /orders/", "POST /orders/"]}), NO_PATCH),
+    (({"name_regex": "^P.+T /users/$"}, {"name_regex": "^G.+ /orders/$"}), [USERS_POST, ORDERS_GET]),
+    (
+        ({"path": "/users/", "method_regex": "GET|POST"}, {"name_regex": "^G.+ /orders/$"}),
+        [USERS_GET, USERS_POST, ORDERS_GET],
+    ),
+]
+
+
+def case_id(case):
+    if isinstance(case[0], APIOperation):
+        return "expected"
+
+    def fmt_item(key, value):
+        if isinstance(value, list):
+            return f"{key}_list"
+        return key
+
+    def fmt_kwargs(kwargs):
+        return ",".join(fmt_item(key, value) for key, value in kwargs.items())
+
+    return "-".join(f"{kind}-{fmt_kwargs(kwargs)}" for kind, kwargs in case)
+
+
+@pytest.mark.parametrize(
+    "chain, expected",
+    [
+        (
+            [("include", kwargs)],
+            selection,
+        )
+        for (kwargs, selection) in SINGLE_INCLUDE_CASES
+    ]
+    + [
+        (
+            [("exclude", kwargs)],
+            [o for o in OPERATIONS if o not in selection],
+        )
+        for (kwargs, selection) in SINGLE_INCLUDE_CASES
+    ]
+    + [
+        (
+            [("include", kwargs) for kwargs in chain],
+            selection,
+        )
+        for (chain, selection) in MULTI_INCLUDE_CASES
+    ]
+    + [
+        (
+            [("exclude", kwargs) for kwargs in chain],
+            [o for o in OPERATIONS if o not in selection],
+        )
+        for (chain, selection) in MULTI_INCLUDE_CASES
+    ]
+    + [
+        ([("include", {"path_regex": "^/u"}), ("exclude", {"method_regex": "..TCH|DELET"})], [USERS_GET, USERS_POST]),
+        (
+            [("include", {"name": "GET /orders/"}), ("exclude", {"method": "POST"}), ("exclude", {"path": "/users/"})],
+            [ORDERS_GET],
+        ),
+        ([("include", {"method": "GET"}), ("exclude", {"path_regex": "^/users/"})], [ORDERS_GET]),
+        (
+            [
+                ("include", {"path": "/users/"}),
+                ("exclude", {"func": lambda ctx: ctx.operation.definition.resolved.get("deprecated") is True}),
+            ],
+            [USERS_GET],
+        ),
+    ],
+    ids=case_id,
+)
+def test_matchers(chain, expected):
+    filter_set = filters.FilterSet()
+    for method, kwargs in chain:
+        getattr(filter_set, method)(**kwargs)
+    assert filter_set.apply_to(OPERATIONS) == expected
+
+
+def matcher_func(ctx):
+    return True
+
+
+@pytest.mark.parametrize(
+    "matchers, expected",
+    (
+        ([filters.Matcher.for_function(matcher_func)], "<Filter: [matcher_func]>"),
+        ([filters.Matcher.for_function(lambda ctx: True)], "<Filter: [<lambda>]>"),
+        ([filters.Matcher.for_value("method", "POST")], "<Filter: [method='POST']>"),
+        (
+            [filters.Matcher.for_value("method", "POST"), filters.Matcher.for_value("path", "/users/")],
+            "<Filter: [method='POST' && path='/users/']>",
+        ),
+        ([filters.Matcher.for_regex("path", "^/u")], "<Filter: [path_regex=re.compile('^/u')]>"),
+        (
+            [filters.Matcher.for_regex("path", re.compile("^/u", re.IGNORECASE))],
+            "<Filter: [path_regex=re.compile('^/u', re.IGNORECASE)]>",
+        ),
+    ),
+)
+def test_filter_repr(matchers, expected):
+    assert repr(filters.Filter(matchers)) == expected
+
+
+def test_matcher_repr():
+    assert repr(filters.Matcher.for_value("method", "POST")) == "<Matcher: method='POST'>"
+
+
+def test_sanity_checks():
+    with pytest.raises(UsageError, match=filters.ERROR_EMPTY_FILTER):
+        filters.FilterSet().include()
+
+
+def test_attach_filter_chain():
+    def auth():
+        pass
+
+    filter_set = filters.FilterSet()
+    filters.attach_filter_chain(auth, "apply_to", filter_set.include)
+    # Returns the same object
+    assert auth.apply_to(method="GET", path="/users/") is auth
+    assert not filter_set.is_empty()
+    assert len(filter_set._includes) == 1
+    assert repr(list(filter_set._includes)[0]) == "<Filter: [method='GET' && path='/users/']>"
+
+
+@pytest.mark.parametrize("method", (filters.FilterSet.include, filters.FilterSet.exclude))
+@pytest.mark.parametrize(
+    "kwargs",
+    (
+        {"name": "foo"},
+        {"func": matcher_func},
+        {"func": matcher_func, "method": "POST"},
+        {"func": lambda o: True},
+    ),
+)
+def test_repeating_filter(method, kwargs):
+    # Adding the same filter twice is an error
+    filter_set = filters.FilterSet()
+    filter_set.include(**kwargs)
+    with pytest.raises(UsageError, match=filters.ERROR_FILTER_EXISTS):
+        method(filter_set, **kwargs)
+
+
+def test_forbid_value_and_auth():
+    filter_set = filters.FilterSet()
+    with pytest.raises(UsageError, match=filters.ERROR_EXPECTED_AND_REGEX):
+        filter_set.include(method="POST", method_regex="GET")

--- a/test/hooks/test_hooks.py
+++ b/test/hooks/test_hooks.py
@@ -6,12 +6,6 @@ from schemathesis.hooks import HookContext, HookDispatcher, HookScope
 from schemathesis.utils import PARAMETRIZE_MARKER
 
 
-@pytest.fixture(autouse=True)
-def reset_hooks():
-    yield
-    schemathesis.hooks.unregister_all()
-
-
 @pytest.fixture(params=["direct", "named"])
 def global_hook(request):
     if request.param == "direct":

--- a/test/service/test_cli.py
+++ b/test/service/test_cli.py
@@ -6,7 +6,6 @@ import pytest
 from _pytest.main import ExitCode
 from requests import Timeout
 
-import schemathesis
 from schemathesis.cli.output.default import SERVICE_ERROR_MESSAGE, wait_for_report_handler
 from schemathesis.constants import USER_AGENT
 from schemathesis.service import ci, events
@@ -14,12 +13,6 @@ from schemathesis.service.constants import CI_PROVIDER_HEADER, REPORT_CORRELATIO
 from schemathesis.service.hosts import load_for_host
 
 from ..utils import strip_style_win32
-
-
-@pytest.fixture(autouse=True)
-def reset_hooks():
-    yield
-    schemathesis.hooks.unregister_all()
 
 
 def get_stdout_lines(stdout):

--- a/test/service/test_usage.py
+++ b/test/service/test_usage.py
@@ -8,12 +8,6 @@ from schemathesis.service import usage
 SCHEMA = "http://127.0.0.1:/schema.json"
 
 
-@pytest.fixture(autouse=True)
-def reset_hooks():
-    yield
-    schemathesis.hooks.unregister_all()
-
-
 @pytest.mark.parametrize(
     "args, expected",
     (


### PR DESCRIPTION
Resolves #1708

TODO:

- [x] Disallow value + regex together in the same filter
- [ ] Add mapping interface to `OperationDefinition` (for convenience) - separate PR
- [x] Allow multiple auth providers per storage and take the first one matched
- [x] Pass `ctx` to custom functions instead of just `APIOperation`
- [x] Document `auth` - examples, corner cases, possible errors, uppercasing `method`
- [x] More docstrings
- [x] Tests for using multiple auths
- [x] Tests with compiler regex with custom flags
- [x] `requests` auth support
