### PR TITLE
chore: bump allowed requests to 2.28.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: prettier
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.19.0dev
+    rev: v0.19.1
     hooks:
       - id: gitlint
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Changed**
+
+- Support ``requests<2.29``.
+
 .. _v3.19.0:
 
 `3.19.0`_ - 2023-03-22

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pytest-subtests>=0.2.1,<0.8.0",
     "pytest>=4.6.4,<8",
     "PyYAML>=5.1,<7.0",
-    "requests>=2.22,<=2.28.1",
+    "requests>=2.22,<2.29",
     "starlette>=0.13,<1",
     "starlette-testclient==0.2.0",
     "tomli-w>=1.0.0,<2.0",


### PR DESCRIPTION
🚨Please review the [guidelines for contributing](https://github.com/schemathesis/schemathesis/blob/master/CONTRIBUTING.rst) to this repository.

### Description

Bump of allowed requests version to 2.28.2

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Added a changelog entry
- [ ] Extended the README / documentation, if necessary
