### PR TITLE
feat: add excluded_checks option

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Added**
+
+- You can now provide a tuple of checks to exclude when validating a response.
+
 .. _v3.19.1:
 
 `3.19.1`_ - 2023-04-26

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -137,6 +137,34 @@ To make Schemathesis perform all built-in checks use ``--checks all`` CLI option
 
     ======================= 3 passed in 1.69s =======================
 
+You can also define a list of checks to exlude using the ``--exclude-checks | -e`` CLI option:
+
+.. code:: text
+
+    $ st run --checks all --exclude-checks not_a_server_error https://example.schemathesis.io/openapi.json
+    ================ Schemathesis test session starts ===============
+    platform Linux -- Python 3.8.5, schemathesis-2.5.0, ...
+    rootdir: /
+    hypothesis profile 'default' -> ...
+    Schema location: https://example.schemathesis.io/openapi.json
+    Base URL: http://api.com/
+    Specification version: Swagger 2.0
+    Workers: 1
+    Collected API operations: 3
+
+    GET /api/path_variable/{key} .                             [ 33%]
+    GET /api/success .                                         [ 66%]
+    POST /api/users/ .                                         [100%]
+
+    ============================ SUMMARY ============================
+
+    Performed checks:
+        status_code_conformance         201 / 201 passed       PASSED
+        content_type_conformance        201 / 201 passed       PASSED
+        response_schema_conformance     201 / 201 passed       PASSED
+
+    ======================= 3 passed in 1.69s =======================
+
 Additionally, you can define the response time limit with ``--max-response-time``.
 If any response will take longer than the provided value (in milliseconds) than it will indicate a failure:
 

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -308,6 +308,22 @@ The code above will run only the ``not_a_server_error`` check. Or a tuple of add
 
     Learn more about writing custom checks :ref:`here <writing-custom-checks>`.
 
+You can also use the ``excluded_checks`` argument to exclude chhecks from running:
+
+.. code-block:: python
+
+    from schemathesis.checks import not_a_server_error
+
+    ...
+
+
+    @schema.parametrize()
+    def test_api(case):
+        response = case.call()
+        case.validate_response(response, excluded_checks=(not_a_server_error,))
+
+The code above will run the default checks, and any additional checks, excluding the ``not_a_server_error`` check.
+
 If you don't use Schemathesis for data generation, you can still utilize response validation:
 
 .. code-block:: python

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -447,6 +447,7 @@ class Case:
         response: GenericResponse,
         checks: Tuple["CheckFunction", ...] = (),
         additional_checks: Tuple["CheckFunction", ...] = (),
+        excluded_checks: Tuple["CheckFunction", ...] = (),
         code_sample_style: Optional[str] = None,
     ) -> None:
         """Validate application response.
@@ -463,6 +464,8 @@ class Case:
         from .checks import ALL_CHECKS
 
         checks = checks or ALL_CHECKS
+        checks = tuple(check for check in checks if check not in excluded_checks)
+        additional_checks = tuple(check for check in additional_checks if check not in excluded_checks)
         failed_checks = []
         for check in chain(checks, additional_checks):
             copied_case = self.partial_deepcopy()

--- a/src/schemathesis/specs/graphql/schemas.py
+++ b/src/schemathesis/specs/graphql/schemas.py
@@ -65,10 +65,12 @@ class GraphQLCase(Case):
         response: GenericResponse,
         checks: Tuple[CheckFunction, ...] = (),
         additional_checks: Tuple[CheckFunction, ...] = (),
+        excluded_checks: Tuple[CheckFunction, ...] = (),
         code_sample_style: Optional[str] = None,
     ) -> None:
         checks = checks or (not_a_server_error,)
         checks += additional_checks
+        checks = tuple(check for check in checks if check not in excluded_checks)
         return super().validate_response(response, checks, code_sample_style=code_sample_style)
 
     def call_asgi(

--- a/test/cli/test_checks.py
+++ b/test/cli/test_checks.py
@@ -1,4 +1,5 @@
 import pytest
+from _pytest.main import ExitCode
 
 import schemathesis
 from schemathesis.cli import reset_checks
@@ -20,3 +21,46 @@ def test_register_returns_a_value(new_check):
     # Then this function should be available for further usage
     # See #721
     assert new_check is not None
+
+
+@pytest.mark.parametrize(
+    "exclude_checks,expected_exit_code,expected_result",
+    [
+        ("not_a_server_error", ExitCode.TESTS_FAILED, "1 passed, 1 failed in"),
+        ("not_a_server_error,status_code_conformance", ExitCode.OK, "2 passed in"),
+    ],
+)
+def test_exclude_checks(
+    testdir,
+    cli,
+    exclude_checks,
+    expected_exit_code,
+    expected_result,
+):
+    module = testdir.make_importable_pyfile(
+        location="""
+        from fastapi import FastAPI
+        from fastapi import HTTPException
+
+        app = FastAPI()
+
+        @app.get("/api/success")
+        async def success():
+            return {"success": True}
+
+        @app.get("/api/failure")
+        async def failure():
+            raise HTTPException(status_code=500)
+            return {"failure": True}
+        """
+    )
+    result = cli.run(
+        "/openapi.json", "--checks", "all", "--exclude-checks", exclude_checks, "--app", f"{module.purebasename}:app"
+    )
+
+    for check in exclude_checks.split(","):
+        assert check not in result.stdout
+
+    assert result.exit_code == expected_exit_code, result.stdout
+
+    assert expected_result in result.stdout

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -227,6 +227,8 @@ def test_commands_run_help(cli):
         "content_type_conformance|response_headers_conformance|response_schema_conformance|all]",
         "                                  Comma-separated list of checks to run.",
         "                                  [default: not_a_server_error]",
+        "  -e, --exclude-checks [not_a_server_error|status_code_conformance|content_type_conformance|response_headers_conformance|response_schema_conformance]",
+        "                                  Comma-separated list of checks to exclude.",
         "  --max-response-time INTEGER RANGE",
         "                                  A custom check that will fail if the response",
         "                                  time is greater than the specified one in",
@@ -587,6 +589,16 @@ def test_comma_separated_checks(cli, mocker, swagger_20):
     execute = mocker.patch("schemathesis.runner.from_schema", autospec=True)
     cli.run(SCHEMA_URI, "--checks=not_a_server_error,status_code_conformance")
     assert execute.call_args[1]["checks"] == (not_a_server_error, status_code_conformance)
+
+
+def test_comma_separated_exclude_checks(cli, mocker, swagger_20):
+    excluded_checks = "not_a_server_error,status_code_conformance"
+    mocker.patch("schemathesis.cli.load_schema", return_value=swagger_20)
+    execute = mocker.patch("schemathesis.runner.from_schema", autospec=True)
+    cli.run(SCHEMA_URI, "--checks=all", f"--exclude-checks={excluded_checks}")
+    assert execute.call_args[1]["checks"] == tuple(
+        check for check in tuple(ALL_CHECKS) if check.__name__ not in excluded_checks.split(",")
+    )
 
 
 @pytest.mark.operations()


### PR DESCRIPTION
### Description

This feature allows users to pass a tuple of check functions that they want to be excluded. Exclusions are applied as a final step so adding an additional_check and excluding it will result in the check not being run.

### Checklist

- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Added a changelog entry
- [x] Extended the README / documentation, if necessary
