### PR TITLE
feat: run ASGI lifespan events

### DIFF
--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -438,9 +438,9 @@ class Case:
             )
         if base_url is None:
             base_url = self.get_full_base_url()
-        client = ASGIClient(application)
 
-        return self.call(base_url=base_url, session=client, headers=headers, **kwargs)
+        with ASGIClient(application) as client:
+            return self.call(base_url=base_url, session=client, headers=headers, **kwargs)
 
     def validate_response(
         self,


### PR DESCRIPTION
Resolves #1727
Resolves #1305

### Description

Currently schemathesis does not run `lifespan.startup` and `lifespan.shutdown` of ASGI applications that implement them.

The `lifespan.startup` event is often used to connect to a database.

This PR makes a very small change so that those events are sent in `call_asgi`.

### Checklist

- [ ] All tests passing
- [ ] Added a changelog entry
- [ ] Extended the README / documentation, if necessary
