### PR TITLE
chore(python): add Python 3.12 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,9 +73,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-python@v3.1.0
+      - uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
 
       - run: pip install tox tox-gh-actions
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         # Set the patch version for "python", so GitHub adds 3 configurations instead of expanding existing ones
         include:
           - os: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,10 +73,9 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-python@v4.7.0
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-          allow-prereleases: true
 
       - run: pip install tox tox-gh-actions
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Added**
+
+- Add Python 3.12 compatibility.
+
 **Changed**
 
 - Generated binary data inside ``Case.body`` is wrapped with a custom wrapper - ``Binary`` in order to simplify

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 
 **Added**
 
-- Add Python 3.12 compatibility.
+- Add Python 3.12 compatibility. `#1809`_
 
 **Changed**
 
@@ -3516,6 +3516,7 @@ Deprecated
 .. _#1835: https://github.com/schemathesis/schemathesis/issues/1835
 .. _#1820: https://github.com/schemathesis/schemathesis/issues/1820
 .. _#1819: https://github.com/schemathesis/schemathesis/issues/1819
+.. _#1809: https://github.com/schemathesis/schemathesis/issues/1809
 .. _#1808: https://github.com/schemathesis/schemathesis/issues/1808
 .. _#1802: https://github.com/schemathesis/schemathesis/issues/1802
 .. _#1801: https://github.com/schemathesis/schemathesis/issues/1801

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Testing",
 ]
@@ -56,7 +57,8 @@ dependencies = [
 ]
 [project.optional-dependencies]
 tests = [
-    "aiohttp>=3.8.3,<4.0",
+    "aiohttp>=3.8,<4.0; python_version<'3.8'",
+    "aiohttp>=3.9.0b0,<4.0; python_version>='3.8'",
     "coverage>=6",
     "fastapi>=0.86.0",
     "Flask>=2.1.1,<3.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 isolated_build = true
 envlist =
-  py{37,38,39,310,311},
+  py{37,38,39,310,311,312},
   pytest53,
   pytest6,
   hypothesis648,
@@ -14,6 +14,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 extras =
@@ -21,7 +22,7 @@ extras =
   cov
 setenv = COVERAGE_PROCESS_START={toxinidir}/pyproject.toml
 commands =
-  coverage run -m pytest {posargs:-n auto --durations=10 -vv} test
+  coverage run -m pytest {posargs:-n auto --durations=10} test
   coverage combine --keep
   coverage report
   coverage xml -i


### PR DESCRIPTION
Resolves #1809 

### Description

Run CI workflows against latest Python 3.12 beta (3.12b4 as of writing this PR), it gives an overall good idea of schemathesis compatibility with this Python version. 

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Added a changelog entry
- [ ] Extended the README / documentation, if necessary
