### PR TITLE
fix: `Unsatisfiable` error for multiple security schemes applied to the same API operation and an explicit `Authorization` header

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- ``Unsatisfiable`` error for multiple security schemes applied to the same API operation and an explicit ``Authorization`` header. `#1763_`
+
 .. _v3.19.6:
 
 `3.19.6`_ - 2023-08-14
@@ -3391,6 +3395,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1763: https://github.com/schemathesis/schemathesis/issues/1763
 .. _#1753: https://github.com/schemathesis/schemathesis/issues/1753
 .. _#1742: https://github.com/schemathesis/schemathesis/issues/1742
 .. _#1739: https://github.com/schemathesis/schemathesis/issues/1739

--- a/src/schemathesis/specs/openapi/parameters.py
+++ b/src/schemathesis/specs/openapi/parameters.py
@@ -390,7 +390,8 @@ def parameters_to_json_schema(operation: APIOperation, parameters: Iterable[Open
     for parameter in parameters:
         name = parameter.name
         properties[name] = parameter.as_json_schema(operation)
-        if parameter.is_required:
+        # If parameter names are duplicated, we need to avoid duplicate entries in `required` anyway
+        if parameter.is_required and name not in required:
             required.append(name)
     return {"properties": properties, "additionalProperties": False, "type": "object", "required": required}
 


### PR DESCRIPTION
Fixes #1763