### PR TITLE
auths/AuthProvider: bind Generic to Auth

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,10 @@ Changelog
 
 - Pin ``Werkzeug`` to ``<3.0``.
 
+**Fixed**
+
+- Fixed type hint for ``AuthProvider``. `#1776_`
+
 .. _v3.19.7:
 
 `3.19.7`_ - 2023-09-03
@@ -3409,6 +3413,7 @@ Deprecated
 .. _0.3.0: https://github.com/schemathesis/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#1776: https://github.com/schemathesis/schemathesis/issues/1776
 .. _#1763: https://github.com/schemathesis/schemathesis/issues/1763
 .. _#1753: https://github.com/schemathesis/schemathesis/issues/1753
 .. _#1742: https://github.com/schemathesis/schemathesis/issues/1742

--- a/src/schemathesis/auths.py
+++ b/src/schemathesis/auths.py
@@ -32,7 +32,7 @@ class AuthContext:
 
 
 @runtime_checkable
-class AuthProvider(Protocol):
+class AuthProvider(Generic[Auth], Protocol):
     """Get authentication data for an API and set it on the generated test cases."""
 
     def get(self, context: AuthContext) -> Optional[Auth]:


### PR DESCRIPTION
### Description

Fix the type hint for auths/AuthProvider (fixes #1776)

### Checklist

- [ ] Created tests which fail without the change (if possible)
        Did not see any tests/CI for mypy
- [ ] All tests passing
- [x] Added a changelog entry

