### PR TITLE
fix: Generated cURL commands now include the `Content-Type` header, which was previously omitted

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -61,6 +61,7 @@ After:
 - Lack of execution for ASGI events during testing. `#1305`_, `#1727`_
 - Confusing error message when trying to load schema from a non-existing file. `#1602`_
 - Reflect disabled TLS verification in generated code samples. `#1054`_
+- Generated cURL commands now include the ``Content-Type`` header, which was previously omitted. `#1783`_
 
 .. _v3.19.7:
 
@@ -3466,6 +3467,7 @@ Deprecated
 .. _#1797: https://github.com/schemathesis/schemathesis/issues/1797
 .. _#1789: https://github.com/schemathesis/schemathesis/issues/1789
 .. _#1788: https://github.com/schemathesis/schemathesis/issues/1788
+.. _#1783: https://github.com/schemathesis/schemathesis/issues/1783
 .. _#1781: https://github.com/schemathesis/schemathesis/issues/1781
 .. _#1780: https://github.com/schemathesis/schemathesis/issues/1780
 .. _#1776: https://github.com/schemathesis/schemathesis/issues/1776

--- a/src/schemathesis/constants.py
+++ b/src/schemathesis/constants.py
@@ -3,6 +3,8 @@ from typing import List
 
 import pytest
 from packaging import version
+from requests.structures import CaseInsensitiveDict
+from requests.utils import default_headers
 
 from ._compat import metadata
 
@@ -72,6 +74,17 @@ class DataGenerationMethod(str, Enum):
 
 
 DEFAULT_DATA_GENERATION_METHODS = (DataGenerationMethod.default(),)
+# These headers are added automatically by Schemathesis or `requests`.
+# Do not show them in code samples to make them more readable
+CURL_EXCLUDED_HEADERS = CaseInsensitiveDict(
+    {
+        "Content-Length": None,
+        "Transfer-Encoding": None,
+        SCHEMATHESIS_TEST_CASE_HEADER: None,
+        **default_headers(),
+    }
+)
+REQUESTS_EXCLUDED_HEADERS = CaseInsensitiveDict({"Content-Type": None, **CURL_EXCLUDED_HEADERS})
 
 
 class CodeSampleStyle(str, Enum):
@@ -93,3 +106,10 @@ class CodeSampleStyle(str, Enum):
             raise ValueError(
                 f"Invalid value for code sample style: {value}. Available styles: {available_styles}"
             ) from None
+
+    @property
+    def ignored_headers(self) -> CaseInsensitiveDict:
+        return {
+            self.python: REQUESTS_EXCLUDED_HEADERS,
+            self.curl: CURL_EXCLUDED_HEADERS,
+        }[self]

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -60,7 +60,6 @@ from .parameters import Parameter, ParameterSet, PayloadAlternatives
 from .serializers import Serializer, SerializerContext
 from .types import Body, Cookies, FormData, Headers, NotSet, PathParameters, Query
 from .utils import (
-    IGNORED_HEADERS,
     NOT_SET,
     GenericResponse,
     WSGIResponse,
@@ -206,7 +205,9 @@ class Case:
             final_headers = kwargs["headers"] or {}
             final_headers.update(headers)
             kwargs["headers"] = final_headers
-        kwargs["headers"] = {key: value for key, value in kwargs["headers"].items() if key not in IGNORED_HEADERS}
+        kwargs["headers"] = {
+            key: value for key, value in kwargs["headers"].items() if key not in CodeSampleStyle.python.ignored_headers
+        }
         method = kwargs["method"].lower()
 
         def should_display(key: str, value: Any) -> bool:
@@ -240,7 +241,7 @@ class Case:
             # Note, it may be not sufficient to reproduce the error :(
             prepared.body = prepared.body.decode("utf-8", errors="replace")
         for header in tuple(prepared.headers):
-            if header in IGNORED_HEADERS and header not in (self.headers or {}):
+            if header in CodeSampleStyle.curl.ignored_headers and header not in (self.headers or {}):
                 del prepared.headers[header]
         return curlify.to_curl(prepared, verify=verify)
 

--- a/src/schemathesis/runner/serialization.py
+++ b/src/schemathesis/runner/serialization.py
@@ -8,9 +8,10 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 import requests
 
+from ..constants import REQUESTS_EXCLUDED_HEADERS
 from ..exceptions import FailureContext, InternalError, make_unique_by_key
 from ..models import Case, Check, Interaction, Request, Response, Status, TestResult
-from ..utils import IGNORED_HEADERS, WSGIResponse, format_exception
+from ..utils import WSGIResponse, format_exception
 
 
 @dataclass
@@ -77,7 +78,7 @@ class SerializedCheck:
             response = Response.from_wsgi(check.response, check.elapsed)
         else:
             response = None
-        headers = {key: value[0] for key, value in request.headers.items() if key not in IGNORED_HEADERS}
+        headers = {key: value[0] for key, value in request.headers.items() if key not in REQUESTS_EXCLUDED_HEADERS}
         history = []
         case = check.example
         while case.source is not None:

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -39,11 +39,11 @@ from hypothesis.reporting import with_reporter
 from hypothesis.strategies import SearchStrategy
 from requests.auth import HTTPDigestAuth
 from requests.exceptions import InvalidHeader  # type: ignore
-from requests.utils import CaseInsensitiveDict, check_header_validity, default_headers  # type: ignore
+from requests.utils import check_header_validity
 from werkzeug.wrappers import Response as BaseResponse
 
 from ._compat import InferType, JSONMixin, get_signature
-from .constants import SCHEMATHESIS_TEST_CASE_HEADER, USER_AGENT, DataGenerationMethod
+from .constants import USER_AGENT, DataGenerationMethod
 from .exceptions import SkipTest, UsageError
 from .types import DataGenerationMethodInput, Filter, GenericTest, NotSet, RawAuth
 
@@ -54,19 +54,6 @@ except ImportError:
 
 
 NOT_SET = NotSet()
-
-
-# These headers are added automatically by Schemathesis or `requests`.
-# Do not show them in code samples to make them more readable
-IGNORED_HEADERS = CaseInsensitiveDict(
-    {
-        "Content-Length": None,
-        "Transfer-Encoding": None,
-        "Content-Type": None,
-        SCHEMATHESIS_TEST_CASE_HEADER: None,
-        **default_headers(),
-    }
-)
 
 
 def file_exists(path: str) -> bool:


### PR DESCRIPTION
Fixes #1783