### PR TITLE
chore: Support `Werkzeug>=3.0`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,7 +21,7 @@ Changelog
 
 **Changed**
 
-- Pin ``Werkzeug`` to ``<3.0``.
+- Support ``Werkzeug>=3.0``. `#1819`_
 - Refined generated reproduction code and shortened ``X-Schemathesis-TestCaseId`` for easier debugging. `#1801`_
 - Add ``case`` as the first argument to ``AuthContext.set``. Previous calling convention is still supported. `#1788`_
 - Disable the 'explain' phase in Hypothesis to improve performance. `#1808`_
@@ -3473,6 +3473,7 @@ Deprecated
 .. _0.2.0: https://github.com/schemathesis/schemathesis/compare/v0.1.0...v0.2.0
 
 .. _#1820: https://github.com/schemathesis/schemathesis/issues/1820
+.. _#1819: https://github.com/schemathesis/schemathesis/issues/1819
 .. _#1808: https://github.com/schemathesis/schemathesis/issues/1808
 .. _#1802: https://github.com/schemathesis/schemathesis/issues/1802
 .. _#1801: https://github.com/schemathesis/schemathesis/issues/1801

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "tomli-w>=1.0.0,<2.0",
     "tomli>=2.0.1,<3.0",
     "typing-extensions>=3.7,<5",
-    "werkzeug>=0.16.0,<3",
+    "werkzeug>=0.16.0,<4",
     "yarl>=1.5,<2.0"
 ]
 [project.optional-dependencies]

--- a/src/schemathesis/_compat.py
+++ b/src/schemathesis/_compat.py
@@ -1,7 +1,6 @@
 import hypothesis
 import hypothesis_jsonschema._from_schema
 import jsonschema
-import werkzeug
 from hypothesis import strategies as st
 from hypothesis.errors import InvalidArgument
 from packaging import version
@@ -11,7 +10,9 @@ try:
 except ImportError:
     import importlib_metadata as metadata  # type: ignore
 
-if version.parse(werkzeug.__version__) < version.parse("2.1.0"):
+WERKZEUG_VERSION = version.parse(metadata.version("werkzeug"))
+IS_WERKZEUG_ABOVE_3 = WERKZEUG_VERSION >= version.parse("3.0")
+if WERKZEUG_VERSION < version.parse("2.1.0"):
     from werkzeug.wrappers.json import JSONMixin
 else:
 


### PR DESCRIPTION
Closes #1819
