### PR TITLE
feat: Add basic httpx support for validate_response

### DIFF
--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import itertools
 import json
 from collections import defaultdict
@@ -34,7 +35,9 @@ from hypothesis.strategies import SearchStrategy
 from requests.structures import CaseInsensitiveDict
 
 from ... import experimental, failures
+from ..._compat import MultipleFailures
 from ...auths import AuthStorage
+from ...generation import DataGenerationMethod
 from ...constants import HTTP_METHODS, NOT_SET
 from ...exceptions import (
     OperationSchemaError,
@@ -43,7 +46,6 @@ from ...exceptions import (
     get_response_parsing_error,
     get_schema_validation_error,
 )
-from ..._compat import MultipleFailures
 from ...hooks import GLOBAL_HOOK_DISPATCHER, HookContext, HookDispatcher, should_skip_operation
 from ...internal.copy import fast_deepcopy
 from ...internal.jsonschema import traverse_schema
@@ -53,6 +55,7 @@ from ...schemas import BaseSchema
 from ...stateful import Stateful, StatefulTest
 from ...stateful.state_machine import APIStateMachine
 from ...transports.content_types import is_json_media_type
+from ...types import Body, Cookies, FormData, Headers, NotSet, PathParameters, Query
 from . import links, serialization
 from ._hypothesis import get_case_strategy
 from .converter import to_json_schema, to_json_schema_recursive

--- a/src/schemathesis/transports/responses.py
+++ b/src/schemathesis/transports/responses.py
@@ -72,4 +72,4 @@ def get_reason(status_code: int) -> str:
     return http.client.responses.get(status_code, "Unknown")
 
 
-GenericResponse = Union["httpxResponse", "Response", WSGIResponse]
+GenericResponse = Union["httpxResponse", "requestsResponse", WSGIResponse]

--- a/src/schemathesis/transports/responses.py
+++ b/src/schemathesis/transports/responses.py
@@ -49,7 +49,8 @@ def copy_response(response: GenericResponse) -> GenericResponse:
         return copied_response
 
     # Can't deepcopy WSGI response due to generators inside (`response.freeze` doesn't completely help)
-    response.freeze()
+    if isinstance(response, WSGIResponse):
+        response.freeze()
     copied_response = copy(response)
     copied_response.request = deepcopy(response.request)
     return copied_response

--- a/src/schemathesis/transports/responses.py
+++ b/src/schemathesis/transports/responses.py
@@ -33,10 +33,9 @@ def get_payload(response: GenericResponse) -> str:
 
 def copy_response(response: GenericResponse) -> GenericResponse:
     """Create a copy of the given response as far as it makes sense."""
-    from httpx import Response as httpxResponse
-    from requests import Response as requestsResponse
+    from requests import Response
 
-    if isinstance(response, requestsResponse):
+    if isinstance(response, Response):
         # Hooks are not copyable. Keep them out and copy the rest
         hooks = None
         if response.request is not None:
@@ -46,12 +45,6 @@ def copy_response(response: GenericResponse) -> GenericResponse:
         if hooks is not None:
             copied_response.request.hooks["response"] = hooks
         copied_response.raw = response.raw
-        copied_response.verify = getattr(response, "verify", True)  # type: ignore[union-attr]
-        return copied_response
-
-    if isinstance(response, httpxResponse):
-        copied_response = deepcopy(response)
-        copied_response.raw = response.content
         copied_response.verify = getattr(response, "verify", True)  # type: ignore[union-attr]
         return copied_response
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from textwrap import dedent
 from types import SimpleNamespace
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import httpx
 import pytest

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from textwrap import dedent
 from types import SimpleNamespace
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 import httpx
 import pytest
@@ -1049,19 +1049,6 @@ def is_older_subtests():
 
 @pytest.fixture
 def response_factory():
-    def _generic_request_factory(
-        response: Union[httpx.Response, requests.Response],
-        content_type: Optional[str] = "application/json",
-        status_code: int = 200,
-        headers: Optional[Dict[str, Any]] = None,
-    ) -> Union[httpx.Response, requests.Response]:
-        response.status_code = status_code
-        headers = headers or {}
-        if content_type:
-            headers.setdefault("Content-Type", content_type)
-        response.headers.update(headers)
-        return response
-
     def httpx_factory(
         *,
         content: bytes = b"{}",
@@ -1069,10 +1056,15 @@ def response_factory():
         status_code: int = 200,
         headers: Optional[Dict[str, Any]] = None,
     ) -> httpx.Response:
-        response = httpx.Response()
-        response = _generic_request_factory(response, content_type, status_code, headers)
-        response.content = HTTPResponse(body=io.BytesIO(content), status=status_code, headers=response.headers)
-        response.request = httpx.Request(method="POST", url="http://127.0.0.1", headers=headers)
+        headers = headers or {}
+        if content_type:
+            headers.setdefault("Content-Type", content_type)
+        response = httpx.Response(
+            status_code=status_code,
+            headers=headers,
+            content=content,
+            request=httpx.Request(method="POST", url="http://127.0.0.1", headers=headers),
+        )
         return response
 
     def requests_factory(
@@ -1083,8 +1075,12 @@ def response_factory():
         headers: Optional[Dict[str, Any]] = None,
     ) -> requests.Response:
         response = requests.Response()
-        response = _generic_request_factory(response, content_type, status_code, headers)
         response._content = content
+        response.status_code = status_code
+        headers = headers or {}
+        if content_type:
+            headers.setdefault("Content-Type", content_type)
+        response.headers.update(headers)
         response.raw = HTTPResponse(body=io.BytesIO(content), status=status_code, headers=response.headers)
         response.request = requests.PreparedRequest()
         response.request.prepare(method="POST", url="http://127.0.0.1", headers=headers)

--- a/test/transports/test_responses.py
+++ b/test/transports/test_responses.py
@@ -1,0 +1,21 @@
+import pytest
+
+from schemathesis.transports.responses import copy_response
+
+
+@pytest.mark.parametrize("factory_type", ("httpx", "requests", "werkzeug"))
+def test_copy_response(response_factory, factory_type):
+    response = getattr(response_factory, factory_type)()
+    copy = copy_response(response)
+    assert response.status_code == copy.status_code
+    assert response.headers == copy.headers
+    if factory_type == "werkzeug":
+        assert response.get_data() == copy.get_data()
+    else:
+        assert response.content == copy.content
+    assert response.request.url == copy.request.url
+    assert response.request.headers == copy.request.headers
+    if factory_type == "httpx":
+        assert response.request.content == copy.request.content
+    else:
+        assert response.request.body == copy.request.body


### PR DESCRIPTION
🚨Please review the [Contributing Guidelines](https://github.com/schemathesis/schemathesis/blob/master/CONTRIBUTING.rst).

### Description

Basic httpx support that allows to pass `httpx.Response` objects to OpeanAPI `validate_response` method.

### Checklist

- [x] Added failing tests for the change
- [x] All new and existing tests pass
- [ ] Added changelog entry (follow guidelines in CONTRIBUTING.rst)
- [ ] Updated README/documentation, if necessary
