### PR TITLE
chore: Deprecate using the `--show-errors-tracebacks` CLI option

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,10 @@ Changelog
 - Store skip reason in the runner events.
 - Build ``bookworm``-based Debian Docker images instead of ``buster``-based.
 
+**Deprecated**
+
+- Using the ``--show-errors-tracebacks`` CLI option. Use ``--show-trace`` instead.
+
 **Fixed**
 
 - Internal error when a non-existing schema file is passed together with ``--base-url``. :issue:`1912`.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -537,7 +537,7 @@ Debugging
 ---------
 
 If Schemathesis produces an internal error, its traceback is hidden. To show error tracebacks in the CLI output, use
-the ``--show-errors-tracebacks`` option.
+the ``--show-trace`` option.
 
 Additionally you can dump all internal events to a JSON Lines file with the ``--debug-output-file`` CLI option.
 

--- a/src/schemathesis/cli/context.py
+++ b/src/schemathesis/cli/context.py
@@ -6,6 +6,7 @@ from queue import Queue
 from typing import TYPE_CHECKING
 
 from ..code_samples import CodeSampleStyle
+from ..internal.deprecation import deprecated_property
 from ..runner.serialization import SerializedTestResult
 
 if TYPE_CHECKING:
@@ -32,7 +33,7 @@ class ExecutionContext:
     hypothesis_output: list[str] = field(default_factory=list)
     workers_num: int = 1
     rate_limit: str | None = None
-    show_errors_tracebacks: bool = False
+    show_trace: bool = False
     wait_for_schema: float | None = None
     validate_schema: bool = True
     operations_processed: int = 0
@@ -48,3 +49,7 @@ class ExecutionContext:
     verbosity: int = 0
     code_sample_style: CodeSampleStyle = CodeSampleStyle.default()
     report: ServiceReportContext | FileReportContext | None = None
+
+    @deprecated_property(removed_in="4.0", replacement="show_trace")
+    def show_errors_tracebacks(self) -> bool:
+        return self.show_trace

--- a/src/schemathesis/cli/output/default.py
+++ b/src/schemathesis/cli/output/default.py
@@ -147,9 +147,9 @@ def display_errors(context: ExecutionContext, event: events.Finished) -> None:
         should_display_full_traceback_message |= display_single_error(context, result)
     if event.generic_errors:
         display_generic_errors(context, event.generic_errors)
-    if should_display_full_traceback_message and not context.show_errors_tracebacks:
+    if should_display_full_traceback_message and not context.show_trace:
         click.secho(
-            "\nAdd this option to your command line parameters to see full tracebacks: --show-errors-tracebacks",
+            "\nAdd this option to your command line parameters to see full tracebacks: --show-trace",
             fg="red",
         )
     click.secho(
@@ -231,7 +231,7 @@ def _display_error(context: ExecutionContext, error: SerializedError) -> bool:
         click.echo(error.exception)
     if error.extras:
         extras = error.extras
-    elif context.show_errors_tracebacks:
+    elif context.show_trace:
         extras = _split_traceback(error.exception_with_traceback)
     else:
         extras = []
@@ -615,7 +615,7 @@ def display_internal_error(context: ExecutionContext, event: events.InternalErro
     click.secho(event.message)
     if event.type == InternalErrorType.SCHEMA:
         extras = event.extras
-    elif context.show_errors_tracebacks:
+    elif context.show_trace:
         extras = _split_traceback(event.exception_with_traceback)
     else:
         extras = [event.exception]
@@ -623,12 +623,12 @@ def display_internal_error(context: ExecutionContext, event: events.InternalErro
     if not should_skip_suggestion(context, event):
         if event.type == InternalErrorType.SCHEMA and isinstance(event.subtype, SchemaErrorType):
             suggestion = SCHEMA_ERROR_SUGGESTIONS.get(event.subtype)
-        elif context.show_errors_tracebacks:
+        elif context.show_trace:
             suggestion = (
                 f"Please consider reporting the traceback above to our issue tracker:\n\n  {ISSUE_TRACKER_URL}."
             )
         else:
-            suggestion = f"To see full tracebacks, add {bold('`--show-errors-tracebacks`')} to your CLI options"
+            suggestion = f"To see full tracebacks, add {bold('`--show-trace`')} to your CLI options"
         _maybe_display_tip(suggestion)
 
 

--- a/test/auth/test_cli.py
+++ b/test/auth/test_cli.py
@@ -65,7 +65,7 @@ def after_call(context, case, response):
     )
     # Then it overrides the one from the auth provider
     # And the auth should be used
-    assert cli.main("run", schema_url, "--show-errors-tracebacks", *args, hooks=module.purebasename) == snapshot_cli
+    assert cli.main("run", schema_url, "--show-trace", *args, hooks=module.purebasename) == snapshot_cli
 
 
 def test_multiple_auth_mechanisms_with_explicit_auth(testdir, empty_open_api_3_schema, cli, snapshot_cli):
@@ -138,7 +138,7 @@ def test_multiple_threads(testdir, cli, schema_url, snapshot_cli):
             "--workers",
             "2",
             "--hypothesis-max-examples=1",
-            "--show-errors-tracebacks",
+            "--show-trace",
             hooks=module.purebasename,
         )
         == snapshot_cli

--- a/test/cli/__snapshots__/test_commands/test_get_request_with_body[Open API 2.0].raw
+++ b/test/cli/__snapshots__/test_commands/test_get_request_with_body[Open API 2.0].raw
@@ -20,7 +20,7 @@ GET requests should not contain body parameters.
 
 Tip: Bypass validation using `--validate-schema=false`. Caution: May cause unexpected errors.
 
-Add this option to your command line parameters to see full tracebacks: --show-errors-tracebacks
+Add this option to your command line parameters to see full tracebacks: --show-trace
 
 Need more help?
     Join our Discord server: https://discord.gg/R9ASRAmHnA

--- a/test/cli/__snapshots__/test_commands/test_get_request_with_body[Open API 3.0].raw
+++ b/test/cli/__snapshots__/test_commands/test_get_request_with_body[Open API 3.0].raw
@@ -20,7 +20,7 @@ GET requests should not contain body parameters.
 
 Tip: Bypass validation using `--validate-schema=false`. Caution: May cause unexpected errors.
 
-Add this option to your command line parameters to see full tracebacks: --show-errors-tracebacks
+Add this option to your command line parameters to see full tracebacks: --show-trace
 
 Need more help?
     Join our Discord server: https://discord.gg/R9ASRAmHnA

--- a/test/cli/__snapshots__/test_commands/test_run_output[args24].raw
+++ b/test/cli/__snapshots__/test_commands/test_run_output[args24].raw
@@ -140,7 +140,7 @@ Generic:
                                   multiple JSON files, is subject to change.
   --debug-output-file FILENAME    Saves debugging information in a JSONL format
                                   at the specified file path.
-  --show-errors-tracebacks        Displays complete traceback information for
+  --show-trace                    Displays complete traceback information for
                                   internal errors.
   --code-sample-style [python|curl]
                                   Selects the code sample style for reproducing
@@ -150,8 +150,6 @@ Generic:
   --cassette-preserve-exact-body-bytes
                                   Retains exact byte sequence of payloads in
                                   cassettes, encoded as base64.
-  --store-network-log FILENAME    [DEPRECATED] Saves the test outcomes in a VCR-
-                                  compatible format.
   --fixups [fast_api|utf8_bom|all]
                                   Applies compatibility adjustments like
                                   'fast_api', 'utf8_bom'.
@@ -159,9 +157,6 @@ Generic:
                                   '<limit>/<duration>' format. Example - `100/m`
                                   for 100 requests per minute.
   --stateful [none|links]         Enables or disables stateful testing features.
-  --stateful-recursion-limit INTEGER RANGE
-                                  Sets the recursion depth limit for stateful
-                                  testing.  [default: 5; 1<=x<=100]
   --force-schema-version [20|30]  Forces the schema to be interpreted as a
                                   particular OpenAPI version.
   --sanitize-output BOOLEAN       Enable or disable automatic output

--- a/test/cli/__snapshots__/test_commands/test_unsatisfiable[real-Open API 2.0-1].raw
+++ b/test/cli/__snapshots__/test_commands/test_unsatisfiable[real-Open API 2.0-1].raw
@@ -23,7 +23,7 @@ Failed to generate test cases for this API operation. Possible reasons:
 
 Tip: Examine the schema for inconsistencies and consider simplifying it.
 
-Add this option to your command line parameters to see full tracebacks: --show-errors-tracebacks
+Add this option to your command line parameters to see full tracebacks: --show-trace
 
 Need more help?
     Join our Discord server: https://discord.gg/R9ASRAmHnA

--- a/test/cli/__snapshots__/test_commands/test_unsatisfiable[real-Open API 2.0-2].raw
+++ b/test/cli/__snapshots__/test_commands/test_unsatisfiable[real-Open API 2.0-2].raw
@@ -23,7 +23,7 @@ Failed to generate test cases for this API operation. Possible reasons:
 
 Tip: Examine the schema for inconsistencies and consider simplifying it.
 
-Add this option to your command line parameters to see full tracebacks: --show-errors-tracebacks
+Add this option to your command line parameters to see full tracebacks: --show-trace
 
 Need more help?
     Join our Discord server: https://discord.gg/R9ASRAmHnA

--- a/test/cli/__snapshots__/test_commands/test_unsatisfiable[real-Open API 3.0-1].raw
+++ b/test/cli/__snapshots__/test_commands/test_unsatisfiable[real-Open API 3.0-1].raw
@@ -23,7 +23,7 @@ Failed to generate test cases for this API operation. Possible reasons:
 
 Tip: Examine the schema for inconsistencies and consider simplifying it.
 
-Add this option to your command line parameters to see full tracebacks: --show-errors-tracebacks
+Add this option to your command line parameters to see full tracebacks: --show-trace
 
 Need more help?
     Join our Discord server: https://discord.gg/R9ASRAmHnA

--- a/test/cli/__snapshots__/test_commands/test_unsatisfiable[real-Open API 3.0-2].raw
+++ b/test/cli/__snapshots__/test_commands/test_unsatisfiable[real-Open API 3.0-2].raw
@@ -23,7 +23,7 @@ Failed to generate test cases for this API operation. Possible reasons:
 
 Tip: Examine the schema for inconsistencies and consider simplifying it.
 
-Add this option to your command line parameters to see full tracebacks: --show-errors-tracebacks
+Add this option to your command line parameters to see full tracebacks: --show-trace
 
 Need more help?
     Join our Discord server: https://discord.gg/R9ASRAmHnA

--- a/test/cli/__snapshots__/test_commands/test_unsatisfiable[wsgi-Open API 2.0-1].raw
+++ b/test/cli/__snapshots__/test_commands/test_unsatisfiable[wsgi-Open API 2.0-1].raw
@@ -23,7 +23,7 @@ Failed to generate test cases for this API operation. Possible reasons:
 
 Tip: Examine the schema for inconsistencies and consider simplifying it.
 
-Add this option to your command line parameters to see full tracebacks: --show-errors-tracebacks
+Add this option to your command line parameters to see full tracebacks: --show-trace
 
 Need more help?
     Join our Discord server: https://discord.gg/R9ASRAmHnA

--- a/test/cli/__snapshots__/test_commands/test_unsatisfiable[wsgi-Open API 2.0-2].raw
+++ b/test/cli/__snapshots__/test_commands/test_unsatisfiable[wsgi-Open API 2.0-2].raw
@@ -23,7 +23,7 @@ Failed to generate test cases for this API operation. Possible reasons:
 
 Tip: Examine the schema for inconsistencies and consider simplifying it.
 
-Add this option to your command line parameters to see full tracebacks: --show-errors-tracebacks
+Add this option to your command line parameters to see full tracebacks: --show-trace
 
 Need more help?
     Join our Discord server: https://discord.gg/R9ASRAmHnA

--- a/test/cli/__snapshots__/test_commands/test_unsatisfiable[wsgi-Open API 3.0-1].raw
+++ b/test/cli/__snapshots__/test_commands/test_unsatisfiable[wsgi-Open API 3.0-1].raw
@@ -23,7 +23,7 @@ Failed to generate test cases for this API operation. Possible reasons:
 
 Tip: Examine the schema for inconsistencies and consider simplifying it.
 
-Add this option to your command line parameters to see full tracebacks: --show-errors-tracebacks
+Add this option to your command line parameters to see full tracebacks: --show-trace
 
 Need more help?
     Join our Discord server: https://discord.gg/R9ASRAmHnA

--- a/test/cli/__snapshots__/test_commands/test_unsatisfiable[wsgi-Open API 3.0-2].raw
+++ b/test/cli/__snapshots__/test_commands/test_unsatisfiable[wsgi-Open API 3.0-2].raw
@@ -23,7 +23,7 @@ Failed to generate test cases for this API operation. Possible reasons:
 
 Tip: Examine the schema for inconsistencies and consider simplifying it.
 
-Add this option to your command line parameters to see full tracebacks: --show-errors-tracebacks
+Add this option to your command line parameters to see full tracebacks: --show-trace
 
 Need more help?
     Join our Discord server: https://discord.gg/R9ASRAmHnA

--- a/test/cli/__snapshots__/test_commands/test_unsupported_regex.raw
+++ b/test/cli/__snapshots__/test_commands/test_unsupported_regex.raw
@@ -21,7 +21,7 @@ Invalid regular expression. Pattern `\\p{Alpha}` is not recognized - `bad escape
 
 Tip: Ensure your regex is compatible with Python's syntax. For guidance, visit: https://docs.python.org/3/library/re.html
 
-Add this option to your command line parameters to see full tracebacks: --show-errors-tracebacks
+Add this option to your command line parameters to see full tracebacks: --show-trace
 
 Need more help?
     Join our Discord server: https://discord.gg/R9ASRAmHnA

--- a/test/cli/output/test_default.py
+++ b/test/cli/output/test_default.py
@@ -289,7 +289,7 @@ def test_after_execution_attributes(execution_context, after_execution):
 
 @pytest.mark.parametrize("show_errors_tracebacks", (True, False))
 def test_display_internal_error(capsys, execution_context, show_errors_tracebacks):
-    execution_context.show_errors_tracebacks = show_errors_tracebacks
+    execution_context.show_trace = show_errors_tracebacks
     try:
         raise ZeroDivisionError("division by zero")
     except ZeroDivisionError as exc:

--- a/test/cli/test_asgi.py
+++ b/test/cli/test_asgi.py
@@ -45,7 +45,7 @@ def test_cli_run_output_success(testdir, cli, workers):
         "--app",
         f"{module.purebasename}:app",
         f"--workers={workers}",
-        "--show-errors-tracebacks",
+        "--show-trace",
         "--force-schema-version=30",
     )
 

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -1070,7 +1070,7 @@ def test_wsgi_app_exception(testdir, cli):
         1 / 0
         """
     )
-    result = cli.run("/schema.yaml", "--app", f"{module.purebasename}:app", "--show-errors-tracebacks")
+    result = cli.run("/schema.yaml", "--app", f"{module.purebasename}:app", "--show-trace")
     assert result.exit_code == ExitCode.TESTS_FAILED, result.stdout
     assert "Traceback (most recent call last):" in result.stdout
     assert "ZeroDivisionError: division by zero" in result.stdout
@@ -1188,7 +1188,7 @@ def test_multipart_upload(testdir, tmp_path, hypothesis_max_examples, openapi3_b
         str(schema_file),
         f"--base-url={openapi3_base_url}",
         f"--hypothesis-max-examples={hypothesis_max_examples or 5}",
-        "--show-errors-tracebacks",
+        "--show-trace",
         "--hypothesis-derandomize",
         f"--cassette-path={cassette_path}",
     )
@@ -1308,7 +1308,7 @@ def test_openapi_links(cli, cli_args, schema_url, hypothesis_max_examples, snaps
             "--hypothesis-seed=1",
             "--hypothesis-derandomize",
             "--hypothesis-deadline=None",
-            "--show-errors-tracebacks",
+            "--show-trace",
         )
         == snapshot_cli
     )
@@ -1324,7 +1324,7 @@ def test_openapi_links_disabled(cli, schema_url, hypothesis_max_examples, snapsh
             "--hypothesis-seed=1",
             "--hypothesis-derandomize",
             "--hypothesis-deadline=None",
-            "--show-errors-tracebacks",
+            "--show-trace",
             "--stateful=none",
         )
         == snapshot_cli
@@ -1343,7 +1343,7 @@ def test_openapi_links_multiple_threads(cli, cli_args, schema_url, recursion_lim
         "--hypothesis-derandomize",
         "--hypothesis-deadline=None",
         "--hypothesis-suppress-health-check=too_slow,filter_too_much",
-        "--show-errors-tracebacks",
+        "--show-trace",
         f"--stateful-recursion-limit={recursion_limit}",
         "--workers=2",
     )
@@ -1617,7 +1617,7 @@ def assert_exit_code(event_stream, code):
             hypothesis_settings=hypothesis.settings(),
             workers_num=1,
             rate_limit=None,
-            show_errors_tracebacks=False,
+            show_trace=False,
             wait_for_schema=None,
             validate_schema=False,
             cassette_path=None,


### PR DESCRIPTION
Use `--show-trace` instead
