### PR TITLE
feat: An option to generate random examples for API operations that lack explicit examples

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 :version:`Unreleased <v3.22.1...HEAD>` - TBD
 --------------------------------------------
 
+**Added**
+
+- New CLI option ``--contrib-openapi-fill-missing-examples`` to automatically generate random examples for API operations that lack explicit examples. :issue:`1728`
+
 **Changed**
 
 - Validate ``--generation-codec`` values in CLI.

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -33,6 +33,32 @@ Uniqueness is determined by the following parts of the generated data:
 - ``query``
 - ``body``
 
+Fill missing examples
+~~~~~~~~~~~~~~~~~~~~~
+
+The ``--contrib-openapi-fill-missing-examples`` option complements ``--hypothesis-phases=explicit`` by generating a random example for operations that lack explicit examples in the schema.
+
+In CLI:
+
+.. code:: text
+
+    $ st run --contrib-openapi-fill-missing-examples --hypothesis-phases=explicit \
+          https://example.schemathesis.io/openapi.json
+
+In Python tests:
+
+.. code:: python
+
+    from schemathesis.contrib.openapi import fill_missing_examples
+
+    fill_missing_examples.install()
+
+This feature ensures that all operations, even those without specified examples, are tested when running with ``--hypothesis-phases=explicit``.
+
+.. note::
+
+    This option is designed for users transitioning from Dredd to Schemathesis.
+
 UUID data for ``format: uuid`` in Open API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -50,6 +50,14 @@ Dredd works more in a way that requires you to write some sort of example-based 
 There are a lot of features that Dredd has are Schemathesis has not (e.g., API Blueprint support, that powerful hook system, and many more) and probably vice versa.
 Definitely, Schemathesis can learn a lot from Dredd and if you miss any feature that exists in Dredd but doesn't exist in Schemathesis, let us know.
 
+Why are no examples generated in Schemathesis when using ``--hypothesis-phase=explicit``?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``--hypothesis-phase=explicit`` option is designed to test only the examples that are explicitly defined in the API schema.
+It avoids generating new examples to maintain predictability and adhere strictly to the documented API behavior.
+
+If you need random examples for API operations without explicit examples, consider using the ``--contrib-openapi-fill-missing-examples`` CLI option.
+
 How should I run Schemathesis?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -134,6 +134,12 @@ def add_examples(test: Callable, operation: APIOperation, hook_dispatcher: HookD
 
 
 def get_single_example(strategy: st.SearchStrategy[Case]) -> Case:
+    examples: list[Case] = []
+    add_single_example(strategy, examples)
+    return examples[0]
+
+
+def add_single_example(strategy: st.SearchStrategy[Case], examples: list[Case]) -> None:
     @hypothesis.given(strategy)  # type: ignore
     @hypothesis.settings(  # type: ignore
         database=None,
@@ -146,6 +152,4 @@ def get_single_example(strategy: st.SearchStrategy[Case]) -> Case:
     def example_generating_inner_function(ex: Case) -> None:
         examples.append(ex)
 
-    examples: list[Case] = []
     example_generating_inner_function()
-    return examples[0]

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -543,6 +543,14 @@ The report data, consisting of a tar gz file with multiple JSON files, is subjec
     show_default=True,
 )
 @click.option(
+    "--contrib-openapi-fill-missing-examples",
+    "contrib_openapi_fill_missing_examples",
+    help="Enables generation of random examples for API operations that do not have explicit examples defined.",
+    is_flag=True,
+    default=False,
+    show_default=True,
+)
+@click.option(
     "--hypothesis-database",
     help="Configures storage for examples discovered by Hypothesis. "
     f"Use 'none' to disable, '{HYPOTHESIS_IN_MEMORY_DATABASE_IDENTIFIER}' for temporary storage, "
@@ -710,6 +718,7 @@ def run(
     sanitize_output: bool = True,
     contrib_unique_data: bool = False,
     contrib_openapi_formats_uuid: bool = False,
+    contrib_openapi_fill_missing_examples: bool = False,
     hypothesis_database: str | None = None,
     hypothesis_deadline: int | NotSet | None = None,
     hypothesis_derandomize: bool | None = None,
@@ -843,6 +852,8 @@ def run(
         contrib.unique_data.install()
     if contrib_openapi_formats_uuid:
         contrib.openapi.formats.uuid.install()
+    if contrib_openapi_fill_missing_examples:
+        contrib.openapi.fill_missing_examples.install()
 
     hypothesis_settings = prepare_hypothesis_settings(
         database=hypothesis_database,

--- a/src/schemathesis/contrib/openapi/__init__.py
+++ b/src/schemathesis/contrib/openapi/__init__.py
@@ -1,9 +1,11 @@
-from . import formats
+from . import formats, fill_missing_examples
 
 
 def install() -> None:
     formats.install()
+    fill_missing_examples.install()
 
 
 def uninstall() -> None:
     formats.uninstall()
+    fill_missing_examples.uninstall()

--- a/src/schemathesis/contrib/openapi/fill_missing_examples.py
+++ b/src/schemathesis/contrib/openapi/fill_missing_examples.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+from ...hooks import HookContext, register, unregister
+
+if TYPE_CHECKING:
+    from ...models import Case
+
+
+def install() -> None:
+    register(before_add_examples)
+
+
+def uninstall() -> None:
+    unregister(before_add_examples)
+
+
+def before_add_examples(context: HookContext, examples: list[Case]) -> None:
+    if not examples and context.operation is not None:
+        from ..._hypothesis import add_single_example
+
+        strategy = context.operation.as_strategy()
+        add_single_example(strategy, examples)

--- a/test/cli/__snapshots__/test_commands/test_run_output[args24].raw
+++ b/test/cli/__snapshots__/test_commands/test_run_output[args24].raw
@@ -165,6 +165,10 @@ Generic:
   --contrib-unique-data           Forces the generation of unique test cases.
   --contrib-openapi-formats-uuid  Enables support for the 'uuid' string format
                                   in OpenAPI.
+  --contrib-openapi-fill-missing-examples
+                                  Enables generation of random examples for API
+                                  operations that do not have explicit examples
+                                  defined.
   --no-color                      Disable ANSI color escape codes.
   --force-color                   Explicitly tells to enable ANSI color escape
                                   codes.

--- a/test/contrib/openapi/__snapshots__/test_fill_missing_examples/test_fills_missing_examples.raw
+++ b/test/contrib/openapi/__snapshots__/test_fill_missing_examples/test_fills_missing_examples.raw
@@ -1,0 +1,23 @@
+Exit code: 0
+---
+Stdout:
+======================= Schemathesis test session starts =======================
+Schema location: http://127.0.0.1/schema.yaml
+Base URL: http://127.0.0.1/api
+Specification version: Open API 3.0.2
+Random seed: 42
+Workers: 1
+Collected API operations: 1
+Collected API links: 0
+
+GET /api/success .                                                        [100%]
+
+=================================== SUMMARY ====================================
+
+Performed checks:
+    not_a_server_error                    1 / 1 passed          PASSED 
+
+Tip: Use the `--report` CLI option to visualize test results via Schemathesis.io.
+We run additional conformance checks on reports from public repos.
+
+============================== 1 passed in 1.00s ===============================

--- a/test/contrib/openapi/test_fill_missing_examples.py
+++ b/test/contrib/openapi/test_fill_missing_examples.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.mark.operations("success")
+def test_fills_missing_examples(cli, openapi3_schema_url, snapshot_cli):
+    assert (
+        cli.run(openapi3_schema_url, "--hypothesis-phases=explicit", "--contrib-openapi-fill-missing-examples")
+        == snapshot_cli
+    )


### PR DESCRIPTION
Resolves #1728