### PR TITLE
fix: Not using `examples` from shared `parameters`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,7 @@ Changelog
 **Fixed**
 
 - Internal error when the configured proxy is not available.
+- Not using ``examples` from shared ``parameters``. :issue:`1729`, :issue:`1513`
 
 .. _v3.22.1:
 


### PR DESCRIPTION
Fixes #1729
Fixes #1513