### PR TITLE
chore: Raise an error if it is not possible to generate explicit examples

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,10 @@ Changelog
 
 - CLI options for overriding Open API parameters in test cases. :issue:`1676`
 
+**Changed**
+
+- Raise an error if it is not possible to generate explicit examples. :issue:`1771`
+
 .. _v3.23.1:
 
 :version:`3.23.1 <v3.23.0...v3.23.1>` - 2024-01-14

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -22,6 +22,7 @@ from requests.auth import HTTPDigestAuth, _basic_auth_str
 from ..override import CaseOverride
 from ... import failures, hooks
 from ..._compat import MultipleFailures
+from ..._hypothesis import has_unsatisfied_example_mark
 from ...auths import unregister as unregister_auth
 from ...generation import DataGenerationMethod, GenerationConfig
 from ...constants import DEFAULT_STATEFUL_RECURSION_LIMIT, RECURSIVE_REFERENCE_ERROR_MESSAGE, USER_AGENT
@@ -400,6 +401,11 @@ def run_test(
     except Exception as error:
         status = Status.error
         result.add_error(error)
+    if has_unsatisfied_example_mark(test):
+        status = Status.error
+        result.add_error(
+            hypothesis.errors.Unsatisfiable("Failed to generate test cases from examples for this API operation")
+        )
     test_elapsed_time = time.monotonic() - test_start_time
     # DEPRECATED: Seed is the same per test run
     # Fetch seed value, hypothesis generates it during test execution

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ extras =
   cov
 setenv = COVERAGE_PROCESS_START={toxinidir}/pyproject.toml
 commands =
-  coverage run -m pytest {posargs:-n auto --durations=10} test
+  coverage run -m pytest {posargs:-n auto --durations=10 -vv} test
   coverage combine --keep
   coverage report
   coverage xml -i


### PR DESCRIPTION
Resolves #1771