### PR TITLE
fix: Ignoring examples referenced via the `$ref` keyword

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,7 @@ Changelog
 **Fixed**
 
 - **Open API**: Properly combine multiple explicit examples extracted from ``examples`` and ``example`` fields. :issue:`1360`
+- **Open API**: Ignoring examples referenced via the ``$ref`` keyword. :issue:`1692`
 
 .. _v3.23.1:
 


### PR DESCRIPTION
Fixes #1692