### PR TITLE
fix: validate that the graphql response is valid

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 
 - ``--hypothesis-no-phases`` CLI option to disable Hypothesis testing phases. :issue:`1324`
 - Support for loading GraphQL schemas from JSON files that contain the ``__schema`` key.
+- Basic GraphQL response checking that only covers whether the response payload is valid JSON.
 
 .. _v3.24.3:
 

--- a/src/schemathesis/checks.py
+++ b/src/schemathesis/checks.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
+import json
 
 from . import failures
-from .exceptions import get_server_error
+from .exceptions import get_server_error, get_response_parsing_error
 from .specs.openapi.checks import (
     content_type_conformance,
     response_headers_conformance,
@@ -17,10 +18,20 @@ if TYPE_CHECKING:
 
 def not_a_server_error(response: GenericResponse, case: Case) -> bool | None:
     """A check to verify that the response is not a server-side error."""
+    from .specs.graphql.schemas import GraphQLCase
+    from .transports.responses import get_json
+
     status_code = response.status_code
     if status_code >= 500:
         exc_class = get_server_error(status_code)
         raise exc_class(failures.ServerError.title, context=failures.ServerError(status_code=status_code))
+    if isinstance(case, GraphQLCase):
+        try:
+            _ = get_json(response)
+        except json.JSONDecodeError as exc:
+            exc_class = get_response_parsing_error(exc)
+            context = failures.JSONDecodeErrorContext.from_exception(exc)
+            raise exc_class(context.title, context=context) from exc
     return None
 
 

--- a/src/schemathesis/specs/graphql/schemas.py
+++ b/src/schemathesis/specs/graphql/schemas.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import enum
 from dataclasses import dataclass, field
 from difflib import get_close_matches
@@ -29,9 +30,9 @@ from ..openapi.constants import LOCATION_TO_CONTAINER
 from ... import auths
 from ...auths import AuthStorage
 from ...checks import not_a_server_error
-from ...generation import DataGenerationMethod, GenerationConfig
-from ...exceptions import OperationSchemaError
 from ...constants import NOT_SET
+from ...exceptions import OperationSchemaError
+from ...generation import DataGenerationMethod, GenerationConfig
 from ...hooks import (
     GLOBAL_HOOK_DISPATCHER,
     HookContext,
@@ -39,7 +40,7 @@ from ...hooks import (
     apply_to_all_dispatchers,
     should_skip_operation,
 )
-from ...internal.result import Result, Ok
+from ...internal.result import Ok, Result
 from ...models import APIOperation, Case, CheckFunction, OperationDefinition
 from ...schemas import BaseSchema, APIOperationMap
 from ...stateful import Stateful, StatefulTest

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import itertools
-import json
 from collections import defaultdict
 from contextlib import ExitStack, contextmanager, suppress
 from dataclasses import dataclass, field
@@ -22,9 +21,7 @@ from typing import (
 )
 from urllib.parse import urlsplit
 
-import httpx
 import jsonschema
-import requests
 from hypothesis.strategies import SearchStrategy
 from requests.structures import CaseInsensitiveDict
 
@@ -52,6 +49,7 @@ from ...schemas import BaseSchema, APIOperationMap
 from ...stateful import Stateful, StatefulTest
 from ...stateful.state_machine import APIStateMachine
 from ...transports.content_types import is_json_media_type
+from ...transports.responses import get_json
 from ...types import Body, Cookies, FormData, Headers, NotSet, PathParameters, Query, GenericTest
 from . import links, serialization
 from ._hypothesis import get_case_strategy
@@ -579,10 +577,7 @@ class BaseOpenAPISchema(BaseSchema):
             _maybe_raise_one_or_more(errors)
             return None
         try:
-            if isinstance(response, (requests.Response, httpx.Response)):
-                data = json.loads(response.text)
-            else:
-                data = response.json
+            data = get_json(response)
         except JSONDecodeError as exc:
             exc_class = get_response_parsing_error(exc)
             context = failures.JSONDecodeErrorContext.from_exception(exc)

--- a/src/schemathesis/transports/responses.py
+++ b/src/schemathesis/transports/responses.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import sys
-from json import JSONDecodeError
-from typing import Union, TYPE_CHECKING, NoReturn
+import json
+from typing import Union, TYPE_CHECKING, NoReturn, Any
 from .._compat import JSONMixin
 from werkzeug.wrappers import Response as BaseResponse
 
@@ -16,7 +16,7 @@ class WSGIResponse(BaseResponse, JSONMixin):
     # We store "requests" request to build a reproduction code
     request: PreparedRequest
 
-    def on_json_loading_failed(self, e: JSONDecodeError) -> NoReturn:
+    def on_json_loading_failed(self, e: json.JSONDecodeError) -> NoReturn:
         # We don't need a werkzeug-specific exception when JSON parsing error happens
         raise e
 
@@ -28,6 +28,15 @@ def get_payload(response: GenericResponse) -> str:
     if isinstance(response, (httpxResponse, requestsResponse)):
         return response.text
     return response.get_data(as_text=True)
+
+
+def get_json(response: GenericResponse) -> Any:
+    from httpx import Response as httpxResponse
+    from requests import Response as requestsResponse
+
+    if isinstance(response, (httpxResponse, requestsResponse)):
+        return json.loads(response.text)
+    return response.json
 
 
 def get_reason(status_code: int) -> str:


### PR DESCRIPTION
### Description

Currently call_and_validate doesn't check if in the graphql response are any errors or the answer is json at all.
This happened in my tests in my project.

This PR should fix the problem but I cannot test it.

It is really hard to contribute.
I don't understand in which test file I can define such a test and the test procedure fails for different sized terminals.

Sorry.

### Checklist

- [ ] Added failing tests for the change
- [ ] All new and existing tests pass
- [ ] Added changelog entry (follow guidelines in CONTRIBUTING.rst)
- [ ] Updated README/documentation, if necessary
