### PR TITLE
built: Set `COLUMNS=80` in tox build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,9 @@ python =
 extras =
   tests
   cov
-setenv = COVERAGE_PROCESS_START={toxinidir}/pyproject.toml
+setenv =
+    COVERAGE_PROCESS_START={toxinidir}/pyproject.toml
+    COLUMNS=80
 commands =
   coverage run -m pytest {posargs:-n auto --durations=10 -vv} test
   coverage combine --keep


### PR DESCRIPTION
This way snapshots will use the proper width