### PR TITLE
chore: Explicitly note that combining `@schema.given` with explicit examples from the spec is not supported

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,10 @@ Changelog
 - Support for loading GraphQL schemas from JSON files that contain the ``__schema`` key.
 - Response validation for GraphQL APIs.
 
+**Changed**
+
+- **Python**: Explicitly note that combining ``@schema.given`` with explicit examples from the spec is not supported. :issue:`1217`
+
 .. _v3.24.3:
 
 :version:`3.24.3 <v3.24.2...v3.24.3>` - 2024-01-23

--- a/src/schemathesis/constants.py
+++ b/src/schemathesis/constants.py
@@ -23,6 +23,10 @@ RECURSIVE_REFERENCE_ERROR_MESSAGE = (
     "recursive references in the operation definition. See more information in "
     "this issue - https://github.com/schemathesis/schemathesis/issues/947"
 )
+GIVEN_AND_EXPLICIT_EXAMPLES_ERROR_MESSAGE = (
+    "Unsupported test setup. Tests using `@schema.given` cannot be combined with explicit schema examples in the same "
+    "function. Separate these tests into distinct functions to avoid conflicts."
+)
 SERIALIZERS_SUGGESTION_MESSAGE = (
     "You can register your own serializer with `schemathesis.serializer` "
     "and Schemathesis will be able to make API calls with this media type. \n"

--- a/src/schemathesis/extra/pytest_plugin.py
+++ b/src/schemathesis/extra/pytest_plugin.py
@@ -17,9 +17,9 @@ from hypothesis_jsonschema._canonicalise import HypothesisRefResolutionError
 
 from .._hypothesis import create_test, get_unsatisfied_example_mark
 from .._override import get_override_from_mark
-from ..constants import RECURSIVE_REFERENCE_ERROR_MESSAGE
+from ..constants import RECURSIVE_REFERENCE_ERROR_MESSAGE, GIVEN_AND_EXPLICIT_EXAMPLES_ERROR_MESSAGE
 from .._dependency_versions import IS_PYTEST_ABOVE_7, IS_PYTEST_ABOVE_54
-from ..exceptions import OperationSchemaError, SkipTest
+from ..exceptions import OperationSchemaError, SkipTest, UsageError
 from ..internal.result import Result, Ok
 from ..models import APIOperation
 from ..utils import (
@@ -254,6 +254,8 @@ def pytest_pyfunc_call(pyfuncitem):  # type:ignore
         try:
             outcome.get_result()
         except InvalidArgument as exc:
+            if "Inconsistent args" in str(exc) and "@example()" in str(exc):
+                raise UsageError(GIVEN_AND_EXPLICIT_EXAMPLES_ERROR_MESSAGE) from None
             raise OperationSchemaError(exc.args[0]) from None
         except HypothesisRefResolutionError:
             pytest.skip(RECURSIVE_REFERENCE_ERROR_MESSAGE)


### PR DESCRIPTION
Resolves #1217