### PR TITLE
fix: Create parent directories when saving JUnit XML reports and other file-based output

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,10 @@ Changelog
 
 - **Python**: Explicitly note that combining ``@schema.given`` with explicit examples from the spec is not supported. :issue:`1217`
 
+**Fixed**
+
+- Create parent directories when saving JUnit XML reports and other file-based output. :issue:`1995`
+
 .. _v3.24.3:
 
 :version:`3.24.3 <v3.24.2...v3.24.3>` - 2024-01-23

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -1343,6 +1343,8 @@ def execute(
     started_at: str,
 ) -> None:
     """Execute a prepared runner by drawing events from it and passing to a proper handler."""
+    from ..utils import _ensure_parent
+
     handlers: list[EventHandler] = []
     report_context: ServiceReportContext | FileReportContext | None = None
     report_queue: Queue
@@ -1363,6 +1365,7 @@ def execute(
             )
         )
     elif isinstance(report, click.utils.LazyFile):
+        _ensure_parent(report.name, fail_silently=False)
         report_queue = Queue()
         report_context = FileReportContext(queue=report_queue, filename=report.name)
         handlers.append(
@@ -1377,11 +1380,14 @@ def execute(
             )
         )
     if junit_xml is not None:
+        _ensure_parent(junit_xml.name, fail_silently=False)
         handlers.append(JunitXMLHandler(junit_xml))
     if debug_output_file is not None:
+        _ensure_parent(debug_output_file.name, fail_silently=False)
         handlers.append(DebugOutputHandler(debug_output_file))
     if cassette_path is not None:
         # This handler should be first to have logs writing completed when the output handler will display statistic
+        _ensure_parent(cassette_path.name, fail_silently=False)
         handlers.append(
             cassettes.CassetteWriter(cassette_path, preserve_exact_body_bytes=cassette_preserve_exact_body_bytes)
         )

--- a/src/schemathesis/service/hosts.py
+++ b/src/schemathesis/service/hosts.py
@@ -49,23 +49,16 @@ def load(path: PathLike) -> dict[str, Any]:
 
     Return an empty dict if it doesn't exist.
     """
+    from ..utils import _ensure_parent
+
     try:
         with open(path, "rb") as fd:
             return tomli.load(fd)
     except FileNotFoundError:
-        _try_make_config_directory(path)
+        _ensure_parent(path)
         return {}
     except tomli.TOMLDecodeError:
         return {}
-
-
-def _try_make_config_directory(path: PathLike) -> None:
-    # Try to create the parent dir - it could be the first run, when the config dir doesn't exist yet
-    try:
-        Path(path).parent.mkdir(mode=0o755, parents=True, exist_ok=True)
-    except OSError:
-        # Ignore permission errors, etc
-        pass
 
 
 def load_for_host(hostname: str = DEFAULT_HOSTNAME, hosts_file: PathLike = DEFAULT_HOSTS_PATH) -> dict[str, Any]:

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -3,6 +3,7 @@ import functools
 import operator
 from contextlib import contextmanager
 from inspect import getfullargspec
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -22,7 +23,7 @@ from ._compat import InferType, get_signature
 # Backward-compat
 from .constants import NOT_SET  # noqa: F401
 from .exceptions import SkipTest, UsageError
-from .types import GenericTest
+from .types import GenericTest, PathLike
 
 
 def is_schemathesis_test(func: Callable) -> bool:
@@ -157,3 +158,12 @@ def combine_strategies(strategies: list[st.SearchStrategy]) -> st.SearchStrategy
 
 def skip(operation_name: str) -> NoReturn:
     raise SkipTest(f"It is not possible to generate negative test cases for `{operation_name}`")
+
+
+def _ensure_parent(path: PathLike, fail_silently: bool = True) -> None:
+    # Try to create the parent dir
+    try:
+        Path(path).parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+    except OSError:
+        if not fail_silently:
+            raise

--- a/test/cli/test_junitxml.py
+++ b/test/cli/test_junitxml.py
@@ -22,9 +22,10 @@ def test_junitxml_option(cli, schema_url, hypothesis_max_examples, tmp_path):
     ElementTree.parse(xml_path)
 
 
+@pytest.mark.parametrize("path", ("junit.xml", "does-not-exist/junit.xml"))
 @pytest.mark.operations("success", "failure", "unsatisfiable")
-def test_junitxml_file(cli, schema_url, hypothesis_max_examples, tmp_path):
-    xml_path = tmp_path / "junit.xml"
+def test_junitxml_file(cli, schema_url, hypothesis_max_examples, tmp_path, path):
+    xml_path = tmp_path / path
     cli.run(
         schema_url,
         f"--junit-xml={xml_path}",


### PR DESCRIPTION
Fixes #1995