### PR TITLE
fix: Incorrect error message when the code inside the hook module raises `ImportError`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 :version:`Unreleased <v3.25.4...HEAD>` - TBD
 --------------------------------------------
 
+**Fixed**
+
+- Incorrect error message when the code inside the hook module raises ``ImportError``. :issue:`2074`
+
 .. _v3.25.4:
 
 :version:`3.25.4 <v3.25.3...v3.25.4>` - 2024-02-25

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -1328,7 +1328,7 @@ def load_hook(module_name: str) -> None:
     except Exception as exc:
         click.secho("Unable to load Schemathesis extension hooks", fg="red", bold=True)
         formatted_module_name = bold(f"'{module_name}'")
-        if isinstance(exc, ModuleNotFoundError):
+        if isinstance(exc, ModuleNotFoundError) and exc.name == module_name:
             click.echo(
                 f"\nAn attempt to import the module {formatted_module_name} failed because it could not be found."
             )

--- a/test/cli/__snapshots__/test_commands/test_hooks_with_inner_import_error.raw
+++ b/test/cli/__snapshots__/test_commands/test_hooks_with_inner_import_error.raw
@@ -1,0 +1,13 @@
+Exit code: 1
+---
+Stdout:
+Unable to load Schemathesis extension hooks
+
+An error occurred while importing the module 'hook'. Traceback:
+
+Traceback (most recent call last):
+  File "/tmp/hook.py", line XXX, in <module>
+    import something_else
+ModuleNotFoundError: No module named 'something_else'
+
+For more information on how to work with hooks, visit https://schemathesis.readthedocs.io/en/stable/extending.html

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -119,6 +119,12 @@ def test_hooks_module_not_found(cli, snapshot_cli):
     assert os.getcwd() in sys.path
 
 
+def test_hooks_with_inner_import_error(testdir, cli, snapshot_cli):
+    # When the hook module itself raises an ImportError
+    module = testdir.make_importable_pyfile(hook="import something_else")
+    assert cli.main("run", "http://127.0.0.1:1", hooks=module.purebasename) == snapshot_cli
+
+
 def test_hooks_invalid(testdir, cli):
     # When hooks are passed to the CLI call
     # And its importing causes an exception


### PR DESCRIPTION
Fixes #2074