### PR TITLE
fix: `InvalidArgument` when using `from_pytest_fixture` with parametrized pytest fixtures

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 :version:`Unreleased <v3.26.0...HEAD>` - TBD
 --------------------------------------------
 
+**Fixed**
+
+- ``InvalidArgument`` when using ``from_pytest_fixture`` with parametrized pytest fixtures and Hypothesis settings. :issue:`2115`
+
 .. _v3.26.0:
 
 :version:`3.26.0 <v3.25.6...v3.26.0>` - 2024-03-21

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -77,7 +77,16 @@ def create_test(
             wrapped_test.hypothesis.inner_test = make_async_test(test)  # type: ignore
     setup_default_deadline(wrapped_test)
     if settings is not None:
-        wrapped_test = settings(wrapped_test)
+        existing_settings = _get_hypothesis_settings(wrapped_test)
+        if existing_settings is not None:
+            # Merge the user-provided settings with the current ones
+            default = hypothesis.settings.default
+            wrapped_test._hypothesis_internal_use_settings = hypothesis.settings(
+                wrapped_test._hypothesis_internal_use_settings,
+                **{item: value for item, value in settings.__dict__.items() if value != getattr(default, item)},
+            )
+        else:
+            wrapped_test = settings(wrapped_test)
     existing_settings = _get_hypothesis_settings(wrapped_test)
     if existing_settings is not None:
         existing_settings = remove_explain_phase(existing_settings)

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -508,7 +508,8 @@ def test_b(case):
     result.assert_outcomes(passed=2)
 
 
-def test_parametrized_fixture(testdir, openapi3_base_url, is_older_subtests):
+@pytest.mark.parametrize("settings", ("", "@settings(deadline=None)"))
+def test_parametrized_fixture(testdir, openapi3_base_url, is_older_subtests, settings):
     # When the used pytest fixture is parametrized via `params`
     testdir.make_test(
         f"""
@@ -521,6 +522,7 @@ def parametrized_lazy_schema(request):
 lazy_schema = schemathesis.from_pytest_fixture("parametrized_lazy_schema")
 
 @lazy_schema.parametrize()
+{settings}
 def test_(case):
     case.call()
 """,


### PR DESCRIPTION
Fixes #2115 