### PR TITLE
fix: Generating invalid examples created by wrapping a named example value into another object

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ Changelog
 
 - Internal error during Open API link resolution if the needed parameter is missing in the response.
 - Improper output when a JSON pointer can't be resolved during Open API link resolution.
+- Generating invalid examples created by wrapping a named example value into another object. :issue:`2238`
 
 .. _v3.29.2:
 

--- a/src/schemathesis/specs/openapi/examples.py
+++ b/src/schemathesis/specs/openapi/examples.py
@@ -183,7 +183,7 @@ def extract_inner_examples(
 ) -> Generator[Any, None, None]:
     """Extract exact examples values from the `examples` dictionary."""
     for name, example in examples.items():
-        if "$ref" in unresolved_definition[name]:
+        if "$ref" in unresolved_definition[name] and "value" not in example and "externalValue" not in example:
             # The example here is a resolved example and should be yielded as is
             yield example
         if isinstance(example, dict):


### PR DESCRIPTION
Fixes #2238