### PR TITLE
fix code typo in python docs

### DIFF
--- a/docs/python.rst
+++ b/docs/python.rst
@@ -102,7 +102,7 @@ For example, to override a query parameter and path:
 
 
     @schema.parametrize()
-    @schema.override(path_parameters={"user_id": "42"}, query={"apiKey": "secret"}}
+    @schema.override(path_parameters={"user_id": "42"}, query={"apiKey": "secret"})
     def test_api(case):
 
 This decorator overrides the ``apiKey`` query parameter and ``user_id`` path parameter, using ``secret`` and ``42`` as their respective values in all applicable test cases.


### PR DESCRIPTION
### Description

Replace closing curly with closing brace to fix syntax in schema.override() example

### Checklist

- [ ] Added failing tests for the change
- [ ] All new and existing tests pass
- [ ] Added changelog entry (follow guidelines in CONTRIBUTING.rst)
- [x] Updated README/documentation, if necessary
