### PR TITLE
fix: Ignoring property examples defined under the `example` key in Open API 2.0 schemas

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,6 +51,7 @@ Changelog
 - Missing body in ``Case`` if it is mutated after the ``make_case`` call. :issue:`2208`
 - Internal error when a rate limiter hits its limit. :issue:`2254`
 - Internal error during reference resolving when using relative file paths.
+- Ignoring property examples defined under the ``example`` key in Open API 2.0 schemas. :issue:`2277`
 
 **Performance**
 

--- a/src/schemathesis/specs/openapi/examples.py
+++ b/src/schemathesis/specs/openapi/examples.py
@@ -42,9 +42,7 @@ class BodyExample:
 Example = Union[ParameterExample, BodyExample]
 
 
-def get_strategies_from_examples(
-    operation: APIOperation[OpenAPIParameter, Case], examples_field: str = "examples"
-) -> list[SearchStrategy[Case]]:
+def get_strategies_from_examples(operation: APIOperation[OpenAPIParameter, Case]) -> list[SearchStrategy[Case]]:
     """Build a set of strategies that generate test cases based on explicit examples in the schema."""
     maps = {}
     for location, container in LOCATION_TO_CONTAINER.items():
@@ -213,8 +211,9 @@ def extract_from_schemas(operation: APIOperation[OpenAPIParameter, Case]) -> Gen
     for alternative in operation.body:
         alternative = cast(OpenAPIBody, alternative)
         schema = alternative.as_json_schema(operation)
-        for value in extract_from_schema(operation, schema, alternative.example_field, alternative.examples_field):
-            yield BodyExample(value=value, media_type=alternative.media_type)
+        for example_field, examples_field in (("example", "examples"), ("x-example", "x-examples")):
+            for value in extract_from_schema(operation, schema, example_field, examples_field):
+                yield BodyExample(value=value, media_type=alternative.media_type)
 
 
 def extract_from_schema(

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -926,7 +926,7 @@ class SwaggerV20(BaseOpenAPISchema):
 
     def get_strategies_from_examples(self, operation: APIOperation) -> list[SearchStrategy[Case]]:
         """Get examples from the API operation."""
-        return get_strategies_from_examples(operation, self.examples_field)
+        return get_strategies_from_examples(operation)
 
     def get_response_schema(self, definition: dict[str, Any], scope: str) -> tuple[list[str], dict[str, Any] | None]:
         scopes, definition = self.resolver.resolve_in_scope(definition, scope)
@@ -1090,7 +1090,7 @@ class OpenApi30(SwaggerV20):
 
     def get_strategies_from_examples(self, operation: APIOperation) -> list[SearchStrategy[Case]]:
         """Get examples from the API operation."""
-        return get_strategies_from_examples(operation, self.examples_field)
+        return get_strategies_from_examples(operation)
 
     def get_content_types(self, operation: APIOperation, response: GenericResponse) -> list[str]:
         definitions = self._get_response_definitions(operation, response)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -30,7 +30,7 @@ def schema():
 @pytest.mark.hypothesis_nested
 def test_examples_validity(schema, openapi3_base_url):
     operation = next(schema.get_all_operations()).ok()
-    strategy = get_strategies_from_examples(operation, "examples")[0]
+    strategy = get_strategies_from_examples(operation)[0]
 
     @given(case=strategy)
     @settings(deadline=None)


### PR DESCRIPTION
Fixes #2277