### PR TITLE
feat: The `--generation-graphql-allow-null` CLI option that controls whether `null` should be used for optional arguments in GraphQL queries

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 - The ``ignored_auth`` check. It verifies that the API operation requires the specified authentication.
 - Enable string format verification in response conformance checks. :issue:`787`
 - Control over cache key in custom auth implementation. :issue:`1775`
+- The ``--generation-graphql-allow-null`` CLI option that controls whether ``null`` should be used for optional arguments in GraphQL queries. Enabled by default. :issue:`1994`
 
 **Changed**
 

--- a/docs/graphql.rst
+++ b/docs/graphql.rst
@@ -50,6 +50,8 @@ If you want to narrow the testing scope, you can use ``--include-name`` and ``--
 
 For GraphQL, the ``name`` attribute is a combination of the type and the field name, for example, ``Query.getBookings`` or ``Mutation.updateUser``.
 
+Additionally, you can disable using ``null`` values for optional arguments via the ``--generation-graphql-allow-null=false`` CLI option.
+
 Custom scalars
 ~~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "httpx>=0.22.0,<1.0",
   "hypothesis>=6.103.4,<7; python_version > '3.8'",
   "hypothesis[zoneinfo]>=6.103.4,<7; python_version == '3.8'",
-  "hypothesis_graphql>=0.11.0,<1",
+  "hypothesis_graphql>=0.11.1,<1",
   "hypothesis_jsonschema>=0.23.1,<0.24",
   "jsonschema[format]>=4.18.0,<5.0",
   "junit-xml>=1.9,<2.0",

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -796,6 +796,14 @@ The report data, consisting of a tar gz file with multiple JSON files, is subjec
     callback=callbacks.convert_boolean_string,
 )
 @click.option(
+    "--generation-graphql-allow-null",
+    help="Whether `null` values should be used for optional arguments in GraphQL queries.",
+    type=str,
+    default="true",
+    show_default=True,
+    callback=callbacks.convert_boolean_string,
+)
+@click.option(
     "--schemathesis-io-token",
     help="Schemathesis.io authentication token.",
     type=str,
@@ -911,6 +919,7 @@ def run(
     no_color: bool = False,
     report_value: str | None = None,
     generation_allow_x00: bool = True,
+    generation_graphql_allow_null: bool = True,
     generation_with_security_parameters: bool = True,
     generation_codec: str = "utf-8",
     schemathesis_io_token: str | None = None,
@@ -953,6 +962,7 @@ def run(
 
     generation_config = generation.GenerationConfig(
         allow_x00=generation_allow_x00,
+        graphql_allow_null=generation_graphql_allow_null,
         codec=generation_codec,
         with_security_parameters=generation_with_security_parameters,
     )

--- a/src/schemathesis/generation/__init__.py
+++ b/src/schemathesis/generation/__init__.py
@@ -75,6 +75,8 @@ class GenerationConfig:
 
     # Allow generating `\x00` bytes in strings
     allow_x00: bool = True
+    # Allowing using `null` for optional arguments in GraphQL queries
+    graphql_allow_null: bool = True
     # Generate strings using the given codec
     codec: str | None = "utf-8"
     # Whether to generate security parameters

--- a/src/schemathesis/specs/graphql/schemas.py
+++ b/src/schemathesis/specs/graphql/schemas.py
@@ -367,6 +367,7 @@ def get_case_strategy(
         custom_scalars=custom_scalars,
         print_ast=_noop,  # type: ignore
         allow_x00=generation_config.allow_x00,
+        allow_null=generation_config.graphql_allow_null,
         codec=generation_config.codec,
     )
     strategy = apply_to_all_dispatchers(operation, hook_context, hooks, strategy, "body").map(graphql.print_ast)

--- a/test/cli/__snapshots__/test_commands/test_run_output[args24].raw
+++ b/test/cli/__snapshots__/test_commands/test_run_output[args24].raw
@@ -225,6 +225,10 @@ Generic:
   --generation-with-security-parameters TEXT
                                   Whether to generate security parameters.
                                   [default: true]
+  --generation-graphql-allow-null TEXT
+                                  Whether `null` values should be used for
+                                  optional arguments in GraphQL queries.
+                                  [default: true]
   --schemathesis-io-token TEXT    Schemathesis.io authentication token.
   --schemathesis-io-url TEXT      Schemathesis.io base URL.
   --schemathesis-io-telemetry TEXT

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -318,6 +318,7 @@ class CliSnapshotConfig:
         return self.request.getfixturevalue("testdir")
 
     def serialize(self, data: str) -> str:
+        print(data)
         lines = data.splitlines()
         lines = [
             line

--- a/test/specs/graphql/__snapshots__/test_basic/test_disallow_null.raw
+++ b/test/specs/graphql/__snapshots__/test_basic/test_disallow_null.raw
@@ -1,0 +1,24 @@
+Exit code: 0
+---
+Stdout:
+======================= Schemathesis test session starts =======================
+Schema location: file:///tmp/schema.gql
+Base URL: file:///tmp/schema.gql
+Specification version: GraphQL
+Random seed: 42
+Workers: 1
+Collected API operations: 1
+Collected API links: 0
+API probing: SKIP
+Schema analysis: SKIP
+
+Query.getValue .                                                          [100%]
+
+=================================== SUMMARY ====================================
+
+No checks were performed.
+
+Tip: Use the `--report` CLI option to visualize test results via Schemathesis.io.
+We run additional conformance checks on reports from public repos.
+
+============================== 1 passed in 1.00s ===============================


### PR DESCRIPTION
Resolves #1994