### PR TITLE
fix "request() got an unexpected keyword argument 'excluded_checks'" …

### DIFF
--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -529,12 +529,16 @@ class Case:
         session: requests.Session | None = None,
         headers: dict[str, Any] | None = None,
         checks: tuple[CheckFunction, ...] = (),
+        additional_checks: tuple[CheckFunction, ...] = (),
+        excluded_checks: tuple[CheckFunction, ...] = (),
         code_sample_style: str | None = None,
         **kwargs: Any,
     ) -> requests.Response:
         __tracebackhide__ = True
         response = self.call(base_url, session, headers, **kwargs)
-        self.validate_response(response, checks, code_sample_style=code_sample_style, headers=headers)
+        self.validate_response(response, checks, code_sample_style=code_sample_style,
+                               headers=headers,additional_checks=additional_checks,
+                               excluded_checks=excluded_checks)
         return response
 
     def _get_url(self, base_url: str | None) -> str:


### PR DESCRIPTION
fix "request() got an unexpected keyword argument 'excluded_checks'" when pass excluded_checks in call_and_validate. add arguments (additional_checks, excluded_checks) in call_and_validate and pass them in  validate_response.