### PR TITLE
refactor: Simplify cloning

### DIFF
--- a/src/schemathesis/constants.py
+++ b/src/schemathesis/constants.py
@@ -5,15 +5,10 @@ GITHUB_APP_LINK = "https://github.com/apps/schemathesis"
 # Maximum test running time
 DEFAULT_DEADLINE = 15000
 DEFAULT_RESPONSE_TIMEOUT = 10
-HTTP_METHODS = frozenset({"get", "put", "post", "delete", "options", "head", "patch", "trace"})
 RECURSIVE_REFERENCE_ERROR_MESSAGE = (
     "Currently, Schemathesis can't generate data for this operation due to "
     "recursive references in the operation definition. See more information in "
     "this issue - https://github.com/schemathesis/schemathesis/issues/947"
-)
-GIVEN_AND_EXPLICIT_EXAMPLES_ERROR_MESSAGE = (
-    "Unsupported test setup. Tests using `@schema.given` cannot be combined with explicit schema examples in the same "
-    "function. Separate these tests into distinct functions to avoid conflicts."
 )
 SERIALIZERS_SUGGESTION_MESSAGE = (
     "You can register your own serializer with `schemathesis.serializer` "
@@ -31,8 +26,6 @@ ISSUE_TRACKER_URL = (
     "labels=Status%3A%20Needs%20Triage%2C+Type%3A+Bug&template=bug_report.md&title=%5BBUG%5D"
 )
 FLAKY_FAILURE_MESSAGE = "[FLAKY] Schemathesis was not able to reliably reproduce this failure"
-BOM_MARK = "\ufeff"
-WAIT_FOR_SCHEMA_INTERVAL = 0.05
 HOOKS_MODULE_ENV_VAR = "SCHEMATHESIS_HOOKS"
 API_NAME_ENV_VAR = "SCHEMATHESIS_API_NAME"
 BASE_URL_ENV_VAR = "SCHEMATHESIS_BASE_URL"

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -33,7 +33,6 @@ from .constants import (
 from .generation import DataGenerationMethod, GenerationConfig, generate_random_case_id
 from .hooks import GLOBAL_HOOK_DISPATCHER, HookContext, HookDispatcher, dispatch
 from .internal.checks import CheckContext
-from .internal.copy import fast_deepcopy
 from .internal.diff import diff
 from .internal.output import prepare_response_payload
 from .parameters import Parameter, ParameterSet, PayloadAlternatives
@@ -69,15 +68,6 @@ class CaseSource:
     elapsed: float
     overrides_all_parameters: bool
     transition_id: TransitionId
-
-    def partial_deepcopy(self) -> CaseSource:
-        return self.__class__(
-            case=self.case.partial_deepcopy(),
-            response=self.response,
-            elapsed=self.elapsed,
-            overrides_all_parameters=self.overrides_all_parameters,
-            transition_id=self.transition_id,
-        )
 
 
 def cant_serialize(media_type: str) -> NoReturn:  # type: ignore
@@ -390,9 +380,8 @@ class Case:
             override=self._override, auth=None, headers=CaseInsensitiveDict(headers) if headers else None
         )
         for check in chain(checks, additional_checks):
-            copied_case = self.partial_deepcopy()
             try:
-                check(ctx, response, copied_case)
+                check(ctx, response, self)
             except Failure as f:
                 # Tracebacks are not relevant here
                 failures.add(f.with_traceback(None))
@@ -459,23 +448,6 @@ class Case:
         request = requests.Request(**kwargs)
         prepared = requests.Session().prepare_request(request)  # type: ignore
         return cast(str, prepared.url)
-
-    def partial_deepcopy(self) -> Case:
-        return self.__class__(
-            operation=self.operation.partial_deepcopy(),
-            data_generation_method=self.data_generation_method,
-            media_type=self.media_type,
-            source=self.source if self.source is None else self.source.partial_deepcopy(),
-            path_parameters=fast_deepcopy(self.path_parameters),
-            headers=fast_deepcopy(self.headers),
-            cookies=fast_deepcopy(self.cookies),
-            query=fast_deepcopy(self.query),
-            body=fast_deepcopy(self.body),
-            generation_time=self.generation_time,
-            id=self.id,
-            _auth=self._auth,
-            _has_explicit_auth=self._has_explicit_auth,
-        )
 
 
 P = TypeVar("P", bound=Parameter)
@@ -650,22 +622,6 @@ class APIOperation(Generic[P, C]):
             "Can not detect appropriate media type. "
             "You can either specify one of the defined media types "
             f"or pass any other media type available for serialization. Defined media types: {media_types_repr}"
-        )
-
-    def partial_deepcopy(self) -> APIOperation:
-        return self.__class__(
-            path=self.path,  # string, immutable
-            method=self.method,  # string, immutable
-            definition=fast_deepcopy(self.definition),
-            schema=self.schema.clone(),  # shallow copy
-            verbose_name=self.verbose_name,  # string, immutable
-            app=self.app,  # not deepcopyable
-            base_url=self.base_url,  # string, immutable
-            path_parameters=fast_deepcopy(self.path_parameters),
-            headers=fast_deepcopy(self.headers),
-            cookies=fast_deepcopy(self.cookies),
-            query=fast_deepcopy(self.query),
-            body=fast_deepcopy(self.body),
         )
 
     def make_case(

--- a/src/schemathesis/pytest/plugin.py
+++ b/src/schemathesis/pytest/plugin.py
@@ -32,11 +32,7 @@ from .._hypothesis._given import (
     validate_given_args,
 )
 from .._override import OverrideMark
-from ..constants import (
-    GIVEN_AND_EXPLICIT_EXAMPLES_ERROR_MESSAGE,
-    RECURSIVE_REFERENCE_ERROR_MESSAGE,
-    SERIALIZERS_SUGGESTION_MESSAGE,
-)
+from ..constants import RECURSIVE_REFERENCE_ERROR_MESSAGE, SERIALIZERS_SUGGESTION_MESSAGE
 from ..internal.result import Ok, Result
 
 if TYPE_CHECKING:
@@ -44,6 +40,11 @@ if TYPE_CHECKING:
 
     from ..models import APIOperation
     from ..schemas import BaseSchema
+
+GIVEN_AND_EXPLICIT_EXAMPLES_ERROR_MESSAGE = (
+    "Unsupported test setup. Tests using `@schema.given` cannot be combined with explicit schema examples in the same "
+    "function. Separate these tests into distinct functions to avoid conflicts."
+)
 
 
 def _is_schema(value: object) -> bool:

--- a/src/schemathesis/runner/phases/unit/_executor.py
+++ b/src/schemathesis/runner/phases/unit/_executor.py
@@ -268,7 +268,7 @@ def run_checks(
         check_results.append(
             result.add_failure(
                 name=check_name,
-                case=copied_case,
+                case=case,
                 request=Request.from_prepared_request(response.request),
                 response=Response.from_requests(response=response),
                 failure=failure,
@@ -277,13 +277,12 @@ def run_checks(
 
     for check in checks:
         check_name = check.__name__
-        copied_case = case.partial_deepcopy()
         try:
-            skip_check = check(ctx, response, copied_case)
+            skip_check = check(ctx, response, case)
             if not skip_check:
                 check_result = result.add_success(
                     name=check_name,
-                    case=copied_case,
+                    case=case,
                     request=Request.from_prepared_request(response.request),
                     response=Response.from_requests(response=response),
                 )

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -289,7 +289,7 @@ class BaseSchema(Mapping):
 
                 return wrapped_test
             HookDispatcher.add_dispatcher(func)
-            cloned = self.clone(test_function=func, filter_set=self.filter_set)
+            cloned = self.clone(test_function=func)
             SchemaHandleMark.set(func, cloned)
             return func
 
@@ -300,48 +300,30 @@ class BaseSchema(Mapping):
         return given_proxy(*args, **kwargs)
 
     def clone(
-        self,
-        *,
-        base_url: str | None | NotSet = NOT_SET,
-        test_function: Callable | None = None,
-        app: Any = NOT_SET,
-        hooks: HookDispatcher | NotSet = NOT_SET,
-        auth: AuthStorage | NotSet = NOT_SET,
-        generation_config: GenerationConfig | NotSet = NOT_SET,
-        output_config: OutputConfig | NotSet = NOT_SET,
-        rate_limiter: Limiter | NotSet | None = NOT_SET,
-        filter_set: FilterSet | None = None,
+        self, *, test_function: Callable | NotSet = NOT_SET, filter_set: FilterSet | NotSet = NOT_SET
     ) -> BaseSchema:
-        if base_url is NOT_SET:
-            base_url = self.base_url
-        if app is NOT_SET:
-            app = self.app
-        if filter_set is None:
-            filter_set = self.filter_set
-        if hooks is NOT_SET:
-            hooks = self.hooks
-        if auth is NOT_SET:
-            auth = self.auth
-        if generation_config is NOT_SET:
-            generation_config = self.generation_config
-        if output_config is NOT_SET:
-            output_config = self.output_config
-        if rate_limiter is NOT_SET:
-            rate_limiter = self.rate_limiter
+        if isinstance(test_function, NotSet):
+            _test_function = self.test_function
+        else:
+            _test_function = test_function
+        if isinstance(filter_set, NotSet):
+            _filter_set = self.filter_set
+        else:
+            _filter_set = filter_set
 
         return self.__class__(
             self.raw_schema,
             specification=self.specification,
             location=self.location,
-            base_url=base_url,  # type: ignore
-            app=app,
-            hooks=hooks,  # type: ignore
-            auth=auth,  # type: ignore
-            test_function=test_function,
-            generation_config=generation_config,  # type: ignore
-            output_config=output_config,  # type: ignore
-            rate_limiter=rate_limiter,  # type: ignore
-            filter_set=filter_set,  # type: ignore
+            base_url=self.base_url,
+            app=self.app,
+            hooks=self.hooks,
+            auth=self.auth,
+            test_function=_test_function,
+            generation_config=self.generation_config,
+            output_config=self.output_config,
+            rate_limiter=self.rate_limiter,
+            filter_set=_filter_set,
         )
 
     def get_local_hook_dispatcher(self) -> HookDispatcher | None:

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -34,7 +34,6 @@ from schemathesis.core.failures import Failure, FailureGroup, MalformedJson
 from schemathesis.openapi.checks import JsonSchemaError, MissingContentType
 
 from ..._override import CaseOverride, OverrideMark, check_no_override_mark
-from ...constants import HTTP_METHODS
 from ...generation import DataGenerationMethod, GenerationConfig
 from ...hooks import HookContext, HookDispatcher
 from ...internal.copy import fast_deepcopy
@@ -75,6 +74,7 @@ if TYPE_CHECKING:
     from ...stateful.state_machine import APIStateMachine
     from ...transports.responses import GenericResponse
 
+HTTP_METHODS = frozenset({"get", "put", "post", "delete", "options", "head", "patch", "trace"})
 SCHEMA_ERROR_MESSAGE = "Ensure that the definition complies with the OpenAPI specification"
 SCHEMA_PARSING_ERRORS = (KeyError, AttributeError, jsonschema.exceptions.RefResolutionError)
 

--- a/src/schemathesis/stateful/validation.py
+++ b/src/schemathesis/stateful/validation.py
@@ -40,7 +40,7 @@ def validate_response(
             status=Status.failure,
             request=Request.from_prepared_request(response.request),
             response=Response.from_generic(response=response),
-            case=copied_case,
+            case=case,
             failure=failure,
         )
         runner_ctx.add_failed_check(failed_check)
@@ -59,11 +59,10 @@ def validate_response(
 
     for check in tuple(checks) + tuple(additional_checks):
         name = check.__name__
-        copied_case = case.partial_deepcopy()
         try:
-            skip_check = check(check_ctx, response, copied_case)
+            skip_check = check(check_ctx, response, case)
             if not skip_check:
-                _on_passed(name, copied_case)
+                _on_passed(name, case)
         except Failure as exc:
             if runner_ctx.is_seen_in_run(exc):
                 continue

--- a/test/cli/__snapshots__/test_commands/test_useful_traceback[Open API 3.0].raw
+++ b/test/cli/__snapshots__/test_commands/test_useful_traceback[Open API 3.0].raw
@@ -28,7 +28,7 @@ division by zero
       File "/package-root/runner/phases/unit/_executor.py", line XXX, in _network_test
         run_checks(
       File "/package-root/runner/phases/unit/_executor.py", line XXX, in run_checks
-        skip_check = check(ctx, response, copied_case)
+        skip_check = check(ctx, response, case)
       File "/tmp/module.py", line XXX, in with_error
         1 / 0
     ZeroDivisionError: division by zero

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -1108,25 +1108,6 @@ def test_finish(event_stream):
     assert next(event_stream, None) is None
 
 
-@pytest.mark.operations("success")
-@pytest.mark.openapi_version("3.0")
-def test_case_mutation(real_app_schema):
-    # When two checks mutate the case
-
-    def check1(ctx, response, case):
-        case.headers = {"Foo": "BAR"}
-        raise AssertionError("Bar!")
-
-    def check2(ctx, response, case):
-        case.headers = {"Foo": "BAZ"}
-        raise AssertionError("Baz!")
-
-    *_, event, _ = from_schema(real_app_schema, checks=[check1, check2]).execute()
-    # Then these mutations should not interfere
-    assert event.result.checks[0].case.headers["Foo"] == "BAR"
-    assert event.result.checks[1].case.headers["Foo"] == "BAZ"
-
-
 @pytest.mark.parametrize(
     ("path", "expected"),
     [


### PR DESCRIPTION
- Removed `partial_deepcopy`, assuming `Case` is not mutated within a check