### PR TITLE
fix: Ignore request-related configuration inside the ignored_auth check

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 :version:`Unreleased <v3.38.9...HEAD>` - TBD
 --------------------------------------------
 
+**Fixed**
+
+- Ignored request-related configuration inside the ``ignored_auth`` check. :issue:`2613`
+
 .. _v3.38.9:
 
 :version:`3.38.9 <v3.38.8...v3.38.9>` - 2024-12-02

--- a/src/schemathesis/internal/checks.py
+++ b/src/schemathesis/internal/checks.py
@@ -52,6 +52,7 @@ class CheckContext:
     auth: HTTPDigestAuth | RawAuth | None
     headers: CaseInsensitiveDict | None
     config: CheckConfig = field(default_factory=CheckConfig)
+    transport_kwargs: dict | None = None
 
 
 def wrap_check(check: Callable) -> CheckFunction:

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -474,6 +474,7 @@ class Case:
         excluded_checks: tuple[CheckFunction, ...] = (),
         code_sample_style: str | None = None,
         headers: dict[str, Any] | None = None,
+        transport_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """Validate application response.
 
@@ -507,7 +508,10 @@ class Case:
         additional_checks = tuple(check for check in _additional_checks if check not in excluded_checks)
         failed_checks = []
         ctx = CheckContext(
-            override=self._override, auth=None, headers=CaseInsensitiveDict(headers) if headers else None
+            override=self._override,
+            auth=None,
+            headers=CaseInsensitiveDict(headers) if headers else None,
+            transport_kwargs=transport_kwargs,
         )
         for check in chain(checks, additional_checks):
             copied_case = self.partial_deepcopy()
@@ -591,6 +595,7 @@ class Case:
             headers=headers,
             additional_checks=additional_checks,
             excluded_checks=excluded_checks,
+            transport_kwargs=kwargs,
         )
         return response
 

--- a/src/schemathesis/specs/graphql/schemas.py
+++ b/src/schemathesis/specs/graphql/schemas.py
@@ -83,11 +83,14 @@ class GraphQLCase(Case):
         excluded_checks: tuple[CheckFunction, ...] = (),
         code_sample_style: str | None = None,
         headers: dict[str, Any] | None = None,
+        transport_kwargs: dict[str, Any] | None = None,
     ) -> None:
         checks = checks or (not_a_server_error,)
         checks += additional_checks
         checks = tuple(check for check in checks if check not in excluded_checks)
-        return super().validate_response(response, checks, code_sample_style=code_sample_style, headers=headers)
+        return super().validate_response(
+            response, checks, code_sample_style=code_sample_style, headers=headers, transport_kwargs=transport_kwargs
+        )
 
 
 C = TypeVar("C", bound=Case)

--- a/src/schemathesis/specs/openapi/checks.py
+++ b/src/schemathesis/specs/openapi/checks.py
@@ -404,14 +404,21 @@ def ignored_auth(ctx: CheckContext, response: GenericResponse, case: Case) -> bo
             # Auth is explicitly set, it is expected to be valid
             # Check if invalid auth will give an error
             _remove_auth_from_case(case, security_parameters)
-            new_response = case.operation.schema.transport.send(case)
+            kwargs = ctx.transport_kwargs or {}
+            kwargs.copy()
+            if "headers" in kwargs:
+                headers = kwargs["headers"].copy()
+                _remove_auth_from_explicit_headers(headers, security_parameters)
+                kwargs["headers"] = headers
+            kwargs.pop("session", None)
+            new_response = case.operation.schema.transport.send(case, **kwargs)
             if new_response.status_code != 401:
                 _update_response(response, new_response)
                 _raise_no_auth_error(new_response, case.operation.verbose_name, "that requires authentication")
             # Try to set invalid auth and check if it succeeds
             for parameter in security_parameters:
                 _set_auth_for_case(case, parameter)
-                new_response = case.operation.schema.transport.send(case)
+                new_response = case.operation.schema.transport.send(case, **kwargs)
                 if new_response.status_code != 401:
                     _update_response(response, new_response)
                     _raise_no_auth_error(new_response, case.operation.verbose_name, "with any auth")
@@ -524,6 +531,13 @@ def _remove_auth_from_case(case: Case, security_parameters: list[SecurityParamet
             case.query.pop(name, None)
         if parameter["in"] == "cookie" and case.cookies:
             case.cookies.pop(name, None)
+
+
+def _remove_auth_from_explicit_headers(headers: dict, security_parameters: list[SecurityParameter]) -> None:
+    for parameter in security_parameters:
+        name = parameter["name"]
+        if parameter["in"] == "header":
+            headers.pop(name, None)
 
 
 def _set_auth_for_case(case: Case, parameter: SecurityParameter) -> None:


### PR DESCRIPTION
Fixes #2613 