### PR TITLE
fix: Ignoring verify=False when specified via get_call_kwargs on a state machine

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,7 @@ Added
 - **CLI**: Make exact method filters case insensitive.
 - Internal error in coverage phase when a parameter is mixing keywords for different types.
 - Do not run irrelevant checks on "Unspecified HTTP method" type of coverage scenarios.
+- Ignoring ``verify=False`` when specified via ``get_call_kwargs`` on a state machine. :issue:`2713`
 
 **Removed**
 

--- a/src/schemathesis/engine/phases/stateful/_executor.py
+++ b/src/schemathesis/engine/phases/stateful/_executor.py
@@ -134,7 +134,7 @@ def execute_state_machine_loop(
             return result
 
         def validate_response(
-            self, response: Response, case: Case, additional_checks: tuple[CheckFunction, ...] = ()
+            self, response: Response, case: Case, additional_checks: tuple[CheckFunction, ...] = (), **kwargs: Any
         ) -> None:
             self.recorder.record_response(case_id=case.id, response=response)
             ctx.collect_metric(case, response)

--- a/src/schemathesis/generation/stateful/state_machine.py
+++ b/src/schemathesis/generation/stateful/state_machine.py
@@ -172,7 +172,7 @@ class APIStateMachine(RuleBasedStateMachine):
         kwargs = self.get_call_kwargs(input.case)
         response = self.call(input.case, **kwargs)
         self.after_call(response, input.case)
-        self.validate_response(response, input.case)
+        self.validate_response(response, input.case, **kwargs)
         return StepOutput(response, input.case)
 
     def before_call(self, case: Case) -> None:
@@ -266,7 +266,7 @@ class APIStateMachine(RuleBasedStateMachine):
         return {}
 
     def validate_response(
-        self, response: Response, case: Case, additional_checks: list[CheckFunction] | None = None
+        self, response: Response, case: Case, additional_checks: list[CheckFunction] | None = None, **kwargs: Any
     ) -> None:
         """Validate an API response.
 
@@ -298,4 +298,4 @@ class APIStateMachine(RuleBasedStateMachine):
         all provided checks rather than only the first encountered exception.
         """
         __tracebackhide__ = True
-        case.validate_response(response, additional_checks=additional_checks)
+        case.validate_response(response, additional_checks=additional_checks, transport_kwargs=kwargs)


### PR DESCRIPTION
Fixes #2713.

Will backport separately and without a breaking change (probably via a private attribute on the state machine instance)