### PR TITLE
fix: Missing reference resolution scope when serializing `multipart` payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.0.0-alpha.8...HEAD) - TBD
 
+
+### :bug: Fixed
+
+- Missing reference resolution scope when serializing `multipart` payloads. [#2776](https://github.com/schemathesis/schemathesis/issues/2776)
+
 ## [4.0.0-alpha.8](https://github.com/schemathesis/schemathesis/compare/v4.0.0-alpha.7...v4.0.0-alpha.8) - 2025-04-05
 
 ### :rocket: Added

--- a/src/schemathesis/generation/hypothesis/builder.py
+++ b/src/schemathesis/generation/hypothesis/builder.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from dataclasses import dataclass, field
 from enum import Enum
 from functools import wraps
 from itertools import combinations
-import os
 from time import perf_counter
 from typing import Any, Callable, Generator, Mapping
 

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -1195,7 +1195,11 @@ class OpenApi30(SwaggerV20):
         files = []
         definition = operation.definition.raw
         if "$ref" in definition["requestBody"]:
-            body = self.resolver.resolve_all(definition["requestBody"], RECURSION_DEPTH_LIMIT)
+            self.resolver.push_scope(operation.definition.scope)
+            try:
+                body = self.resolver.resolve_all(definition["requestBody"], RECURSION_DEPTH_LIMIT)
+            finally:
+                self.resolver.pop_scope()
         else:
             body = definition["requestBody"]
         content = body["content"]

--- a/test/fixtures/ctx.py
+++ b/test/fixtures/ctx.py
@@ -34,10 +34,16 @@ class OpenApiContext:
         return {**template, **kwargs}
 
     def write_schema(
-        self, paths: dict[str, Any], *, version: str = "3.0.2", format: str = "json", **kwargs: dict[str, Any]
+        self,
+        paths: dict[str, Any],
+        *,
+        version: str = "3.0.2",
+        format: str = "json",
+        filename: str = "schema",
+        **kwargs: dict[str, Any],
     ) -> dict[str, Any]:
         schema = self.build_schema(paths, version=version, **kwargs)
-        return self.parent.makefile(schema, format=format)
+        return self.parent.makefile(schema, format=format, filename=filename)
 
 
 @dataclass
@@ -54,11 +60,11 @@ class Context:
     def _testdir(self):
         return self.request.getfixturevalue("testdir")
 
-    def makefile(self, schema: dict[str, Any], *, format: str = "json"):
+    def makefile(self, schema: dict[str, Any], *, format: str = "json", filename: str = "schema"):
         if format == "json":
-            return self._testdir.makefile(".json", schema=json.dumps(schema))
+            return self._testdir.makefile(".json", **{filename: json.dumps(schema)})
         if format == "yaml":
-            return self._testdir.makefile(".yaml", schema=yaml.dump(schema))
+            return self._testdir.makefile(".yaml", **{filename: yaml.dump(schema)})
         raise ValueError(f"Unknown format: {format}")
 
     def write_pymodule(self, content: str, *, filename: str = "module"):


### PR DESCRIPTION
Fixes #2776 