### PR TITLE
fix: Improve process interruption handling, for cases when interrupted while starting handlers

### DIFF
--- a/src/schemathesis/cli/commands/run/executor.py
+++ b/src/schemathesis/cli/commands/run/executor.py
@@ -121,17 +121,21 @@ def _execute(
     args: list[str],
     params: dict[str, Any],
 ) -> None:
-    handlers = initialize_handlers(config=config, args=args, params=params)
-    ctx = ExecutionContext(config=config)
+    handlers: list[EventHandler] = []
+    ctx: ExecutionContext | None = None
 
     def shutdown() -> None:
-        for _handler in handlers:
-            _handler.shutdown(ctx)
-
-    for handler in handlers:
-        handler.start(ctx)
+        if ctx is not None:
+            for _handler in handlers:
+                _handler.shutdown(ctx)
 
     try:
+        handlers = initialize_handlers(config=config, args=args, params=params)
+        ctx = ExecutionContext(config=config)
+
+        for handler in handlers:
+            handler.start(ctx)
+
         for event in event_stream:
             ctx.on_event(event)
             for handler in handlers:


### PR DESCRIPTION
### Description

It improves process interruption handling for cases when interrupted while starting handlers.

In this implementation, the handlers aren't going to be `shutdown()` in case of `click.Abort` interruption. I keep this part of logic as is, because changing it would affect the responsiveness from the user perspective.

But I think that a more graceful shutdown might make sense, so if you want this, please let me know and I will update the patch.

### Checklist

- [ ] Added failing tests for the change
- [x] All new and existing tests pass
- [ ] Added changelog entry (follow guidelines in CONTRIBUTING.rst)
- [ ] Updated README/documentation, if necessary
