### PR TITLE
feat: Support for validating `requests` / `httpx` / `werkzeug` responses in `Case.validate_response`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.0.0-alpha.12...HEAD) - TBD
 
+### :rocket: Added
+
+- Support for validating `requests` / `httpx` / `werkzeug` responses in `Case.validate_response`. [#1718](https://github.com/schemathesis/schemathesis/issues/1718)
+
 ### :wrench: Changed
 
 - Generate at least one non-NULL character in path parameters. [#2790](https://github.com/schemathesis/schemathesis/issues/2790)

--- a/src/schemathesis/core/transport.py
+++ b/src/schemathesis/core/transport.py
@@ -100,6 +100,20 @@ class Response:
         self._override = _override
 
     @classmethod
+    def from_any(cls, response: Response | httpx.Response | requests.Response | TestResponse) -> Response:
+        import httpx
+        import requests
+        from werkzeug.test import TestResponse
+
+        if isinstance(response, requests.Response):
+            return Response.from_requests(response, verify=True)
+        elif isinstance(response, httpx.Response):
+            return Response.from_httpx(response, verify=True)
+        elif isinstance(response, TestResponse):
+            return Response.from_wsgi(response)
+        return response
+
+    @classmethod
     def from_requests(cls, response: requests.Response, verify: bool, _override: Override | None = None) -> Response:
         raw = response.raw
         raw_headers = raw.headers if raw is not None else {}

--- a/src/schemathesis/generation/case.py
+++ b/src/schemathesis/generation/case.py
@@ -14,8 +14,11 @@ from schemathesis.hooks import HookContext, dispatch
 from schemathesis.transport.prepare import prepare_path, prepare_request
 
 if TYPE_CHECKING:
+    import httpx
+    import requests
     import requests.auth
     from requests.structures import CaseInsensitiveDict
+    from werkzeug.test import TestResponse
 
     from schemathesis.schemas import APIOperation
 
@@ -142,7 +145,7 @@ class Case:
 
     def validate_response(
         self,
-        response: Response,
+        response: Response | httpx.Response | requests.Response | TestResponse,
         checks: list[CheckFunction] | None = None,
         additional_checks: list[CheckFunction] | None = None,
         excluded_checks: list[CheckFunction] | None = None,
@@ -162,6 +165,8 @@ class Case:
         """
         __tracebackhide__ = True
         from requests.structures import CaseInsensitiveDict
+
+        response = Response.from_any(response)
 
         checks = [
             check

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -810,19 +810,7 @@ class APIOperation(Generic[P]):
             FailureGroup: If the response does not conform to the schema.
 
         """
-        import httpx
-        import requests
-        from werkzeug.test import TestResponse
-
-        if isinstance(response, requests.Response):
-            response_ = Response.from_requests(response, verify=True)
-        elif isinstance(response, httpx.Response):
-            response_ = Response.from_httpx(response, verify=True)
-        elif isinstance(response, TestResponse):
-            response_ = Response.from_wsgi(response)
-        else:
-            response_ = response
-        return self.schema.validate_response(self, response_)
+        return self.schema.validate_response(self, Response.from_any(response))
 
     def is_valid_response(self, response: Response | httpx.Response | requests.Response | TestResponse) -> bool:
         """Check if the provided response is valid against the API schema.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1118,11 +1118,14 @@ def response_factory():
         status_code: int = 200,
         headers: dict[str, Any] | None = None,
     ):
+        headers = headers or {}
+        if content_type:
+            headers.setdefault("Content-Type", content_type)
         request = Request.from_values(method="POST", base_url="http://127.0.0.1", path="/test", headers=headers)
         response = TestResponse(
             response=iter([content]),
             status=str(status_code),
-            headers=Headers({"Content-Type": content_type, **(headers or {})}),
+            headers=Headers(headers),
             request=request,
         )
         return response


### PR DESCRIPTION
Closes #1718 