### PR TITLE
fix: Do not send explicitly passed headers for the `missing_required_header` check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.0.1...HEAD) - TBD
 
+### :bug: Fixed
+
+- Don't send explicitly passed headers for the `missing_required_header` check. [#2898](https://github.com/schemathesis/schemathesis/issues/2898)  
+
 ## [4.0.1](https://github.com/schemathesis/schemathesis/compare/v4.0.0...v4.0.1) - 2025-06-13
 
 ### :rocket: Added

--- a/src/schemathesis/transport/prepare.py
+++ b/src/schemathesis/transport/prepare.py
@@ -34,8 +34,6 @@ def prepare_headers(case: Case, headers: dict[str, str] | None = None) -> CaseIn
     default_headers.setdefault(SCHEMATHESIS_TEST_CASE_HEADER, case.id)
     if headers:
         default_headers.update(headers)
-    for header in get_exclude_headers(case):
-        default_headers.pop(header, None)
     return default_headers
 
 

--- a/src/schemathesis/transport/wsgi.py
+++ b/src/schemathesis/transport/wsgi.py
@@ -12,7 +12,13 @@ from schemathesis.generation.case import Case
 from schemathesis.generation.overrides import Override
 from schemathesis.python import wsgi
 from schemathesis.transport import BaseTransport, SerializationContext
-from schemathesis.transport.prepare import normalize_base_url, prepare_body, prepare_headers, prepare_path
+from schemathesis.transport.prepare import (
+    get_exclude_headers,
+    normalize_base_url,
+    prepare_body,
+    prepare_headers,
+    prepare_path,
+)
 from schemathesis.transport.requests import REQUESTS_TRANSPORT
 from schemathesis.transport.serialization import serialize_binary, serialize_json, serialize_xml, serialize_yaml
 
@@ -72,6 +78,10 @@ class WSGITransport(BaseTransport["werkzeug.Client"]):
 
         data = self.serialize_case(case, headers=headers, params=params)
         data.update({key: value for key, value in kwargs.items() if key not in data})
+
+        excluded_headers = get_exclude_headers(case)
+        for name in excluded_headers:
+            data["headers"].pop(name, None)
 
         client = session or wsgi.get_client(application)
         cookies = {**(case.cookies or {}), **(cookies or {})}


### PR DESCRIPTION
Fixes #2898