### PR TITLE
fix: Empty path parameter in the negative tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.0.3...HEAD) - TBD
 
+### :bug: Fixed
+
+- Empty path parameter in the negative tests. [#2912](https://github.com/schemathesis/schemathesis/issues/2912)
+
 ## [4.0.3](https://github.com/schemathesis/schemathesis/compare/v4.0.2...v4.0.3) - 2025-06-30
 
 ### :wrench: Changed

--- a/src/schemathesis/generation/coverage.py
+++ b/src/schemathesis/generation/coverage.py
@@ -1060,7 +1060,7 @@ def _negative_type(
         strategies["number"] = FLOAT_STRATEGY.filter(_is_non_integer_float)
     for strategy in strategies.values():
         value = ctx.generate_from(strategy)
-        if seen.insert(value):
+        if seen.insert(value) and ctx.is_valid_for_location(value):
             yield NegativeValue(value, description="Incorrect type", location=ctx.current_path)
 
 

--- a/test/coverage/test_phase.py
+++ b/test/coverage/test_phase.py
@@ -1646,6 +1646,55 @@ def test_query_parameters_dont_exceed_max_length(ctx):
     )
 
 
+def test_path_parameters_always_present(ctx):
+    schema = ctx.openapi.build_schema(
+        {
+            "/foo/{foo_id}": {
+                "post": {
+                    "parameters": [
+                        {
+                            "name": "foo_id",
+                            "in": "path",
+                            "required": True,
+                            "schema": {
+                                "type": "integer",
+                            },
+                        },
+                    ],
+                    "responses": {"default": {"description": "OK"}},
+                }
+            },
+        }
+    )
+    assert_coverage(
+        schema,
+        [GenerationMode.NEGATIVE],
+        [
+            {
+                "path_parameters": {
+                    "foo_id": {},
+                },
+            },
+            {
+                "path_parameters": {
+                    "foo_id": "null,null",
+                },
+            },
+            {
+                "path_parameters": {
+                    "foo_id": "null",
+                },
+            },
+            {
+                "path_parameters": {
+                    "foo_id": "false",
+                },
+            },
+        ],
+        ("/foo/{foo_id}", "post"),
+    )
+
+
 def test_negative_query_parameter(ctx):
     schema = ctx.openapi.build_schema(
         {


### PR DESCRIPTION
Fixes #2912 