### PR TITLE
fix: Internal error if the stateful phase is used with `--generation-unique-inputs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.0.15...HEAD) - TBD
 
+### :bug: Fixed
+
+- Internal error if the stateful phase is used with `--generation-unique-inputs`. [#2977](https://github.com/schemathesis/schemathesis/issues/2977) 
+
 ## [4.0.15](https://github.com/schemathesis/schemathesis/compare/v4.0.14...v4.0.15) - 2025-07-26
 
 ### :bug: Fixed

--- a/src/schemathesis/generation/stateful/state_machine.py
+++ b/src/schemathesis/generation/stateful/state_machine.py
@@ -185,9 +185,11 @@ class APIStateMachine(RuleBasedStateMachine):
         if target is not None:
             super()._add_result_to_targets((target,), result)
 
-    def _add_results_to_targets(self, targets: tuple[str, ...], results: list[StepOutput]) -> None:
+    def _add_results_to_targets(self, targets: tuple[str, ...], results: list[StepOutput | None]) -> None:
         # Hypothesis >6.131.15
         for result in results:
+            if result is None:
+                continue
             target = self._get_target_for_result(result)
             if target is not None:
                 super()._add_results_to_targets((target,), [result])

--- a/test/specs/openapi/stateful/__snapshots__/test_cli/test_unique_inputs.raw
+++ b/test/specs/openapi/stateful/__snapshots__/test_cli/test_unique_inputs.raw
@@ -1,0 +1,64 @@
+Exit code: 1
+---
+Stdout:
+Schemathesis dev
+━━━━━━━━━━━━━━━━
+
+
+ ✅  Loaded specification from /tmp/schema.json (in 0.00s)
+
+     Base URL:         http://127.0.0.1/api
+     Specification:    Open API 3.0.2
+     Operations:       2 selected / 2 total
+
+
+ ✅  API capabilities:
+
+     Supports NULL byte in headers:    ✘
+
+ ❌  Stateful (in 0.00s)
+
+     Scenarios:    N
+     API Links:    N covered / 1 selected / 1 total
+
+     ✅ N passed  ❌ 1 failed
+
+=================================== FAILURES ===================================
+________________________________ Stateful tests ________________________________
+1. Test Case ID: <PLACEHOLDER>
+
+- Undocumented HTTP status code
+
+    Received: 404
+    Documented: 200
+
+[404] Not Found:
+
+    `404: Not Found`
+
+Reproduce with:
+
+    curl -X POST http://127.0.0.1/api/items
+
+=================================== SUMMARY ====================================
+
+API Operations:
+  Selected: 2/2
+  Tested: 1
+  Skipped: 1
+
+Test Phases:
+  ⏭  Examples (disabled)
+  ⏭  Coverage (disabled)
+  ⏭  Fuzzing (disabled)
+  ❌ Stateful
+
+Failures:
+  ❌ Undocumented HTTP status code: 1
+
+Test cases:
+  N generated, N found N unique failures, N skipped
+
+Seed: 42
+
+============================== 1 failure in 1.00s ==============================

--- a/test/specs/openapi/stateful/test_cli.py
+++ b/test/specs/openapi/stateful/test_cli.py
@@ -252,3 +252,36 @@ def test_non_json_response(app_factory, app_runner, cli, snapshot_cli, content):
         )
         == snapshot_cli
     )
+
+
+def test_unique_inputs(ctx, cli, snapshot_cli, openapi3_base_url):
+    # See GH-2977
+    schema_path = ctx.openapi.write_schema(
+        {
+            "/items": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "links": {"getItem": {"operationId": "GetById"}},
+                        }
+                    }
+                }
+            },
+            "/item/{id}": {
+                "get": {
+                    "operationId": "GetById",
+                    "responses": {"200": {"descrionn": "Ok"}},
+                },
+            },
+        }
+    )
+    assert (
+        cli.run(
+            str(schema_path),
+            f"--url={openapi3_base_url}",
+            "--phases=stateful",
+            "--generation-unique-inputs",
+            "--max-examples=10",
+        )
+        == snapshot_cli
+    )


### PR DESCRIPTION
Fixes #2977