### PR TITLE
fix: Generating negative test cases incorrectly marked as invalid if `anyOf` is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.0.16...HEAD) - TBD
 
+### :bug: Fixed
+
+- Generating negative test cases incorrectly marked as invalid if `anyOf` is present. [#2975](https://github.com/schemathesis/schemathesis/issues/2975)
+
 ## [4.0.16](https://github.com/schemathesis/schemathesis/compare/v4.0.15...v4.0.16) - 2025-07-31
 
 ### :bug: Fixed
 
-- Internal error if the stateful phase is used with `--generation-unique-inputs`. [#2977](https://github.com/schemathesis/schemathesis/issues/2977) 
+- Internal error if the stateful phase is used with `--generation-unique-inputs`. [#2977](https://github.com/schemathesis/schemathesis/issues/2977)
 - Do not show auth headers for cases when the test case was sent specifically without auth.
 - Do not show unnecessary auth warning if the only test that happened was for missing auth.
 


### PR DESCRIPTION
Fixes #2975