### PR TITLE
fix: set default app

### DIFF
--- a/src/schemathesis/specs/openapi/checks.py
+++ b/src/schemathesis/specs/openapi/checks.py
@@ -513,6 +513,7 @@ def ignored_auth(ctx: CheckContext, response: Response, case: Case) -> bool | No
                     _remove_auth_from_container(container, security_parameters, location=location)
                     kwargs[container_name] = container
             kwargs.pop("session", None)
+            kwargs.setdefault("app", case.operation.app)
             ctx._record_case(parent_id=case.id, case=no_auth_case)
             no_auth_response = case.operation.schema.transport.send(no_auth_case, **kwargs)
             ctx._record_response(case_id=no_auth_case.id, response=no_auth_response)


### PR DESCRIPTION
I encountered an error while using the following code.

```python
@schema.parametrize()
@pytest.mark.django_db(transaction=True)
def test_api(case: Case):
    user, _ = User.objects.get_or_create(username="testuser")
    access_token = generate_access_token(user.pk)
    case.call_and_validate(headers={"Authorization": f"Bearer {access_token}"})
```

```
    | Traceback (most recent call last):
    |   File "/Users/lee/workspace/wallnest/.venv/lib/python3.12/site-packages/schemathesis/generation/hypothesis/builder.py", line 211, in test_wrapper
    |     return test_function(*args, **kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/lee/workspace/wallnest/tests/tests.py", line 37, in test_api
    |     case.call_and_validate(headers={"Authorization": f"Bearer {access_token}"})
    |   File "/Users/lee/workspace/wallnest/.venv/lib/python3.12/site-packages/schemathesis/generation/case.py", line 324, in call_and_validate
    |     self.validate_response(
    |   File "/Users/lee/workspace/wallnest/.venv/lib/python3.12/site-packages/schemathesis/generation/case.py", line 278, in validate_response
    |     failures = run_checks(
    |                ^^^^^^^^^^^
    |   File "/Users/lee/workspace/wallnest/.venv/lib/python3.12/site-packages/schemathesis/checks.py", line 172, in run_checks
    |     skip_check = check(ctx, response, case)
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/lee/workspace/wallnest/.venv/lib/python3.12/site-packages/schemathesis/specs/openapi/checks.py", line 517, in ignored_auth
    |     no_auth_response = case.operation.schema.transport.send(no_auth_case, **kwargs)
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/lee/workspace/wallnest/.venv/lib/python3.12/site-packages/schemathesis/transport/wsgi.py", line 77, in send
    |     application = kwargs.pop("app")
    |                   ^^^^^^^^^^^^^^^^^
    | KeyError: 'app'
```

I added a line of code. I'm not sure if it's correct, but it worked.
