### PR TITLE
fix: Escape examples for path parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### :bug: Fixed
 
 - Parameter overrides replacing all explicit examples instead of merging with them. [#3000](https://github.com/schemathesis/schemathesis/issues/3000)
+- Escape examples for path parameters. [#3003](https://github.com/schemathesis/schemathesis/issues/3003)
 
 ## [4.0.21](https://github.com/schemathesis/schemathesis/compare/v4.0.20...v4.0.21) - 2025-08-04
 

--- a/src/schemathesis/specs/openapi/_hypothesis.py
+++ b/src/schemathesis/specs/openapi/_hypothesis.py
@@ -301,6 +301,8 @@ def generate_parameter(
     if value == explicit:
         # When we pass `explicit`, then its parts are excluded from generation of the final value
         # If the final value is the same, then other parameters were generated at all
+        if value is not None and location == "path":
+            value = quote_all(value)
         used_generator = None
     return ValueContainer(value=value, location=location, generator=used_generator)
 

--- a/test/specs/openapi/__snapshots__/test_examples/test_path_parameters_example_escaping.raw
+++ b/test/specs/openapi/__snapshots__/test_examples/test_path_parameters_example_escaping.raw
@@ -1,0 +1,60 @@
+Exit code: 1
+---
+Stdout:
+Schemathesis dev
+━━━━━━━━━━━━━━━━
+
+
+ ✅  Loaded specification from /tmp/schema.json (in 0.00s)
+
+     Base URL:         http://127.0.0.1/api
+     Specification:    Open API 3.0.2
+     Operations:       1 selected / 1 total
+
+
+ ✅  API capabilities:
+
+     Supports NULL byte in headers:    ✘
+
+ ❌  Examples (in 0.00s)
+
+     ❌ 1 failed
+
+=================================== FAILURES ===================================
+___________________________ GET /networks/{network} ____________________________
+1. Test Case ID: <PLACEHOLDER>
+
+- Undocumented HTTP status code
+
+    Received: 404
+    Documented: 202
+
+[404] Not Found:
+
+    `404: Not Found`
+
+Reproduce with:
+
+    curl -X GET http://127.0.0.1/api/networks/fd00%3A%3A%2F64
+
+=================================== SUMMARY ====================================
+
+API Operations:
+  Selected: 1/1
+  Tested: 1
+
+Test Phases:
+  ❌ Examples
+  ⏭  Coverage (disabled)
+  ⏭  Fuzzing (disabled)
+  ⏭  Stateful (disabled)
+
+Failures:
+  ❌ Undocumented HTTP status code: 1
+
+Test cases:
+  N generated, N found N unique failures
+
+Seed: 42
+
+============================== 1 failure in 1.00s ==============================


### PR DESCRIPTION
Fixes #3003