### PR TITLE
fix: Internal error on incorrect value for `--tls-verify` when the schema URL is accessed via HTTPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.0.23...HEAD) - TBD
 
+### :bug: Fixed
+
+- Internal error on incorrect value for `--tls-verify` when the schema URL is accessed via HTTPs. [#3007](https://github.com/schemathesis/schemathesis/issues/3007)
+
 ## [4.0.23](https://github.com/schemathesis/schemathesis/compare/v4.0.22...v4.0.23) - 2025-08-07
 
 ### :bug: Fixed

--- a/src/schemathesis/core/errors.py
+++ b/src/schemathesis/core/errors.py
@@ -330,6 +330,7 @@ class LoaderErrorKind(str, enum.Enum):
     CONNECTION_SSL = "connection_ssl"
     CONNECTION_OTHER = "connection_other"
     NETWORK_OTHER = "network_other"
+    INVALID_CERTIFICATE = "invalid_certificate"
 
     # HTTP error codes
     HTTP_SERVER_ERROR = "http_server_error"

--- a/src/schemathesis/core/loaders.py
+++ b/src/schemathesis/core/loaders.py
@@ -67,6 +67,9 @@ def make_request(func: Callable[..., requests.Response], url: str, **kwargs: Any
         return raise_for_status(response)
     except requests.RequestException as exc:
         handle_request_error(exc)
+    except OSError as exc:
+        # Possible with certificate errors
+        raise LoaderError(message=str(exc), kind=LoaderErrorKind.INVALID_CERTIFICATE, url=url, extras=[]) from None
 
 
 WAIT_FOR_SCHEMA_INTERVAL = 0.05

--- a/test/cli/__snapshots__/test_commands/test_invalid_tls_verify[Open API 3.0].raw
+++ b/test/cli/__snapshots__/test_commands/test_invalid_tls_verify[Open API 3.0].raw
@@ -1,0 +1,12 @@
+Exit code: 1
+---
+Stdout:
+Schemathesis dev
+━━━━━━━━━━━━━━━━
+
+
+ ❌  Failed to load specification from https://127.0.0.1/schema.yaml after 0.00s
+
+ Schema Loading Error
+
+ Could not find a suitable TLS CA certificate bundle, invalid path: falst

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -1303,6 +1303,12 @@ def test_rate_limit(cli, schema_url):
     assert cli.run(schema_url, "--rate-limit=1/s").exit_code == ExitCode.OK
 
 
+@pytest.mark.openapi_version("3.0")
+@pytest.mark.operations("failure")
+def test_invalid_tls_verify(cli, schema_url, snapshot_cli):
+    assert cli.run(schema_url.replace("http", "https"), "--tls-verify=falst") == snapshot_cli
+
+
 @pytest.mark.parametrize("version", ["3.0.2", "3.1.0"])
 def test_invalid_schema_with_disabled_validation(
     ctx, cli, openapi_3_schema_with_invalid_security, version, snapshot_cli, openapi3_base_url


### PR DESCRIPTION
Fixes #3007