### PR TITLE
chore: Make `before_call` hook accept `kwargs` instead of `**kwargs` in a backward compatible way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `--max-redirects` CLI & config file option. [#712](https://github.com/schemathesis/schemathesis/issues/712)
 
+### :wrench: Changed
+
+- `before_call` hooks now accept `kwargs` as a regular parameter instead of `**kwargs`. There is a backward compatibility shim for existing hooks with `**kwargs` signatures. The old calling convention will be removed in Schemathesis 5.0. [#3028](https://github.com/schemathesis/schemathesis/issues/3028)
+
 ## [4.0.26](https://github.com/schemathesis/schemathesis/compare/v4.0.25...v4.0.26) - 2025-08-12
 
 ### :rocket: Added

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -111,6 +111,7 @@ schemathesis run --phases=examples,coverage <SCHEMA_URL>
 - `schemathesis.HeaderConfig`. Use config file instead.
 - `schemathesis.runner`. The Schemathesis engine is not a public API anymore.
 - `add_case` hook.
+- `process_call_kwargs` hook. Use `before_call` instead.
 - `SCHEMA_ANALYSIS` experimental feature. Parts of this feature will be open sourced in the future.
 - `as_requests_kwargs` / `as_werkzeug_kwargs`. Use `as_transport_kwargs` instead.
 

--- a/docs/guides/extending.md
+++ b/docs/guides/extending.md
@@ -217,7 +217,7 @@ For complex scenarios, modify the entire request:
 
 ```python
 @schemathesis.hook
-def before_call(ctx, case, **kwargs):
+def before_call(ctx, case, kwargs):
     """Modify the request just before it's sent"""
     # Add correlation ID for tracing
     case.headers["X-Correlation-ID"] = f"test-{uuid.uuid4()}"

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -34,11 +34,10 @@ Hooks that execute during test case execution.
 
 | Hook | Signature | Execution Stage | Purpose |
 |------|-----------|-----------------|---------|
-| **before_call** | `(ctx, case: Case, **kwargs) -> None` | Before HTTP request | Modify test case (headers, body, etc.) |
-| **process_call_kwargs** | `(ctx, case: Case, kwargs: dict) -> dict` | Before `case.call()` | Modify request library arguments (timeout, verify, etc.) |
+| **before_call** | `(ctx, case: Case, kwargs) -> None` | Before HTTP request | Modify test case (headers, body, etc.) |
 | **after_call** | `(ctx, case: Case, response: Response) -> None` | After HTTP response | Inspect/modify response before checks |
 
-**Flow:** `before_call` → `process_call_kwargs` → HTTP Request → `after_call` → Checks
+**Flow:** `before_call` → HTTP Request → `after_call` → Checks
 
 ## Hook Registration
 

--- a/src/schemathesis/generation/case.py
+++ b/src/schemathesis/generation/case.py
@@ -200,7 +200,7 @@ class Case:
 
         """
         hook_context = HookContext(operation=self.operation)
-        dispatch("before_call", hook_context, self, **kwargs)
+        dispatch("before_call", hook_context, self, _with_dual_style_kwargs=True, **kwargs)
         if self.operation.app is not None:
             kwargs.setdefault("app", self.operation.app)
         if "app" in kwargs:

--- a/test/cli/test_hooks.py
+++ b/test/cli/test_hooks.py
@@ -21,6 +21,20 @@ def before_call(context, case, **kwargs):
 
 @pytest.mark.openapi_version("3.0")
 @pytest.mark.operations("success")
+def test_before_call_no_kwargs_unpacking(ctx, cli, schema_url):
+    module = ctx.write_pymodule(
+        """
+@schemathesis.hook
+def before_call(context, case, kwargs):
+    kwargs["allow_redirects"] = False
+        """
+    )
+    result = cli.main("run", schema_url, hooks=module)
+    assert result.exit_code == ExitCode.OK, result.stdout
+
+
+@pytest.mark.openapi_version("3.0")
+@pytest.mark.operations("success")
 def test_after_call(ctx, cli, schema_url, snapshot_cli):
     # When the `after_call` hook is registered
     # And it modifies the response and making it incorrect


### PR DESCRIPTION
Resolves #3028