### PR TITLE
Make coverage.py compatible with pypy3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### :wrench: Changed
 
 - `before_call` hooks now accept `kwargs` as a regular parameter instead of `**kwargs`. There is a backward compatibility shim for existing hooks with `**kwargs` signatures. The old calling convention will be removed in Schemathesis 5.0. [#3028](https://github.com/schemathesis/schemathesis/issues/3028)
+- Schemathesis now runs under pypy3
 
 ## [4.0.26](https://github.com/schemathesis/schemathesis/compare/v4.0.25...v4.0.26) - 2025-08-12
 


### PR DESCRIPTION
🚨Please review the [Contributing Guidelines](https://github.com/schemathesis/schemathesis/blob/master/CONTRIBUTING.md).

### Description

Non-functional changes that allows schemathesis to run under pypy3. In short, uses the documented python api for iterative encoding. 

Unfortunately, there's no speedup using pypy, but this is an easy win for people who really want to use pypy.

### Checklist

- [ ] Added failing tests for the change - No change in functionality
- [X] All new and existing tests pass
- [X] Added changelog entry
- [ ] Updated README/documentation, if necessary
