### PR TITLE
perf: Cache response validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### :racing_car: Performance
 
 - Avoid choosing mutations that aren't applicable in the current context.
+- Response schema validation is now 5–15x faster on average.
 
 ## [4.1.4](https://github.com/schemathesis/schemathesis/compare/v4.1.3...v4.1.4) - 2025-09-01
 

--- a/src/schemathesis/generation/hypothesis/builder.py
+++ b/src/schemathesis/generation/hypothesis/builder.py
@@ -536,7 +536,7 @@ def _iter_coverage_cases(
     seen_negative = coverage.HashSet()
     seen_positive = coverage.HashSet()
     assert isinstance(operation.schema, BaseOpenAPISchema)
-    validator_cls = operation.schema.validator_cls
+    validator_cls = operation.schema.adapter.jsonschema_validator_cls
 
     for parameter in operation.iter_parameters():
         location = parameter.location

--- a/src/schemathesis/specs/openapi/_hypothesis.py
+++ b/src/schemathesis/specs/openapi/_hypothesis.py
@@ -208,7 +208,12 @@ def _get_body_strategy(
     schema = parameter.as_json_schema()
     assert isinstance(operation.schema, BaseOpenAPISchema)
     strategy = strategy_factory(
-        schema, operation.label, "body", parameter.media_type, generation_config, operation.schema.validator_cls
+        schema,
+        operation.label,
+        "body",
+        parameter.media_type,
+        generation_config,
+        operation.schema.adapter.jsonschema_validator_cls,
     )
     if not parameter.is_required:
         strategy |= st.just(NOT_SET)
@@ -364,7 +369,12 @@ def get_parameters_strategy(
         else:
             assert isinstance(operation.schema, BaseOpenAPISchema)
             strategy = strategy_factory(
-                schema, operation.label, location, None, generation_config, operation.schema.validator_cls
+                schema,
+                operation.label,
+                location,
+                None,
+                generation_config,
+                operation.schema.adapter.jsonschema_validator_cls,
             )
             serialize = operation.get_parameter_serializer(location)
             if serialize is not None:

--- a/src/schemathesis/specs/openapi/adapter/__init__.py
+++ b/src/schemathesis/specs/openapi/adapter/__init__.py
@@ -1,4 +1,4 @@
-from schemathesis.specs.openapi.adapter import v2, v3
+from schemathesis.specs.openapi.adapter import v2, v3_0, v3_1
 from schemathesis.specs.openapi.adapter.parameters import prepare_parameters
 from schemathesis.specs.openapi.adapter.responses import OpenApiResponse, OpenApiResponses
 
@@ -7,5 +7,6 @@ __all__ = [
     "OpenApiResponses",
     "prepare_parameters",
     "v2",
-    "v3",
+    "v3_0",
+    "v3_1",
 ]

--- a/src/schemathesis/specs/openapi/adapter/protocol.py
+++ b/src/schemathesis/specs/openapi/adapter/protocol.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Protocol, Union
 
 if TYPE_CHECKING:
+    from jsonschema.protocols import Validator
+
     from schemathesis.core.compat import RefResolver
     from schemathesis.core.jsonschema.types import JsonSchema
 
@@ -12,3 +14,4 @@ ExtractResponseSchema = Callable[[Mapping[str, Any], "RefResolver", str, str], U
 class SpecificationAdapter(Protocol):
     nullable_keyword: str
     extract_response_schema: ExtractResponseSchema
+    jsonschema_validator_cls: type[Validator]

--- a/src/schemathesis/specs/openapi/adapter/v3_0.py
+++ b/src/schemathesis/specs/openapi/adapter/v3_0.py
@@ -3,6 +3,6 @@ from jsonschema import Draft4Validator
 from schemathesis.specs.openapi.adapter import responses
 from schemathesis.specs.openapi.adapter.protocol import ExtractResponseSchema
 
-nullable_keyword = "x-nullable"
-extract_response_schema: ExtractResponseSchema = responses.extract_response_schema_v2
+nullable_keyword = "nullable"
+extract_response_schema: ExtractResponseSchema = responses.extract_response_schema_v3
 jsonschema_validator_cls = Draft4Validator

--- a/src/schemathesis/specs/openapi/adapter/v3_1.py
+++ b/src/schemathesis/specs/openapi/adapter/v3_1.py
@@ -1,5 +1,8 @@
+from jsonschema import Draft202012Validator
+
 from schemathesis.specs.openapi.adapter import responses
 from schemathesis.specs.openapi.adapter.protocol import ExtractResponseSchema
 
 nullable_keyword = "nullable"
 extract_response_schema: ExtractResponseSchema = responses.extract_response_schema_v3
+jsonschema_validator_cls = Draft202012Validator

--- a/test/coverage/test_phase.py
+++ b/test/coverage/test_phase.py
@@ -2310,7 +2310,7 @@ def _validate_serialized_items_are_negative(serialized_items, parameter, case):
 
     # Get the JSON schema for validation
     schema = parameter.as_json_schema()
-    validator = case.operation.schema.validator_cls(
+    validator = case.operation.schema.adapter.jsonschema_validator_cls(
         schema,
         format_checker=jsonschema.Draft202012Validator.FORMAT_CHECKER,
     )


### PR DESCRIPTION
note: changelog entry covers previous improvements (caching schema transformation, fewer clones, skipping `RefResolver` construction, etc)