### PR TITLE
fix: Curl commands with non-printable characters now use shell-aware escaping and display warnings for unknown shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.3.18...HEAD) - TBD
 
+### :bug: Fixed
+
+- Curl commands with non-printable characters now use shell-aware escaping and display warnings for unknown shells. [#2159](https://github.com/schemathesis/schemathesis/issues/2159)
+
 ## [4.3.18](https://github.com/schemathesis/schemathesis/compare/v4.3.17...v4.3.18) - 2025-11-02
 
 ### :bug: Fixed

--- a/src/schemathesis/core/curl.py
+++ b/src/schemathesis/core/curl.py
@@ -1,13 +1,38 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from functools import lru_cache
 from shlex import quote
 from typing import TYPE_CHECKING, Any
 
 from schemathesis.core import SCHEMATHESIS_TEST_CASE_HEADER
+from schemathesis.core.shell import escape_for_shell, has_non_printable
 
 if TYPE_CHECKING:
     from requests.models import CaseInsensitiveDict
+
+
+@dataclass(frozen=True)
+class CurlCommand:
+    """Result of generating a curl command."""
+
+    command: str
+    """The curl command string."""
+
+    warnings: list[str]
+    """Warnings about non-printable characters or shell compatibility."""
+
+    __slots__ = ("command", "warnings")
+
+
+def _escape_and_quote(value: str, warnings: list[str], ctx: str) -> str:
+    """Escape value for shell, adding warnings if needed."""
+    if has_non_printable(value):
+        escape_result = escape_for_shell(value)
+        if escape_result.needs_warning:
+            warnings.append(f"{ctx} contains non-printable characters. Actual value: {escape_result.original_bytes!r}")
+        return escape_result.escaped_value
+    return quote(value)
 
 
 def generate(
@@ -18,24 +43,37 @@ def generate(
     verify: bool,
     headers: dict[str, Any],
     known_generated_headers: dict[str, Any] | None,
-) -> str:
+) -> CurlCommand:
     """Generate a code snippet for making HTTP requests."""
     _filter_headers(headers, known_generated_headers or {})
+    warnings: list[str] = []
     command = f"curl -X {method}"
+
+    # Process headers with shell-aware escaping
     for key, value in headers.items():
         # To send an empty header with cURL we need to use `;`, otherwise empty header is ignored
         if not value:
             header = f"{key};"
         else:
             header = f"{key}: {value}"
-        command += f" -H {quote(header)}"
+
+        escaped_header = _escape_and_quote(header, warnings, f"Header '{key}'")
+        command += f" -H {escaped_header}"
+
+    # Process body with shell-aware escaping
     if body:
         if isinstance(body, bytes):
             body = body.decode("utf-8", errors="replace")
-        command += f" -d {quote(body)}"
+
+        escaped_body = _escape_and_quote(body, warnings, "Request body")
+        command += f" -d {escaped_body}"
+
     if not verify:
         command += " --insecure"
-    return f"{command} {quote(url)}"
+
+    command += f" {quote(url)}"
+
+    return CurlCommand(command=command, warnings=warnings)
 
 
 def _filter_headers(headers: dict[str, Any], known_generated_headers: dict[str, Any]) -> None:

--- a/src/schemathesis/core/shell.py
+++ b/src/schemathesis/core/shell.py
@@ -1,0 +1,203 @@
+"""Shell detection and escaping for generating reproducible curl commands."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ShellType(str, Enum):
+    """Supported shell types."""
+
+    BASH = "bash"
+    ZSH = "zsh"
+    FISH = "fish"
+    UNKNOWN = "unknown"
+
+    @property
+    def supports_ansi_c_quoting(self) -> bool:
+        r"""Whether shell supports $'...\xHH' syntax."""
+        return self in (ShellType.BASH, ShellType.ZSH)
+
+    @property
+    def supports_hex_in_quotes(self) -> bool:
+        r"""Whether shell interprets \xHH in single quotes."""
+        return self == ShellType.FISH
+
+
+@dataclass(frozen=True)
+class EscapeResult:
+    """Result of escaping a value for shell."""
+
+    escaped_value: str
+    """The escaped string ready for shell."""
+
+    needs_warning: bool
+    """Whether a warning should be shown to the user."""
+
+    original_bytes: bytes | None
+    """Original bytes if warning is needed, for detailed display."""
+
+    shell_used: ShellType
+    """Which shell type the escaping is for."""
+
+    __slots__ = ("escaped_value", "needs_warning", "original_bytes", "shell_used")
+
+
+_DETECTED_SHELL: ShellType | None = None
+
+
+def detect_shell() -> ShellType:
+    """Detect the current shell type from $SHELL environment variable."""
+    global _DETECTED_SHELL
+
+    if _DETECTED_SHELL is not None:
+        return _DETECTED_SHELL
+
+    # Check $SHELL environment variable
+    shell_path = os.environ.get("SHELL", "")
+    if shell_path:
+        shell_name = os.path.basename(shell_path).lower()
+        detected = _parse_shell_name(shell_name)
+        _DETECTED_SHELL = detected
+        return detected
+
+    _DETECTED_SHELL = ShellType.UNKNOWN
+    return ShellType.UNKNOWN
+
+
+def _parse_shell_name(name: str) -> ShellType:
+    """Parse shell name string to ShellType."""
+    name_lower = name.lower()
+
+    # Check exact matches first
+    for shell_type in (ShellType.BASH, ShellType.ZSH, ShellType.FISH):
+        if shell_type.value == name_lower:
+            return shell_type
+
+    # Check substring matches
+    for shell_type in (ShellType.BASH, ShellType.ZSH, ShellType.FISH):
+        if shell_type.value in name_lower:
+            return shell_type
+
+    return ShellType.UNKNOWN
+
+
+def has_non_printable(value: str | bytes) -> bool:
+    """Check if value contains ASCII control characters."""
+    if isinstance(value, bytes):
+        try:
+            value = value.decode("utf-8")
+        except UnicodeDecodeError:
+            # Binary data that can't be decoded - treat as non-printable
+            return True
+
+    # Check for ASCII control characters: 0-31 and 127 (DEL)
+    return any(ord(c) < 32 or ord(c) == 127 for c in value)
+
+
+def escape_for_shell(value: str, shell: ShellType | None = None) -> EscapeResult:
+    """Escape value for shell use in curl commands."""
+    if shell is None:
+        shell = detect_shell()
+
+    # Fast path: no non-printable characters
+    if not has_non_printable(value):
+        return EscapeResult(
+            escaped_value=value,
+            needs_warning=False,
+            original_bytes=None,
+            shell_used=shell,
+        )
+
+    original_bytes = value.encode("utf-8")
+
+    # Bash/Zsh: Use ANSI-C quoting $'...\xHH'
+    if shell.supports_ansi_c_quoting:
+        escaped = _escape_with_ansi_c(value)
+        return EscapeResult(
+            escaped_value=f"$'{escaped}'",
+            needs_warning=False,
+            original_bytes=None,
+            shell_used=shell,
+        )
+
+    # Fish: Use \xHH in single quotes
+    if shell.supports_hex_in_quotes:
+        escaped = _escape_with_hex(value)
+        return EscapeResult(
+            escaped_value=f"'{escaped}'",
+            needs_warning=False,
+            original_bytes=None,
+            shell_used=shell,
+        )
+
+    # Unknown shell: Show bash-style with warning
+    escaped = _escape_with_ansi_c(value)
+    return EscapeResult(
+        escaped_value=f"$'{escaped}'",
+        needs_warning=True,
+        original_bytes=original_bytes,
+        shell_used=ShellType.BASH,
+    )
+
+
+def _escape_with_ansi_c(value: str) -> str:
+    """Escape string for ANSI-C quoting ($'...') used in bash/zsh."""
+    result = []
+    for char in value:
+        code = ord(char)
+
+        # Readable escapes for common control characters
+        if char == "\t":
+            result.append("\\t")
+        elif char == "\n":
+            result.append("\\n")
+        elif char == "\r":
+            result.append("\\r")
+        elif code < 32:
+            # Other control characters as hex
+            result.append(f"\\x{code:02x}")
+        elif code == 127:
+            # DEL character
+            result.append("\\x7f")
+        elif char in ("'", "\\", "$", "`"):
+            # Shell special characters that need escaping in $'...'
+            result.append(f"\\{char}")
+        else:
+            result.append(char)
+
+    return "".join(result)
+
+
+def _escape_with_hex(value: str) -> str:
+    r"""Escape string with \xHH notation for fish shell.
+
+    Fish interprets \x escapes directly in single quotes.
+    We still need to escape single quotes and backslashes.
+    """
+    result = []
+    for char in value:
+        code = ord(char)
+
+        # Readable escapes for common control characters
+        if char == "\t":
+            result.append("\\t")
+        elif char == "\n":
+            result.append("\\n")
+        elif char == "\r":
+            result.append("\\r")
+        elif code < 32 or code == 127:
+            # Control characters as hex
+            result.append(f"\\x{code:02x}")
+        elif char == "'":
+            # Escape single quote for fish
+            result.append("\\'")
+        elif char == "\\":
+            # Escape backslash
+            result.append("\\\\")
+        else:
+            result.append(char)
+
+    return "".join(result)

--- a/src/schemathesis/generation/case.py
+++ b/src/schemathesis/generation/case.py
@@ -293,7 +293,7 @@ class Case:
 
         """
         request_data = prepare_request(self, headers, config=self.operation.schema.config.output.sanitization)
-        return curl.generate(
+        result = curl.generate(
             method=str(request_data.method),
             url=str(request_data.url),
             body=request_data.body,
@@ -301,6 +301,11 @@ class Case:
             headers=dict(request_data.headers),
             known_generated_headers=dict(self.headers or {}),
         )
+        # Include warnings if any exist
+        if result.warnings:
+            warnings_text = "\n\n".join(f"⚠️  {warning}" for warning in result.warnings)
+            return f"{result.command}\n\n{warnings_text}"
+        return result.command
 
     def as_transport_kwargs(self, base_url: str | None = None, headers: dict[str, str] | None = None) -> dict[str, Any]:
         return self.operation.schema.transport.serialize_case(self, base_url=base_url, headers=headers)

--- a/test/cli/__snapshots__/test_commands/test_curl_with_non_printable_characters.raw
+++ b/test/cli/__snapshots__/test_commands/test_curl_with_non_printable_characters.raw
@@ -1,0 +1,76 @@
+Exit code: 1
+---
+Stdout:
+Schemathesis dev
+━━━━━━━━━━━━━━━━
+
+
+ ✅  Loaded specification from /tmp/schema.json (in 0.00s)
+
+     Base URL:         http://127.0.0.1/api
+     Specification:    Open API 3.0.2
+     Operations:       1 selected / 1 total
+
+
+ ✅  API capabilities:
+
+     Supports NULL byte in headers:    ✘
+
+ ✅  Examples (in 0.00s)
+
+     ✅ 1 passed
+
+ ❌  Coverage (in 0.00s)
+
+     ❌ 1 failed
+
+ ✅  Fuzzing (in 0.00s)
+
+     ✅ 1 passed
+
+=================================== FAILURES ===================================
+________________________________ POST /failure _________________________________
+1. Test Case ID: <PLACEHOLDER>
+
+- Server error
+
+[500] Internal Server Error:
+
+    `500: Internal Server Error`
+
+Reproduce with:
+
+    curl -X GET -H 'Content-Type: text/plain' -d $'line1\nline2\ttab\x1fcontrol' http://127.0.0.1/api/failure
+
+=================================== WARNINGS ===================================
+
+Schema validation mismatch: 1 operation mostly rejected generated data due to validation errors, indicating schema constraints don't match API validation
+
+  - POST /failure
+
+💡 Check your schema constraints - API validation may be stricter than documented
+
+=================================== SUMMARY ====================================
+
+API Operations:
+  Selected: 1/1
+  Tested: 1
+
+Test Phases:
+  ✅ Examples
+  ❌ Coverage
+  ✅ Fuzzing
+  ⏭  Stateful (not applicable)
+
+Failures:
+  ❌ Server error: 1
+
+Warnings:
+  ⚠️ Schema validation mismatch: 1 operation mostly rejected generated data
+
+Test cases:
+  N generated, N found N unique failures
+
+Seed: 42
+
+============================== 1 failure in 1.00s ==============================

--- a/test/cli/__snapshots__/test_commands/test_curl_with_non_printable_characters_unknown_shell.raw
+++ b/test/cli/__snapshots__/test_commands/test_curl_with_non_printable_characters_unknown_shell.raw
@@ -1,0 +1,78 @@
+Exit code: 1
+---
+Stdout:
+Schemathesis dev
+━━━━━━━━━━━━━━━━
+
+
+ ✅  Loaded specification from /tmp/schema.json (in 0.00s)
+
+     Base URL:         http://127.0.0.1/api
+     Specification:    Open API 3.0.2
+     Operations:       1 selected / 1 total
+
+
+ ✅  API capabilities:
+
+     Supports NULL byte in headers:    ✘
+
+ ✅  Examples (in 0.00s)
+
+     ✅ 1 passed
+
+ ❌  Coverage (in 0.00s)
+
+     ❌ 1 failed
+
+ ✅  Fuzzing (in 0.00s)
+
+     ✅ 1 passed
+
+=================================== FAILURES ===================================
+________________________________ POST /failure _________________________________
+1. Test Case ID: <PLACEHOLDER>
+
+- Server error
+
+[500] Internal Server Error:
+
+    `500: Internal Server Error`
+
+Reproduce with:
+
+    curl -X GET -H 'X-Custom;' -H 'Content-Type: text/plain' -d $'data\x1f' http://127.0.0.1/api/failure
+
+    ⚠️  Request body contains non-printable characters. Actual value: b'data\x1f'
+
+=================================== WARNINGS ===================================
+
+Schema validation mismatch: 1 operation mostly rejected generated data due to validation errors, indicating schema constraints don't match API validation
+
+  - POST /failure
+
+💡 Check your schema constraints - API validation may be stricter than documented
+
+=================================== SUMMARY ====================================
+
+API Operations:
+  Selected: 1/1
+  Tested: 1
+
+Test Phases:
+  ✅ Examples
+  ❌ Coverage
+  ✅ Fuzzing
+  ⏭  Stateful (not applicable)
+
+Failures:
+  ❌ Server error: 1
+
+Warnings:
+  ⚠️ Schema validation mismatch: 1 operation mostly rejected generated data
+
+Test cases:
+  N generated, N found N unique failures
+
+Seed: 42
+
+============================== 1 failure in 1.00s ==============================

--- a/test/core/test_shell.py
+++ b/test/core/test_shell.py
@@ -1,0 +1,222 @@
+import pytest
+
+from schemathesis.core.shell import (
+    ShellType,
+    _escape_with_ansi_c,
+    _escape_with_hex,
+    _parse_shell_name,
+    detect_shell,
+    escape_for_shell,
+    has_non_printable,
+)
+
+
+@pytest.mark.parametrize(
+    ("input_value", "expected"),
+    [
+        ("hello world", False),
+        ("hello\tworld", True),
+        ("hello\nworld", True),
+        ("hello\x00world", True),
+        ("hello\x1fworld", True),
+        ("hello\x7fworld", True),
+        (b"hello\x00world", True),
+        (b"\xff\xfe", True),
+        ("hello 世界", False),
+    ],
+    ids=[
+        "printable-string",
+        "with-tab",
+        "with-newline",
+        "with-null-byte",
+        "with-control-char",
+        "with-del",
+        "bytes-input",
+        "invalid-utf8-bytes",
+        "unicode-printable",
+    ],
+)
+def test_has_non_printable(input_value, expected):
+    assert has_non_printable(input_value) == expected
+
+
+@pytest.mark.parametrize(
+    ("input_value", "expected"),
+    [
+        ("hello", "hello"),
+        ("a\tb", "a\\tb"),
+        ("a\nb", "a\\nb"),
+        ("a\rb", "a\\rb"),
+        ("a\x00b", "a\\x00b"),
+        ("a\x1fb", "a\\x1fb"),
+        ("a\x7fb", "a\\x7fb"),
+        ("it's", "it\\'s"),
+        ("a\\b", "a\\\\b"),
+        ("$VAR", "\\$VAR"),
+        ("`cmd`", "\\`cmd\\`"),
+        ("0\x1f", "0\\x1f"),
+    ],
+    ids=[
+        "printable-string",
+        "with-tab",
+        "with-newline",
+        "with-carriage-return",
+        "with-null-byte",
+        "with-control-char",
+        "with-del",
+        "escapes-single-quote",
+        "escapes-backslash",
+        "escapes-dollar",
+        "escapes-backtick",
+        "complex-case",
+    ],
+)
+def test_escape_with_ansi_c(input_value, expected):
+    assert _escape_with_ansi_c(input_value) == expected
+
+
+@pytest.mark.parametrize(
+    ("input_value", "expected"),
+    [
+        ("hello", "hello"),
+        ("a\tb", "a\\tb"),
+        ("a\nb", "a\\nb"),
+        ("a\x00b", "a\\x00b"),
+        ("a\x1fb", "a\\x1fb"),
+        ("it's", "it\\'s"),
+        ("a\\b", "a\\\\b"),
+    ],
+    ids=[
+        "printable-string",
+        "with-tab",
+        "with-newline",
+        "with-null-byte",
+        "with-control-char",
+        "escapes-single-quote",
+        "escapes-backslash",
+    ],
+)
+def test_escape_with_hex(input_value, expected):
+    assert _escape_with_hex(input_value) == expected
+
+
+@pytest.mark.parametrize(
+    ("input_value", "shell_type", "expected_escaped", "expected_warning", "expected_shell"),
+    [
+        ("hello", ShellType.BASH, "hello", False, ShellType.BASH),
+        ("0\x1f", ShellType.BASH, "$'0\\x1f'", False, ShellType.BASH),
+        ("0\x1f", ShellType.ZSH, "$'0\\x1f'", False, ShellType.ZSH),
+        ("0\x1f", ShellType.FISH, "'0\\x1f'", False, ShellType.FISH),
+        ("0\x1f", ShellType.UNKNOWN, "$'0\\x1f'", True, ShellType.BASH),
+        # autodetect
+        ("hello", None, "hello", False, None),
+    ],
+    ids=[
+        "bash-printable",
+        "bash-non-printable",
+        "zsh-non-printable",
+        "fish-non-printable",
+        "unknown-shell",
+        "autodetect",
+    ],
+)
+def test_escape_for_shell(input_value, shell_type, expected_escaped, expected_warning, expected_shell):
+    result = escape_for_shell(input_value, shell_type)
+    assert result.escaped_value == expected_escaped
+    assert result.needs_warning == expected_warning
+    if expected_shell is not None:
+        assert result.shell_used == expected_shell
+    if expected_warning:
+        assert result.original_bytes == b"0\x1f"
+
+
+def test_detect_shell_caches_result():
+    shell1 = detect_shell()
+    shell2 = detect_shell()
+    assert shell1 == shell2
+
+
+@pytest.mark.parametrize(
+    ("input_value", "expected_bash", "expected_fish"),
+    [
+        ("hello", "hello", "hello"),
+        ("a\tb", "a\\tb", "a\\tb"),
+        ("a\nb", "a\\nb", "a\\nb"),
+        ("a\rb", "a\\rb", "a\\rb"),
+        ("a\x00b", "a\\x00b", "a\\x00b"),
+        ("a\x01b", "a\\x01b", "a\\x01b"),
+        ("a\x1fb", "a\\x1fb", "a\\x1fb"),
+        ("a\x7fb", "a\\x7fb", "a\\x7fb"),
+        ("it's", "it\\'s", "it\\'s"),
+        ("a\\b", "a\\\\b", "a\\\\b"),
+        ("$VAR", "\\$VAR", "$VAR"),
+        ("`cmd`", "\\`cmd\\`", "`cmd`"),
+        ("0\x1f", "0\\x1f", "0\\x1f"),
+    ],
+)
+def test_escape_consistency(input_value, expected_bash, expected_fish):
+    assert _escape_with_ansi_c(input_value) == expected_bash
+    assert _escape_with_hex(input_value) == expected_fish
+
+
+@pytest.mark.parametrize(
+    ("shell_name", "expected"),
+    [
+        ("bash", ShellType.BASH),
+        ("zsh", ShellType.ZSH),
+        ("fish", ShellType.FISH),
+        ("BASH", ShellType.BASH),
+        ("/bin/bash", ShellType.BASH),
+        ("/usr/bin/zsh", ShellType.ZSH),
+        ("bash-5.1", ShellType.BASH),
+        ("zsh-5.8", ShellType.ZSH),
+        ("sh", ShellType.UNKNOWN),
+        ("python", ShellType.UNKNOWN),
+        ("", ShellType.UNKNOWN),
+        ("unknown-shell", ShellType.UNKNOWN),
+    ],
+    ids=[
+        "bash-lowercase",
+        "zsh-lowercase",
+        "fish-lowercase",
+        "bash-uppercase",
+        "bash-with-path",
+        "zsh-with-path",
+        "bash-with-version",
+        "zsh-with-version",
+        "sh-not-recognized",
+        "python-not-shell",
+        "empty-string",
+        "unknown-shell",
+    ],
+)
+def test_parse_shell_name(shell_name, expected):
+    assert _parse_shell_name(shell_name) == expected
+
+
+@pytest.mark.parametrize(
+    ("shell_env", "expected", "delete_env"),
+    [
+        ("/bin/bash", ShellType.BASH, False),
+        ("/usr/bin/zsh", ShellType.ZSH, False),
+        ("/usr/local/bin/fish", ShellType.FISH, False),
+        ("/bin/sh", ShellType.UNKNOWN, False),
+        ("", ShellType.UNKNOWN, False),
+        (None, ShellType.UNKNOWN, True),
+    ],
+    ids=[
+        "bash-env",
+        "zsh-env",
+        "fish-env",
+        "unknown-shell-env",
+        "empty-shell-env",
+        "no-shell-env",
+    ],
+)
+def test_detect_shell_from_environment(monkeypatch, shell_env, expected, delete_env):
+    monkeypatch.setattr("schemathesis.core.shell._DETECTED_SHELL", None)
+    if delete_env:
+        monkeypatch.delenv("SHELL", raising=False)
+    else:
+        monkeypatch.setenv("SHELL", shell_env)
+    assert detect_shell() == expected


### PR DESCRIPTION
Fixes #2159 