### PR TITLE
feat: Support for custom content types in `multipart/form-data` encoding via OpenAPI's `encoding` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@
 
 ### :rocket: Added
 
+- Support for custom content types in `multipart/form-data` encoding via OpenAPI's `encoding` property. [#697](https://github.com/schemathesis/schemathesis/issues/697)
 - Option to make warnings cause test failures via `fail-on` in warnings configuration. [#2956](https://github.com/schemathesis/schemathesis/issues/2956)
 
 ### :bug: Fixed
 
 - Curl commands with non-printable characters now use shell-aware escaping and display warnings for unknown shells. [#2159](https://github.com/schemathesis/schemathesis/issues/2159)
+
+### :wrench: Changed
+
+- Custom media type strategies now support wildcard patterns (e.g., `image/*`) for all request body types, not just multipart encoding.
 
 ## [4.3.18](https://github.com/schemathesis/schemathesis/compare/v4.3.17...v4.3.18) - 2025-11-02
 

--- a/src/schemathesis/specs/openapi/adapter/parameters.py
+++ b/src/schemathesis/specs/openapi/adapter/parameters.py
@@ -260,6 +260,12 @@ class OpenApiBody(OpenApiComponent):
         """Return default type if body is a form type."""
         return "object" if self.media_type in FORM_MEDIA_TYPES else None
 
+    def get_property_content_type(self, property_name: str) -> str | None:
+        """Get custom contentType for a form property from `encoding` definition."""
+        encoding = self.definition.get("encoding", {})
+        property_encoding = encoding.get(property_name, {})
+        return property_encoding.get("contentType")
+
     def get_strategy(
         self,
         operation: APIOperation,

--- a/test/specs/openapi/parameters/test_multipart_encoding.py
+++ b/test/specs/openapi/parameters/test_multipart_encoding.py
@@ -1,0 +1,661 @@
+from hypothesis import given
+from hypothesis import strategies as st
+
+import schemathesis
+from schemathesis.transport.serialization import Binary
+
+
+def test_multipart_with_custom_encoding():
+    xml_strategy = st.just(b"<?xml version='1.0'?><root>test</root>")
+    schemathesis.openapi.media_type("text/xml", xml_strategy)
+
+    # Given an OpenAPI schema with multipart/form-data and custom encoding
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["name", "file"],
+                                        "properties": {
+                                            "name": {"type": "string"},
+                                            "file": {"type": "string", "format": "binary"},
+                                        },
+                                    },
+                                    "encoding": {"file": {"contentType": "text/xml"}},
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        # Then the file property should use the XML strategy
+        assert case.body["file"] == b"<?xml version='1.0'?><root>test</root>"
+        assert isinstance(case.body["name"], str)
+
+    test()
+
+
+def test_multipart_without_custom_encoding_uses_default():
+    # Given an OpenAPI schema with multipart but NO custom encoding
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["name", "file"],
+                                        "properties": {
+                                            "name": {"type": "string"},
+                                            "file": {"type": "string", "format": "binary"},
+                                        },
+                                    },
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        assert isinstance(case.body["file"], (bytes, Binary))
+        assert isinstance(case.body["name"], str)
+
+    test()
+
+
+def test_multipart_encoding_without_registered_strategy_falls_back():
+    # Given custom encoding but NO registered strategy for that content type
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["file"],
+                                        "properties": {
+                                            "file": {"type": "string", "format": "binary"},
+                                        },
+                                    },
+                                    "encoding": {"file": {"contentType": "application/unknown"}},
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        # Should fall back to default strategy
+        assert isinstance(case.body["file"], (bytes, Binary))
+
+    test()
+
+
+def test_multipart_multiple_properties_with_different_encodings():
+    # Register strategies for different media types
+    xml_strategy = st.just(b"<xml>data</xml>")
+    csv_strategy = st.just(b"col1,col2\nval1,val2")
+    schemathesis.openapi.media_type("text/xml", xml_strategy)
+    schemathesis.openapi.media_type("text/csv", csv_strategy)
+
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["document", "spreadsheet", "description"],
+                                        "properties": {
+                                            "document": {"type": "string", "format": "binary"},
+                                            "spreadsheet": {"type": "string", "format": "binary"},
+                                            "description": {"type": "string"},
+                                        },
+                                    },
+                                    "encoding": {
+                                        "document": {"contentType": "text/xml"},
+                                        "spreadsheet": {"contentType": "text/csv"},
+                                    },
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        assert case.body["document"] == b"<xml>data</xml>"
+        assert case.body["spreadsheet"] == b"col1,col2\nval1,val2"
+        assert isinstance(case.body["description"], str)
+
+    test()
+
+
+def test_multipart_encoding_with_multiple_content_types():
+    # Register strategies for both image types
+    png_strategy = st.just(b"\x89PNG\r\n\x1a\n")
+    jpeg_strategy = st.just(b"\xff\xd8\xff\xe0")
+    schemathesis.openapi.media_type("image/png", png_strategy)
+    schemathesis.openapi.media_type("image/jpeg", jpeg_strategy)
+
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["image"],
+                                        "properties": {
+                                            "image": {"type": "string", "format": "binary"},
+                                        },
+                                    },
+                                    "encoding": {"image": {"contentType": "image/png, image/jpeg"}},
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        # Should use one of the registered strategies
+        assert case.body["image"] in (b"\x89PNG\r\n\x1a\n", b"\xff\xd8\xff\xe0")
+
+    test()
+
+
+def test_urlencoded_form_with_encoding():
+    xml_strategy = st.just(b"<data>test</data>")
+    schemathesis.openapi.media_type("text/xml", xml_strategy)
+
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/submit": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "application/x-www-form-urlencoded": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["data"],
+                                        "properties": {
+                                            "data": {"type": "string"},
+                                        },
+                                    },
+                                    "encoding": {"data": {"contentType": "text/xml"}},
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/submit"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        assert case.body["data"] == b"<data>test</data>"
+
+    test()
+
+
+def test_multipart_optional_properties():
+    xml_strategy = st.just(b"<optional/>")
+    schemathesis.openapi.media_type("text/xml", xml_strategy)
+
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["name"],
+                                        "properties": {
+                                            "name": {"type": "string"},
+                                            "file": {"type": "string", "format": "binary"},
+                                        },
+                                    },
+                                    "encoding": {"file": {"contentType": "text/xml"}},
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        assert isinstance(case.body["name"], str)
+        if "file" in case.body:
+            assert case.body["file"] == b"<optional/>"
+
+    test()
+
+
+def test_multipart_wildcard_matching_specific_to_wildcard():
+    image_strategy = st.just(b"\x89PNG\r\n\x1a\n")
+    schemathesis.openapi.media_type("image/*", image_strategy)
+
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["avatar"],
+                                        "properties": {
+                                            "avatar": {"type": "string", "format": "binary"},
+                                        },
+                                    },
+                                    "encoding": {
+                                        "avatar": {
+                                            # Specific type should match wildcard
+                                            "contentType": "image/png"
+                                        }
+                                    },
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        assert case.body["avatar"] == b"\x89PNG\r\n\x1a\n"
+
+    test()
+
+
+def test_multipart_wildcard_matching_wildcard_to_specific():
+    png_strategy = st.just(b"\x89PNG")
+    jpeg_strategy = st.just(b"\xff\xd8\xff")
+    schemathesis.openapi.media_type("image/png", png_strategy)
+    schemathesis.openapi.media_type("image/jpeg", jpeg_strategy)
+
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["photo"],
+                                        "properties": {
+                                            "photo": {"type": "string", "format": "binary"},
+                                        },
+                                    },
+                                    "encoding": {
+                                        "photo": {
+                                            # Wildcard should match registered specific types
+                                            "contentType": "image/*"
+                                        }
+                                    },
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        assert case.body["photo"] in (b"\x89PNG", b"\xff\xd8\xff")
+
+    test()
+
+
+def test_multipart_exact_match_preferred_over_wildcard():
+    wildcard_strategy = st.just(b"WILDCARD")
+    exact_strategy = st.just(b"EXACT")
+    schemathesis.openapi.media_type("image/*", wildcard_strategy)
+    schemathesis.openapi.media_type("image/png", exact_strategy)
+
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["icon"],
+                                        "properties": {
+                                            "icon": {"type": "string", "format": "binary"},
+                                        },
+                                    },
+                                    "encoding": {"icon": {"contentType": "image/png"}},
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        assert case.body["icon"] == b"EXACT"
+
+    test()
+
+
+def test_multipart_defensive_non_string_content_type():
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["data"],
+                                        "properties": {
+                                            "data": {"type": "string", "format": "binary"},
+                                        },
+                                    },
+                                    # Malformed encoding (contentType is not a string)
+                                    "encoding": {"data": {"contentType": 123}},
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        # Should fall back to default strategy
+        assert isinstance(case.body["data"], (bytes, Binary))
+
+    test()
+
+
+def test_nested_object_with_encoding():
+    xml_strategy = st.just(b"<xml/>")
+    schemathesis.openapi.media_type("text/xml", xml_strategy)
+
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "metadata": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "file": {"type": "string", "format": "binary"},
+                                                },
+                                            },
+                                        },
+                                        "required": ["metadata"],
+                                    },
+                                    "encoding": {
+                                        # This refers to top-level "file", but there isn't one
+                                        "file": {"contentType": "text/xml"}
+                                    },
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        # Should ignore the encoding since "file" is nested, not top-level
+        assert "metadata" in case.body
+        assert isinstance(case.body["metadata"], dict)
+
+    test()
+
+
+def test_additional_properties_with_encoding():
+    xml_strategy = st.just(b"<xml/>")
+    schemathesis.openapi.media_type("text/xml", xml_strategy)
+
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "file": {"type": "string", "format": "binary"},
+                                        },
+                                        "required": ["file"],
+                                        "additionalProperties": {"type": "string"},
+                                    },
+                                    "encoding": {"file": {"contentType": "text/xml"}},
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        assert case.body["file"] == b"<xml/>"
+        for key, value in case.body.items():
+            if key != "file":
+                assert isinstance(value, str)
+
+    test()
+
+
+def test_empty_encoding_object():
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "file": {"type": "string", "format": "binary"},
+                                        },
+                                        "required": ["file"],
+                                    },
+                                    "encoding": {},
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        assert "file" in case.body
+
+    test()
+
+
+def test_encoding_with_invalid_content_type_format():
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "file": {"type": "string", "format": "binary"},
+                                        },
+                                        "required": ["file"],
+                                    },
+                                    "encoding": {"file": {"contentType": ""}},
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        # Should handle empty string gracefully
+        assert "file" in case.body
+
+    test()


### PR DESCRIPTION
Resolves #697 