### PR TITLE
fix: Incorrect error message when combining `@schema.given()` with schema examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### :bug: Fixed
 
 - Positive test cases generated without required body. [#3327](https://github.com/schemathesis/schemathesis/issues/3327)
+- Incorrect error message when combining `@schema.given()` with schema examples. [#3328](https://github.com/schemathesis/schemathesis/issues/3328)
 
 ## [4.5.2](https://github.com/schemathesis/schemathesis/compare/v4.5.1...v4.5.2) - 2025-11-15
 

--- a/src/schemathesis/generation/hypothesis/given.py
+++ b/src/schemathesis/generation/hypothesis/given.py
@@ -22,6 +22,8 @@ __all__ = [
     "GivenKwargsMark",
     "GIVEN_TARGET_ATTR",
     "GIVEN_REFRESH_ATTR",
+    "GIVEN_AND_EXPLICIT_EXAMPLE_ERROR_MESSAGE",
+    "format_given_and_schema_examples_error",
 ]
 
 EllipsisType = type(...)
@@ -31,6 +33,30 @@ GivenArgsMark = Mark[tuple](attr_name="given_args", default=())
 GivenKwargsMark = Mark[dict[str, Any]](attr_name="given_kwargs", default=dict)
 GIVEN_TARGET_ATTR = "_schemathesis_given_target"
 GIVEN_REFRESH_ATTR = "_schemathesis_given_refresh"
+
+# Error messages for incompatible @schema.given() usage
+GIVEN_AND_EXPLICIT_EXAMPLE_ERROR_MESSAGE = (
+    "Cannot combine `@schema.given()` with explicit `@example()` decorators.\n\n"
+    "When you use `@schema.given(param=...)`, your test function gains additional parameters beyond 'case'. "
+    "However, `@example()` decorators only provide values for a different set of parameters. "
+    "This parameter mismatch prevents the test from running.\n\n"
+    "Solution: Create separate test functions:\n"
+    "  1. One with `@example()` for specific test cases\n"
+    "  2. One with `@schema.given()` for property-based testing"
+)
+
+
+def format_given_and_schema_examples_error(param_names: str) -> str:
+    """Format error message when @schema.given() is used with schema examples."""
+    return (
+        f"Cannot combine `@schema.given()` with schema examples.\n\n"
+        f"Your test uses `@schema.given()` with custom strategies for: {param_names}\n"
+        f"This adds extra parameters to your test function that schema examples cannot provide values for. "
+        f"Schema examples only work with the standard 'case' parameter.\n\n"
+        f"Solution: Create separate test functions:\n"
+        f"  1. One without `@schema.given()` to test schema examples\n"
+        f"  2. One with `@schema.given()` for custom property-based testing"
+    )
 
 
 def is_given_applied(func: Callable) -> bool:

--- a/src/schemathesis/pytest/plugin.py
+++ b/src/schemathesis/pytest/plugin.py
@@ -53,11 +53,6 @@ if TYPE_CHECKING:
 
     from schemathesis.schemas import BaseSchema
 
-GIVEN_AND_EXPLICIT_EXAMPLES_ERROR_MESSAGE = (
-    "Unsupported test setup. Tests using `@schema.given` cannot be combined with explicit schema examples in the same "
-    "function. Separate these tests into distinct functions to avoid conflicts."
-)
-
 
 def _is_schema(value: object) -> bool:
     from schemathesis.schemas import BaseSchema
@@ -376,7 +371,9 @@ def pytest_pyfunc_call(pyfuncitem):  # type: ignore[no-untyped-def]
                 yield
         except InvalidArgument as exc:
             if "Inconsistent args" in str(exc) and "@example()" in str(exc):
-                raise IncorrectUsage(GIVEN_AND_EXPLICIT_EXAMPLES_ERROR_MESSAGE) from None
+                from schemathesis.generation.hypothesis.given import GIVEN_AND_EXPLICIT_EXAMPLE_ERROR_MESSAGE
+
+                raise IncorrectUsage(GIVEN_AND_EXPLICIT_EXAMPLE_ERROR_MESSAGE) from None
             raise InvalidSchema(exc.args[0]) from None
         except (SkipTest, unittest.SkipTest) as exc:
             if UnsatisfiableExampleMark.is_set(pyfuncitem.obj):


### PR DESCRIPTION
Resolves #3328 