### PR TITLE
fix: Custom media type strategies now apply when `encoding.contentType` is an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **CLI**: Dependency-based operation ordering in non-stateful tests.
 - **CLI**: Capture and reuse of successful API responses in the fuzzing phase.
 
+### :bug: Fixed
+
+- Custom media type strategies now apply when `encoding.contentType` is an array. [#3339](https://github.com/schemathesis/schemathesis/issues/3339)
+
 ## [4.5.4](https://github.com/schemathesis/schemathesis/compare/v4.5.3...v4.5.4) - 2025-11-18
 
 ### :bug: Fixed

--- a/src/schemathesis/specs/openapi/_hypothesis.py
+++ b/src/schemathesis/specs/openapi/_hypothesis.py
@@ -425,15 +425,16 @@ def _build_form_strategy_with_encoding(
     property_content_type_selections: dict[str, list[str]] = {}
 
     for property_name in properties:
-        content_type = parameter.get_property_content_type(property_name)
+        raw_content_type = parameter.get_property_content_type(property_name)
 
-        if content_type is not None and not isinstance(content_type, str):
-            # Happens in broken schemas
-            continue  # type: ignore[unreachable]
+        # contentType can be a string (or comma-separated list) or an array of strings per the spec
+        content_types: list[str] = []
+        if isinstance(raw_content_type, str):
+            content_types = [ct.strip() for ct in raw_content_type.split(",")]
+        elif isinstance(raw_content_type, list):
+            content_types = [ct.strip() for ct in raw_content_type if isinstance(ct, str)]
 
-        if content_type:
-            # Handle multiple content types (e.g., "image/png, image/jpeg")
-            content_types = [ct.strip() for ct in content_type.split(",")]
+        if content_types:
             strategies_for_types = []
             for ct in content_types:
                 strategy = _find_media_type_strategy(ct)

--- a/src/schemathesis/specs/openapi/adapter/parameters.py
+++ b/src/schemathesis/specs/openapi/adapter/parameters.py
@@ -263,7 +263,7 @@ class OpenApiBody(OpenApiComponent):
         """Return default type if body is a form type."""
         return "object" if self.media_type in FORM_MEDIA_TYPES else None
 
-    def get_property_content_type(self, property_name: str) -> str | None:
+    def get_property_content_type(self, property_name: str) -> str | list[str] | None:
         """Get custom contentType for a form property from `encoding` definition."""
         encoding = self.definition.get("encoding", {})
         property_encoding = encoding.get(property_name, {})


### PR DESCRIPTION
Fixes #3339 