### PR TITLE
fix: `auth` argument passed to `call_and_validate` not being recognized by the `ignored_auth` check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Missing curl reproduction commands for network errors with Hypothesis 6.148.7+.
 - Missing type violations in coverage phase for properties with both `const` and `type` keywords.
 - `PointerToNowhere` error when `prefixItems` contains `$ref` in Open API 3.1 schemas.
+- `auth` argument passed to `call_and_validate` not being recognized by the `ignored_auth` check. [#3386](https://github.com/schemathesis/schemathesis/issues/3386)
 
 ## [4.6.8](https://github.com/schemathesis/schemathesis/compare/v4.6.7...v4.6.8) - 2025-12-04
 

--- a/src/schemathesis/generation/case.py
+++ b/src/schemathesis/generation/case.py
@@ -430,7 +430,7 @@ class Case:
 
         ctx = CheckContext(
             override=self._override,
-            auth=None,
+            auth=transport_kwargs.get("auth") if transport_kwargs else None,
             headers=CaseInsensitiveDict(headers) if headers else None,
             config=config,
             transport_kwargs=transport_kwargs,

--- a/src/schemathesis/specs/openapi/checks.py
+++ b/src/schemathesis/specs/openapi/checks.py
@@ -733,8 +733,7 @@ def ignored_auth(ctx: CheckContext, response: Response, case: Case) -> bool | No
             # Auth is explicitly set, it is expected to be valid
             # Check if invalid auth will give an error
             no_auth_case = remove_auth(case, security_parameters)
-            kwargs = ctx._transport_kwargs or {}
-            kwargs.copy()
+            kwargs = (ctx._transport_kwargs or {}).copy()
             for location, container_name in (
                 ("header", "headers"),
                 ("cookie", "cookies"),
@@ -745,6 +744,7 @@ def ignored_auth(ctx: CheckContext, response: Response, case: Case) -> bool | No
                     _remove_auth_from_container(container, security_parameters, location=location)
                     kwargs[container_name] = container
             kwargs.pop("session", None)
+            kwargs.pop("auth", None)
             if case.operation.app is not None:
                 kwargs.setdefault("app", case.operation.app)
             ctx._record_case(parent_id=case.id, case=no_auth_case)


### PR DESCRIPTION
Fixes #3386 