### PR TITLE
fix: Examples phase generating invalid data for schemas with `anyOf`/`oneOf` containing only `required` constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.7.4...HEAD) - TBD
 
+### :bug: Fixed
+
+- Examples phase generating invalid data for schemas with `anyOf`/`oneOf` containing only `required` constraints. [#3404](https://github.com/schemathesis/schemathesis/issues/3404)
+
 ## [4.7.4](https://github.com/schemathesis/schemathesis/compare/v4.7.3...v4.7.4) - 2025-12-10
 
 ### :bug: Fixed


### PR DESCRIPTION
Fixes #3404 