### PR TITLE
fix: Coverage phase silently replacing path parameter values with `"value"` when a custom format generates strings containing `/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Coverage phase generating schema-invalid positive values for schemas with `anyOf`/`oneOf` and `required` constraints. [#3520](https://github.com/schemathesis/schemathesis/issues/3520)
 - `missing_required_header` now accepts `400`, `401`, `403`, and `422` (in addition to `406`) for missing non-`Authorization` required headers. [#3521](https://github.com/schemathesis/schemathesis/issues/3521)
+- Coverage phase silently replacing path parameter values with `"value"` when a custom format (e.g., `ipv4-network`) generates strings containing `/`. [#3527](https://github.com/schemathesis/schemathesis/issues/3527)
 
 ### :wrench: Changed
 

--- a/src/schemathesis/generation/coverage.py
+++ b/src/schemathesis/generation/coverage.py
@@ -1067,7 +1067,7 @@ def _positive_string(ctx: CoverageContext, schema: JsonSchemaObject) -> Generato
     if min_length == 0:
         min_length = None
     max_length = schema.get("maxLength")
-    if ctx.location == "path":
+    if ctx.location == "path" and not ("format" in schema and schema["format"] in ctx.custom_formats):
         schema = _ensure_valid_path_parameter_schema(schema)
     elif ctx.location in ("header", "cookie") and not ("format" in schema and schema["format"] in FORMAT_STRATEGIES):
         # Don't apply it for known formats - they will insure the correct format during generation

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -39,6 +39,7 @@ from schemathesis.core.hooks import HOOKS_MODULE_ENV_VAR
 from schemathesis.core.transport import Response
 from schemathesis.core.version import SCHEMATHESIS_VERSION
 from schemathesis.specs.openapi import media_types
+from schemathesis.specs.openapi.formats import STRING_FORMATS
 from schemathesis.transport.asgi import ASGI_TRANSPORT
 from schemathesis.transport.requests import REQUESTS_TRANSPORT
 from schemathesis.transport.wsgi import WSGI_TRANSPORT
@@ -73,6 +74,7 @@ output.SCHEMATHESIS_VERSION = "dev"
 def reset_hooks():
     # Store built-in deserializers to restore after test
     builtin_deserializers = deserialization.deserializers().copy()
+    builtin_string_formats = set(STRING_FORMATS.keys())
 
     CUSTOM_HANDLERS.clear()
     hooks.unregister_all()
@@ -92,6 +94,10 @@ def reset_hooks():
     deserialization.unregister_deserializer(*current)
     for media_type, func in builtin_deserializers.items():
         deserialization.register_deserializer(func, media_type)
+    # Remove any string formats registered during the test
+    for name in list(STRING_FORMATS.keys()):
+        if name not in builtin_string_formats:
+            del STRING_FORMATS[name]
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Fixes #3527 