### PR TITLE
fix: False positive `negative_data_rejection` for `application/xml` bodies in the coverage phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### :bug: Fixed
 
+- False positive `negative_data_rejection` for `application/xml` bodies in the coverage phase due to type mutations producing wire-identical bytes. [#3525](https://github.com/schemathesis/schemathesis/issues/3525)
 - Coverage phase generating schema-invalid positive values for schemas with `anyOf`/`oneOf` and `required` constraints. [#3520](https://github.com/schemathesis/schemathesis/issues/3520)
 - `missing_required_header` now accepts `400`, `401`, `403`, and `422` (in addition to `406`) for missing non-`Authorization` required headers. [#3521](https://github.com/schemathesis/schemathesis/issues/3521)
 - Coverage phase silently replacing path parameter values with `"value"` when a custom format (e.g., `ipv4-network`) generates strings containing `/`. [#3527](https://github.com/schemathesis/schemathesis/issues/3527)

--- a/src/schemathesis/core/media_types.py
+++ b/src/schemathesis/core/media_types.py
@@ -79,6 +79,12 @@ def is_xml(value: str) -> bool:
     return sub == "xml" or sub.endswith("+xml")
 
 
+def is_xml_parts(media_type: tuple[str, str]) -> bool:
+    """Detect variations of the ``application/xml`` media type from a parsed tuple."""
+    _, sub = media_type
+    return sub == "xml" or sub.endswith("+xml")
+
+
 def matches_parts(expected: tuple[str, str], actual: tuple[str, str]) -> bool:
     """Check if two parsed media types match with wildcard support."""
     expected_main, expected_sub = expected


### PR DESCRIPTION
Fixes #3525 