### PR TITLE
fix: Examples phase not escaping path examples containing `/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Coverage phase generating schema-invalid positive values for schemas with `anyOf`/`oneOf` and `required` constraints. [#3520](https://github.com/schemathesis/schemathesis/issues/3520)
 - `missing_required_header` now accepts `400`, `401`, `403`, and `422` (in addition to `406`) for missing non-`Authorization` required headers. [#3521](https://github.com/schemathesis/schemathesis/issues/3521)
 - Coverage phase silently replacing path parameter values with `"value"` when a custom format (e.g., `ipv4-network`) generates strings containing `/`. [#3527](https://github.com/schemathesis/schemathesis/issues/3527)
+- Examples phase not escaping path examples containing `/` when some path parameters were generated from schema. [#3533](https://github.com/schemathesis/schemathesis/issues/3533)
 
 ### :wrench: Changed
 

--- a/test/openapi/test_filters.py
+++ b/test/openapi/test_filters.py
@@ -63,7 +63,7 @@ def test_invalid_query_fails_with_requests(invalid_params):
         req.prepare()
 
 
-@pytest.mark.parametrize("value", ["/", "\udc9b"])
+@pytest.mark.parametrize("value", ["/", "%2F", "%2f", "foo%2Fbar", "\udc9b"])
 def test_filter_path_parameters(value):
     assert not is_valid_path({"foo": value})
 

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -464,7 +464,18 @@ def test_optional_form_data(ctx, openapi3_base_url):
     inner()
 
 
-@pytest.mark.parametrize(("value", "expected"), [(".", "%2E"), ("..", "%2E%2E"), (".foo", ".foo")])
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (".", "%2E"),
+        ("..", "%2E%2E"),
+        (".foo", ".foo"),
+        ("%2E", "%2E"),
+        ("%2e", "%2E"),
+        ("%2E%2E", "%2E%2E"),
+        ("%2e%2e", "%2E%2E"),
+    ],
+)
 def test_path_parameters_quotation(value, expected):
     # See GH-1036
     assert quote_all({"foo": value})["foo"] == expected


### PR DESCRIPTION
Fixes #3533 