### PR TITLE
fix: Misconfigured `[auth.openapi.*]` scheme names (e.g. typos) now emit a `UserWarning` in pytest mode, matching the existing CLI behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### :bug: Fixed
 
+- Misconfigured `[auth.openapi.*]` scheme names (e.g. typos) now emit a `UserWarning` in pytest mode, matching the existing CLI behavior. [#3575](https://github.com/schemathesis/schemathesis/issues/3575)
 - False positive `negative_data_rejection` for `application/xml` body string fields in the fuzzing phase due to type mutations producing wire-identical strings (e.g. `False` -> `"False"`). [#3525](https://github.com/schemathesis/schemathesis/issues/3525)
 - Internal `ValueError` when validating a response containing lone Unicode surrogate characters (e.g. `\uDCF3`); now reported as a `JSON deserialization error` since lone surrogates are invalid JSON per RFC 8259.
 - False positive `negative_data_rejection` for `format: hostname` in OpenAPI 3.0.x during the coverage phase. [#3567](https://github.com/schemathesis/schemathesis/issues/3567)

--- a/src/schemathesis/pytest/lazy.py
+++ b/src/schemathesis/pytest/lazy.py
@@ -27,6 +27,7 @@ from schemathesis.generation.hypothesis.given import (
     validate_given_args,
 )
 from schemathesis.pytest.control_flow import fail_on_no_matches
+from schemathesis.pytest.warnings import emit_openapi_auth_warnings
 from schemathesis.schemas import BaseSchema
 
 if TYPE_CHECKING:
@@ -213,6 +214,7 @@ class LazySchema:
                     test_function=test_func,
                     filter_set=self.filter_set,
                 )
+                emit_openapi_auth_warnings(schema)
                 # Check if test function is a method and inject self from request.instance
                 sig = signature(test_func)
                 if "self" in sig.parameters and request.instance is not None:

--- a/src/schemathesis/pytest/plugin.py
+++ b/src/schemathesis/pytest/plugin.py
@@ -45,6 +45,7 @@ from schemathesis.generation.hypothesis.reporting import (
     ignore_hypothesis_output,
 )
 from schemathesis.pytest.control_flow import fail_on_no_matches
+from schemathesis.pytest.warnings import emit_openapi_auth_warnings
 from schemathesis.schemas import APIOperation
 
 if TYPE_CHECKING:
@@ -249,6 +250,7 @@ class SchemathesisCase(PyCollector):
     def collect(self) -> list[Function]:  # type: ignore[return]
         """Generate different test items for all API operations available in the given schema."""
         try:
+            emit_openapi_auth_warnings(self.schema)
             items = [item for operation in self.schema.get_all_operations() for item in self._gen_items(operation)]
             if not items:
                 fail_on_no_matches(self.nodeid)

--- a/src/schemathesis/pytest/warnings.py
+++ b/src/schemathesis/pytest/warnings.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from schemathesis.schemas import BaseSchema
+
+
+def emit_openapi_auth_warnings(schema: BaseSchema) -> None:
+    """Emit Python warnings for unused OpenAPI auth configuration."""
+    from schemathesis.specs.openapi.schemas import OpenApiSchema
+    from schemathesis.specs.openapi.warnings import UnusedOpenAPIAuthWarning
+
+    if not isinstance(schema, OpenApiSchema):
+        return
+    for warning in schema.analysis._get_schema_warnings():
+        if isinstance(warning, UnusedOpenAPIAuthWarning):
+            warnings.warn(
+                f"Unused OpenAPI auth configuration: {warning.message}",
+                UserWarning,
+                stacklevel=6,
+            )

--- a/test/auth/test_pytest.py
+++ b/test/auth/test_pytest.py
@@ -467,3 +467,56 @@ def test_api_with_overrides(case):
     )
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
+
+
+def test_unused_openapi_auth_warning_in_pytest_mode(testdir):
+    # See GH-3575
+    # When a user configures [auth.openapi.WRONG_SCHEME] but WRONG_SCHEME doesn't exist
+    # in the schema's securitySchemes, a warning should be emitted.
+    testdir.makefile(
+        ".toml",
+        schemathesis="""
+[auth.openapi.WRONG_MISSING_AUTH]
+username = "testuser"
+password = "testpass"
+""",
+    )
+    testdir.makepyfile(
+        """
+import pytest
+import schemathesis
+from hypothesis import settings, Phase
+
+raw_schema = {
+    "openapi": "3.0.0",
+    "info": {"title": "Test API", "version": "1.0.0"},
+    "paths": {
+        "/protected": {
+            "get": {
+                "security": [{"BasicAuth": []}],
+                "responses": {"200": {"description": "OK"}}
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "BasicAuth": {"type": "http", "scheme": "basic"}
+        }
+    }
+}
+
+@pytest.fixture
+def api_schema():
+    return schemathesis.openapi.from_dict(raw_schema)
+
+lazy_schema = schemathesis.pytest.from_fixture("api_schema")
+
+@lazy_schema.parametrize()
+@settings(max_examples=1, phases=[Phase.generate])
+def test_api(case):
+    pass
+"""
+    )
+    result = testdir.runpytest("-W", "always")
+    # The unused OpenAPI auth scheme warning should be emitted
+    result.stdout.re_match_lines([r".*WRONG_MISSING_AUTH.*"])


### PR DESCRIPTION
Ref: #3575 