### PR TITLE
fix: Flaky `does not match any API operations` on repeated pytest runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Warning count in the final summary line now reflects the number of distinct warning kinds shown, not just `missing_auth` operations.
 - False positive `use_after_free` when the server reuses freed resource IDs and a re-created resource is accessed in the same scenario. [#3582](https://github.com/schemathesis/schemathesis/issues/3582)
 - Correctly resolve `$ref` inside `oneOf`/`anyOf` sub-schemas during the coverage phase. [#3584](https://github.com/schemathesis/schemathesis/issues/3584)
+- `pytest.from_fixture().exclude()` (and `.include()`) intermittently failing with "does not match any API operations" on repeated runs when no `[[operations]]` are configured in `schemathesis.toml`. [#3572](https://github.com/schemathesis/schemathesis/issues/3572)
 
 ### :wrench: Changed
 

--- a/src/schemathesis/config/_operations.py
+++ b/src/schemathesis/config/_operations.py
@@ -170,7 +170,7 @@ class OperationsConfig(DiffBase):
 
     def filter_set_with(self, include: FilterSet, exclude: FilterSet | None = None) -> FilterSet:
         if not self.operations and exclude is None:
-            return include
+            return include.clone()
         operations = list(self.operations)
 
         final = FilterSet()

--- a/test/config/test_config.py
+++ b/test/config/test_config.py
@@ -3,10 +3,11 @@ from pathlib import Path
 import pytest
 
 from schemathesis.config import ConfigError, SchemathesisConfig
-from schemathesis.config._operations import OperationConfig
+from schemathesis.config._operations import OperationConfig, OperationsConfig
 from schemathesis.config._projects import ProjectConfig
 from schemathesis.config._validator import CONFIG_SCHEMA
 from schemathesis.core.errors import HookError
+from schemathesis.filters import FilterSet
 
 CONFIGS_DIR = Path(__file__).parent / "configs"
 
@@ -107,3 +108,14 @@ def test_project_config_path_delegates_to_parent(tmp_path):
 def test_project_config_path_none_without_parent():
     project_config = ProjectConfig()
     assert project_config.config_path is None
+
+
+def test_filter_set_with_returns_copy_when_no_operations():
+    # See GH-3572.
+    # filter_set_with() must return a copy when there are no `[[operations]]` configured.
+    # This avoids mutations that can corrupt the execution flow on subsequent runs
+    ops = OperationsConfig()
+    original = FilterSet()
+    original.exclude(path="/admin")
+
+    assert ops.filter_set_with(include=original) is not original

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -885,6 +885,140 @@ def test_api(case):
     assert "GET /products" in result.stdout.str()
 
 
+_NO_MATCHES_PREAMBLE = """
+import pytest
+import schemathesis
+from hypothesis import settings, Phase
+
+@pytest.fixture
+def api_schema():
+    return schemathesis.openapi.from_dict({
+        "openapi": "3.0.0",
+        "paths": {
+            "/users": {"get": {"responses": {"200": {"description": "OK"}}}},
+            "/admin": {"get": {"responses": {"200": {"description": "OK"}}}},
+        }
+    })
+"""
+
+
+def test_no_false_no_matches_on_repeated_runs_with_config(testdir):
+    # When a schemathesis.toml disables one operation, repeated runs must NOT fail with
+    # "does not match any API operations" for the remaining enabled operations.
+    testdir.makefile(
+        ".toml",
+        schemathesis="""
+[[operations]]
+include-name = "GET /admin"
+enabled = false
+""",
+    )
+    testdir.makepyfile(
+        _NO_MATCHES_PREAMBLE
+        + """
+lazy_schema = schemathesis.pytest.from_fixture("api_schema")
+
+@lazy_schema.parametrize()
+@settings(max_examples=1, phases=[Phase.generate])
+def test_api(case):
+    pass
+"""
+    )
+
+    testdir.runpytest("--tb=short")  # populate caches
+    result = testdir.runpytest("--tb=short")
+    assert "does not match any API operations" not in result.stdout.str()
+    result.assert_outcomes(passed=1)
+
+
+def test_no_false_no_matches_with_multiple_lazy_schema_tests(testdir):
+    # When multiple test functions share the same lazy schema instance and a config disables
+    # one operation, all test functions must still find the remaining enabled operations.
+    testdir.makefile(
+        ".toml",
+        schemathesis="""
+[[operations]]
+include-name = "GET /admin"
+enabled = false
+""",
+    )
+    testdir.makepyfile(
+        _NO_MATCHES_PREAMBLE
+        + """
+lazy_schema = schemathesis.pytest.from_fixture("api_schema")
+
+@lazy_schema.parametrize()
+@settings(max_examples=1, phases=[Phase.generate])
+def test_api_first(case):
+    pass
+
+@lazy_schema.parametrize()
+@settings(max_examples=1, phases=[Phase.generate])
+def test_api_second(case):
+    pass
+"""
+    )
+
+    result = testdir.runpytest("--tb=short")
+    assert "does not match any API operations" not in result.stdout.str()
+    result.assert_outcomes(passed=2)
+
+
+def test_no_false_no_matches_on_repeated_runs_with_exclude(testdir):
+    # See GH-3572: from_fixture().exclude() without [[operations]] config must not produce
+    # "does not match any API operations" on repeated runs.
+    testdir.makepyfile(
+        _NO_MATCHES_PREAMBLE
+        + """
+lazy_schema = schemathesis.pytest.from_fixture("api_schema").exclude(path="/admin")
+
+@lazy_schema.parametrize()
+@settings(max_examples=1, phases=[Phase.generate])
+def test_api(case):
+    pass
+"""
+    )
+
+    testdir.runpytest("--tb=short")  # populate caches
+    result = testdir.runpytest("--tb=short")
+    assert "does not match any API operations" not in result.stdout.str()
+    result.assert_outcomes(passed=1)
+
+
+def test_config_disabled_all_operations_with_from_fixture(testdir):
+    # When a schemathesis.toml disables the ONLY available operation, from_fixture must
+    # correctly report "does not match any API operations".
+    testdir.makefile(
+        ".toml",
+        schemathesis="""
+[[operations]]
+include-name = "GET /users"
+enabled = false
+""",
+    )
+    testdir.makepyfile("""
+import pytest
+import schemathesis
+
+@pytest.fixture
+def api_schema():
+    return schemathesis.openapi.from_dict({
+        "openapi": "3.0.0",
+        "paths": {"/users": {"get": {"responses": {"200": {"description": "OK"}}}}}
+    })
+
+lazy_schema = schemathesis.pytest.from_fixture("api_schema")
+
+@lazy_schema.parametrize()
+def test_api(case):
+    pass
+""")
+
+    result = testdir.runpytest("--tb=short")
+    assert "does not match any API operations" in result.stdout.str()
+    result.assert_outcomes(failed=1)
+
+
 @pytest.mark.usefixtures("reload_profile")
 def test_hypothesis_settings_database_from_profile_lazy(testdir):
     # When a hypothesis profile with a custom database is loaded


### PR DESCRIPTION
Fixes #3572 