### PR TITLE
docs: use API token environment variable for GHA instead of arg

### DIFF
--- a/docs/guides/cicd.md
+++ b/docs/guides/cicd.md
@@ -38,9 +38,9 @@ jobs:
       - uses: schemathesis/action@v2
         with:
           schema: 'http://localhost:8080/openapi.json'
-          args: >-
-            --header "Authorization: Bearer ${{ secrets.API_TOKEN }}"
-            --report junit
+          args: --report junit
+        env:
+          API_TOKEN: ${{ secrets.API_TOKEN }}
           
       - name: Upload test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Refactor CI/CD configuration to set API_TOKEN in env.

🚨Please review the [Contributing Guidelines](https://github.com/schemathesis/schemathesis/blob/master/CONTRIBUTING.md).

### Description

this updates the documentation for GHA to align the token with what's recommended for gitlab and other documentation pages.

### Checklist

- [ ] Added failing tests for the change
- [ ] All new and existing tests pass
- [ ] Added changelog entry
- [x] Updated README/documentation, if necessary
