### PR TITLE
Fix/coverage path param minlength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.12.1...HEAD) - TBD
 
+### :bug: Fixed
+
+- False positive `positive_data_acceptance` in the coverage phase for path parameters with `minLength` greater than 1 — `_ensure_valid_path_parameter_schema` unconditionally set `minLength` to 1, overwriting stricter schema constraints.
+
 ## [4.12.1](https://github.com/schemathesis/schemathesis/compare/v4.12.0...v4.12.1) - 2026-03-14
 
 ### :bug: Fixed

--- a/src/schemathesis/generation/coverage.py
+++ b/src/schemathesis/generation/coverage.py
@@ -1118,7 +1118,8 @@ def _ensure_valid_path_parameter_schema(schema: JsonSchemaObject) -> JsonSchemaO
     # The implementation below sneaks into `not` to avoid clashing with existing `pattern` keyword
     not_ = _get_not_schema(schema)
     not_["pattern"] = r"[/{}]"
-    return {**schema, "minLength": 1, "not": not_}
+    min_length = max(schema.get("minLength", 0), 1)
+    return {**schema, "minLength": min_length, "not": not_}
 
 
 def _ensure_valid_headers_schema(schema: JsonSchemaObject) -> JsonSchemaObject:

--- a/test/coverage/test_phase.py
+++ b/test/coverage/test_phase.py
@@ -1379,6 +1379,31 @@ def test_path_parameter_as_string_non_empty(ctx):
     )
 
 
+def test_path_parameter_preserves_min_length(ctx):
+    schema = build_schema(
+        ctx,
+        [
+            {
+                "name": "uid",
+                "in": "path",
+                "required": True,
+                "schema": {"type": "string", "minLength": 5, "maxLength": 64, "pattern": "^[0-9.]*$"},
+            },
+        ],
+        path="/foo/{uid}",
+    )
+    assert_positive_coverage(
+        schema,
+        [
+            {"path_parameters": {"uid": "0" * 63}},
+            {"path_parameters": {"uid": "0" * 64}},
+            {"path_parameters": {"uid": "0" * 6}},
+            {"path_parameters": {"uid": "0" * 5}},
+        ],
+        path=("/foo/{uid}", "post"),
+    )
+
+
 def test_incorrect_headers_with_loose_schema(ctx):
     schema = build_schema(
         ctx,


### PR DESCRIPTION
Description

_ensure_valid_path_parameter_schema unconditionally set minLength to 1,
overwriting any stricter constraint from the original schema. This caused the
Coverage phase to generate path parameter values shorter than the schema
allows (e.g. "0" for a parameter with minLength: 5), leading to false positive
 positive_data_acceptance failures.

Fix: use max(schema.get("minLength", 0), 1) to preserve the original
constraint when it is already >= 1.

Checklist

- [x] Added failing tests for the change
- [x] All new and existing tests pass
- [x] Added changelog entry
- [ ] Updated README/documentation, if necessary
