### PR TITLE
Bugfix: apply_to filter_set not updated between hook registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.12.2...HEAD) - TBD
 
+### :bug: Fixed
+
+- `apply_to` / `skip_for` filter sets not updated between hook registrations, causing hooks registered after the first to silently receive the wrong filter set.
+
 ## [4.12.2](https://github.com/schemathesis/schemathesis/compare/v4.12.1...v4.12.2) - 2026-03-19
 
 ### :bug: Fixed

--- a/src/schemathesis/hooks.py
+++ b/src/schemathesis/hooks.py
@@ -86,7 +86,7 @@ def to_filterable_hook(dispatcher: HookDispatcher) -> Callable:
             return decorator
 
         hook.filter_set = filter_set  # type: ignore[attr-defined]
-        init_filter_set(register)
+        filter_set = init_filter_set(register)
         return dispatcher.register_hook_with_name(hook, hook.__name__)
 
     def init_filter_set(target: Callable) -> FilterSet:

--- a/test/hooks/test_filters.py
+++ b/test/hooks/test_filters.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -186,45 +184,33 @@ def test_filter_body_works_in_negative_mode(ctx):
     inner()
 
 
-def _make_hook_context(operation_id):
-    """Build a minimal HookContext whose operation carries the given operationId."""
-    operation = SimpleNamespace(
-        definition=SimpleNamespace(raw={"operationId": operation_id}),
-        label=operation_id,
-        method="POST",
-        path=f"/fake/{operation_id}",
-        tags=[],
-    )
-    return HookContext(operation=operation)
+def _build_operation(ctx, operation_id, path):
+    op = {"operationId": operation_id, "responses": {"200": {"description": "OK"}}}
+    schema = schemathesis.openapi.from_dict(ctx.openapi.build_schema({path: {"post": op}}))
+    return schema[path]["POST"]
 
 
+# Each hook registered with a different apply_to filter must receive its own filter_set
 def test_multiple_apply_to_have_distinct_filters(ctx):
-    """Hooks registered with different apply_to filters must each receive their own filter_set.
-
-    Regression: a bug in to_filterable_hook caused the outer ``filter_set``
-    variable to go stale after the first registration, so every subsequent hook
-    was silently assigned the *first* hook's filter_set.
-    """
     with ctx.restore_hooks():
 
         @schemathesis.hook.apply_to(operation_id="operationA")
         def before_call(context, case, **kwargs):
-            """Hook for operation A."""
+            pass
 
         hook_a = before_call
 
         @schemathesis.hook.apply_to(operation_id="operationB")
         def before_call(context, case, **kwargs):  # noqa: F811
-            """Hook for operation B."""
+            pass
 
         hook_b = before_call
 
-        # Each hook must carry its own, distinct filter_set
         assert hook_a.filter_set is not hook_b.filter_set
 
-        ctx_a = _make_hook_context("operationA")
-        ctx_b = _make_hook_context("operationB")
-        ctx_other = _make_hook_context("operationC")
+        ctx_a = HookContext(operation=_build_operation(ctx, "operationA", "/a"))
+        ctx_b = HookContext(operation=_build_operation(ctx, "operationB", "/b"))
+        ctx_other = HookContext(operation=_build_operation(ctx, "operationC", "/c"))
 
         # hook_a should run for operationA only
         assert not _should_skip_hook(hook_a, ctx_a)
@@ -237,25 +223,25 @@ def test_multiple_apply_to_have_distinct_filters(ctx):
         assert _should_skip_hook(hook_b, ctx_other)
 
 
+# Mixing apply_to and skip_for across multiple hooks must keep filters independent
 def test_multiple_apply_to_with_skip_for(ctx):
-    """Mixing apply_to and skip_for across multiple hooks must keep filters independent."""
     with ctx.restore_hooks():
 
         @schemathesis.hook.apply_to(operation_id="opInclude")
         def before_call(context, case, **kwargs):
-            """Include-filtered hook."""
+            pass
 
         hook_include = before_call
 
         @schemathesis.hook.skip_for(operation_id="opExclude")
         def before_call(context, case, **kwargs):  # noqa: F811
-            """Exclude-filtered hook."""
+            pass
 
         hook_exclude = before_call
 
-        ctx_include = _make_hook_context("opInclude")
-        ctx_exclude = _make_hook_context("opExclude")
-        ctx_other = _make_hook_context("opOther")
+        ctx_include = HookContext(operation=_build_operation(ctx, "opInclude", "/include"))
+        ctx_exclude = HookContext(operation=_build_operation(ctx, "opExclude", "/exclude"))
+        ctx_other = HookContext(operation=_build_operation(ctx, "opOther", "/other"))
 
         # hook_include: runs only for opInclude
         assert not _should_skip_hook(hook_include, ctx_include)

--- a/test/hooks/test_filters.py
+++ b/test/hooks/test_filters.py
@@ -1,9 +1,12 @@
+from types import SimpleNamespace
+
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
 import schemathesis
 from schemathesis.generation import GenerationMode
+from schemathesis.hooks import HookContext, _should_skip_hook
 from schemathesis.specs.openapi.negative import GeneratedValue
 
 
@@ -181,3 +184,85 @@ def test_filter_body_works_in_negative_mode(ctx):
         assert not isinstance(case.body, bytes)
 
     inner()
+
+
+def _make_hook_context(operation_id):
+    """Build a minimal HookContext whose operation carries the given operationId."""
+    operation = SimpleNamespace(
+        definition=SimpleNamespace(raw={"operationId": operation_id}),
+        label=operation_id,
+        method="POST",
+        path=f"/fake/{operation_id}",
+        tags=[],
+    )
+    return HookContext(operation=operation)
+
+
+def test_multiple_apply_to_have_distinct_filters(ctx):
+    """Hooks registered with different apply_to filters must each receive their own filter_set.
+
+    Regression: a bug in to_filterable_hook caused the outer ``filter_set``
+    variable to go stale after the first registration, so every subsequent hook
+    was silently assigned the *first* hook's filter_set.
+    """
+    with ctx.restore_hooks():
+
+        @schemathesis.hook.apply_to(operation_id="operationA")
+        def before_call(context, case, **kwargs):
+            """Hook for operation A."""
+
+        hook_a = before_call
+
+        @schemathesis.hook.apply_to(operation_id="operationB")
+        def before_call(context, case, **kwargs):  # noqa: F811
+            """Hook for operation B."""
+
+        hook_b = before_call
+
+        # Each hook must carry its own, distinct filter_set
+        assert hook_a.filter_set is not hook_b.filter_set
+
+        ctx_a = _make_hook_context("operationA")
+        ctx_b = _make_hook_context("operationB")
+        ctx_other = _make_hook_context("operationC")
+
+        # hook_a should run for operationA only
+        assert not _should_skip_hook(hook_a, ctx_a)
+        assert _should_skip_hook(hook_a, ctx_b)
+        assert _should_skip_hook(hook_a, ctx_other)
+
+        # hook_b should run for operationB only
+        assert _should_skip_hook(hook_b, ctx_a)
+        assert not _should_skip_hook(hook_b, ctx_b)
+        assert _should_skip_hook(hook_b, ctx_other)
+
+
+def test_multiple_apply_to_with_skip_for(ctx):
+    """Mixing apply_to and skip_for across multiple hooks must keep filters independent."""
+    with ctx.restore_hooks():
+
+        @schemathesis.hook.apply_to(operation_id="opInclude")
+        def before_call(context, case, **kwargs):
+            """Include-filtered hook."""
+
+        hook_include = before_call
+
+        @schemathesis.hook.skip_for(operation_id="opExclude")
+        def before_call(context, case, **kwargs):  # noqa: F811
+            """Exclude-filtered hook."""
+
+        hook_exclude = before_call
+
+        ctx_include = _make_hook_context("opInclude")
+        ctx_exclude = _make_hook_context("opExclude")
+        ctx_other = _make_hook_context("opOther")
+
+        # hook_include: runs only for opInclude
+        assert not _should_skip_hook(hook_include, ctx_include)
+        assert _should_skip_hook(hook_include, ctx_exclude)
+        assert _should_skip_hook(hook_include, ctx_other)
+
+        # hook_exclude: runs for everything EXCEPT opExclude
+        assert not _should_skip_hook(hook_exclude, ctx_include)
+        assert _should_skip_hook(hook_exclude, ctx_exclude)
+        assert not _should_skip_hook(hook_exclude, ctx_other)


### PR DESCRIPTION
### Description

When multiple hooks are registered via `schemathesis.hook.apply_to()` with different filters, only the first hook receives the correct filter_set. All subsequent hooks silently inherit the first hook's filter, causing them to fire for the wrong operations.

#### Root Cause

In `to_filterable_hook` (src/schemathesis/hooks.py), the register closure captures `filter_set` via `nonlocal`. After registering a hook, `init_filter_set(register)` is called to prepare fresh state for the next registration — it creates a new `FilterSet` and attaches new include/exclude closures to `register.apply_to/register.skip_for`. However, the return value was discarded:

  hook.filter_set = filter_set          # assigns current (stale) outer filter_set
  init_filter_set(register)             # creates new FilterSet locally, return value ignored

Because `init_filter_set` creates the new `FilterSet` as a local variable (no nonlocal `filter_set`), the outer `filter_set` that register references is never updated. The next `apply_to` call correctly populates the new `FilterSet` (via the replaced include closure), but `register` then assigns the old one to the hook.

#### Fix

One-liner: capture the return value so the outer `filter_set` stays in sync.

### Checklist

- [x] Added failing tests for the change
- [x] All new and existing tests pass
- [x] Added changelog entry
- [x] Updated README/documentation, if necessary (not needed)
