### PR TITLE
fix: Base URL truncated with an ellipsis in the startup summary on narrow terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### :bug: Fixed
 
 - `apply_to` / `skip_for` filter sets not updated between hook registrations, causing hooks registered after the first to silently receive the wrong filter set.
+- Base URL truncated with an ellipsis in the startup summary on narrow terminals (e.g. CI environments). [#3618](https://github.com/schemathesis/schemathesis/issues/3618)
 
 ## [4.12.2](https://github.com/schemathesis/schemathesis/compare/v4.12.1...v4.12.2) - 2026-03-19
 

--- a/src/schemathesis/cli/commands/run/handlers/output.py
+++ b/src/schemathesis/cli/commands/run/handlers/output.py
@@ -775,7 +775,7 @@ class OutputHandler(EventHandler):
             collapse_padding=True,
         )
         table.add_column("Field", style=Style(color="bright_white", bold=True))
-        table.add_column("Value", style="cyan")
+        table.add_column("Value", style="cyan", overflow="fold")
 
         table.add_row("Base URL:", event.base_url)
         table.add_row("Specification:", event.specification.name)

--- a/test/cli/test_config_display.py
+++ b/test/cli/test_config_display.py
@@ -1,3 +1,17 @@
+import click
+
+
+def test_base_url_not_truncated_on_narrow_terminal(ctx, cli):
+    schema_path = ctx.openapi.write_schema({})
+    long_url = "https://internal.staging.example.com/api/v3/internal/prefix/of/something-very-long"
+    result = cli.run(
+        str(schema_path),
+        f"--url={long_url}",
+        env={"PYTEST_VERSION": None, "COLUMNS": "80"},
+    )
+    assert long_url in "".join(click.unstyle(result.output).split())
+
+
 def test_cli_displays_config_path(ctx, cli, openapi3_base_url, snapshot_cli):
     # Create schema file
     schema_path = ctx.openapi.write_schema(


### PR DESCRIPTION
Fixes #3618