### PR TITLE
fix(corpus): switch to safe_load in tools

### DIFF
--- a/corpus/tools.py
+++ b/corpus/tools.py
@@ -99,7 +99,7 @@ def parse_schemas(directory: pathlib.Path) -> dict[str, dict[str, Any]]:
                 file_path = os.path.join(root, file)
                 try:
                     with open(file_path) as fd:
-                        schema = yaml.load(fd, Loader)
+                        schema = yaml.safe_load(fd, Loader)
                     version = get_schema_version(schema)
                     schema_name = (
                         os.path.relpath(file_path, directory)


### PR DESCRIPTION
Was going through corpus/tools.py and this caught my eye.

**What's going on:** yaml.load() without a safe loader can instantiate arbitrary Python objects from the YAML content. Switched to safe_load() which only allows basic types.

**Why it matters:** This is a security concern that could be exploited in production.

Feel free to tweak the approach if needed.