### PR TITLE
fix: Validate length constraints after regex-based string generation …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - `apply_to` / `skip_for` filter sets not updated between hook registrations, causing hooks registered after the first to silently receive the wrong filter set.
 - Base URL truncated with an ellipsis in the startup summary on narrow terminals (e.g. CI environments). [#3618](https://github.com/schemathesis/schemathesis/issues/3618)
+- Generated strings from regex patterns violating `minLength`/`maxLength` constraints in the coverage phase when `update_quantifier` cannot encode length into the pattern.
 
 ## [4.12.2](https://github.com/schemathesis/schemathesis/compare/v4.12.1...v4.12.2) - 2026-03-19
 

--- a/src/schemathesis/generation/coverage.py
+++ b/src/schemathesis/generation/coverage.py
@@ -402,11 +402,16 @@ class CoverageContext:
                 re.compile(pattern)
             except re.error:
                 raise Unsatisfiable from None
-            if "minLength" in schema or "maxLength" in schema:
-                min_length = schema.get("minLength")
-                max_length = schema.get("maxLength")
+            min_length = schema.get("minLength")
+            max_length = schema.get("maxLength")
+            if min_length is not None or max_length is not None:
                 pattern = update_quantifier(pattern, min_length, max_length)
-            return cached_draw(st.from_regex(pattern))
+            strategy = st.from_regex(pattern)
+            if min_length is not None:
+                strategy = strategy.filter(lambda s: len(s) >= min_length)
+            if max_length is not None:
+                strategy = strategy.filter(lambda s: len(s) <= max_length)
+            return cached_draw(strategy)
         if (keys == ["items", "type"] or keys == ["items", "minItems", "type"]) and isinstance(schema["items"], dict):
             items = schema["items"]
             min_items = schema.get("minItems", 0)

--- a/src/schemathesis/generation/coverage.py
+++ b/src/schemathesis/generation/coverage.py
@@ -407,9 +407,11 @@ class CoverageContext:
             if min_length is not None or max_length is not None:
                 pattern = update_quantifier(pattern, min_length, max_length)
             strategy = st.from_regex(pattern)
-            if min_length is not None:
+            if min_length is not None and max_length is not None:
+                strategy = strategy.filter(lambda s: min_length <= len(s) <= max_length)
+            elif min_length is not None:
                 strategy = strategy.filter(lambda s: len(s) >= min_length)
-            if max_length is not None:
+            elif max_length is not None:
                 strategy = strategy.filter(lambda s: len(s) <= max_length)
             return cached_draw(strategy)
         if (keys == ["items", "type"] or keys == ["items", "minItems", "type"]) and isinstance(schema["items"], dict):

--- a/src/schemathesis/generation/coverage.py
+++ b/src/schemathesis/generation/coverage.py
@@ -406,7 +406,7 @@ class CoverageContext:
             max_length = schema.get("maxLength")
             if min_length is not None or max_length is not None:
                 pattern = update_quantifier(pattern, min_length, max_length)
-            strategy = st.from_regex(pattern)
+            strategy = st.from_regex(pattern, fullmatch=True)
             if min_length is not None and max_length is not None:
                 strategy = strategy.filter(lambda s: min_length <= len(s) <= max_length)
             elif min_length is not None:
@@ -1194,35 +1194,38 @@ def _positive_string(ctx: CoverageContext, schema: JsonSchemaObject) -> Generato
         key = (min_length, min_length)
         if key not in seen_constraints:
             seen_constraints.add(key)
-            value = ctx.generate_from_schema({**schema, "maxLength": min_length})
-            if seen_values.insert(value):
-                yield PositiveValue(
-                    value, scenario=CoverageScenario.MINIMUM_LENGTH_STRING, description="Minimum length string"
-                )
+            with _ignore_unfixable():
+                value = ctx.generate_from_schema({**schema, "maxLength": min_length})
+                if seen_values.insert(value):
+                    yield PositiveValue(
+                        value, scenario=CoverageScenario.MINIMUM_LENGTH_STRING, description="Minimum length string"
+                    )
 
         # One character more than minimum if possible
         larger = min_length + 1
         key = (larger, larger)
         if larger < INTERNAL_BUFFER_SIZE and key not in seen_constraints and (not max_length or larger <= max_length):
             seen_constraints.add(key)
-            value = ctx.generate_from_schema({**schema, "minLength": larger, "maxLength": larger})
-            if seen_values.insert(value):
-                yield PositiveValue(
-                    value,
-                    scenario=CoverageScenario.NEAR_BOUNDARY_LENGTH_STRING,
-                    description="Near-boundary length string",
-                )
+            with _ignore_unfixable():
+                value = ctx.generate_from_schema({**schema, "minLength": larger, "maxLength": larger})
+                if seen_values.insert(value):
+                    yield PositiveValue(
+                        value,
+                        scenario=CoverageScenario.NEAR_BOUNDARY_LENGTH_STRING,
+                        description="Near-boundary length string",
+                    )
 
     if max_length is not None:
         # Exactly the maximum length
         key = (max_length, max_length)
         if max_length < INTERNAL_BUFFER_SIZE and key not in seen_constraints:
             seen_constraints.add(key)
-            value = ctx.generate_from_schema({**schema, "minLength": max_length, "maxLength": max_length})
-            if seen_values.insert(value):
-                yield PositiveValue(
-                    value, scenario=CoverageScenario.MAXIMUM_LENGTH_STRING, description="Maximum length string"
-                )
+            with _ignore_unfixable():
+                value = ctx.generate_from_schema({**schema, "minLength": max_length, "maxLength": max_length})
+                if seen_values.insert(value):
+                    yield PositiveValue(
+                        value, scenario=CoverageScenario.MAXIMUM_LENGTH_STRING, description="Maximum length string"
+                    )
 
         # One character less than maximum if possible
         smaller = max_length - 1
@@ -1233,13 +1236,14 @@ def _positive_string(ctx: CoverageContext, schema: JsonSchemaObject) -> Generato
             and (smaller > 0 and (min_length is None or smaller >= min_length))
         ):
             seen_constraints.add(key)
-            value = ctx.generate_from_schema({**schema, "minLength": smaller, "maxLength": smaller})
-            if seen_values.insert(value):
-                yield PositiveValue(
-                    value,
-                    scenario=CoverageScenario.NEAR_BOUNDARY_LENGTH_STRING,
-                    description="Near-boundary length string",
-                )
+            with _ignore_unfixable():
+                value = ctx.generate_from_schema({**schema, "minLength": smaller, "maxLength": smaller})
+                if seen_values.insert(value):
+                    yield PositiveValue(
+                        value,
+                        scenario=CoverageScenario.NEAR_BOUNDARY_LENGTH_STRING,
+                        description="Near-boundary length string",
+                    )
 
 
 def closest_multiple_greater_than(y: int, x: int) -> int:

--- a/test/coverage/test_combinations.py
+++ b/test/coverage/test_combinations.py
@@ -1110,6 +1110,16 @@ def test_positive_pattern(pctx):
     assert_conform(covered, schema)
 
 
+def test_positive_pattern_with_char_class_and_min_length(pctx):
+    # Regression: update_quantifier can't encode minLength into patterns with bare
+    # character classes like [a-z] (IN opcode). The .filter() safety net ensures
+    # generated strings still respect minLength.
+    schema = {"pattern": r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$", "minLength": 3, "type": "string"}
+    covered = cover_schema(pctx, schema)
+    for value in covered:
+        assert len(value) >= 3, f"Generated string {value!r} violates minLength=3"
+
+
 def test_negative_pattern_with_incompatible_length(nctx):
     schema = {
         "minLength": 6,


### PR DESCRIPTION
Description

Update_quantifier cannot encode minLength/maxLength into regex quantifiers for patterns with bare character classes (IN opcode), e.g. ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ with minLength=3. The pattern is returned unchanged, so the coverage phase generates strings like "a" that violate the length constraint.

This adds .filter() on the st.from_regex() strategy to enforce minLength/maxLength after generation — the same approach hypothesis-jsonschema uses internally. update_quantifier is kept as a best-effort optimization to reduce the filter rejection rate. 

Checklist

[x] Added failing tests for the change
[x] All new and existing tests pass
[x] Added changelog entry
[ ] Updated README/documentation, if necessary

