### PR TITLE
chore: Suppress `HypothesisWarning` when overriding built-in string formats via `schemathesis.openapi.format()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Examples phase generates optional properties and one disjoint set per `oneOf`/`anyOf` branch. [#2371](https://github.com/schemathesis/schemathesis/issues/2371)
 
+### :wrench: Changed
+
+- Suppress `HypothesisWarning` when overriding built-in string formats via `schemathesis.openapi.format()`. [#3269](https://github.com/schemathesis/schemathesis/issues/3269)
+
 ## [4.13.0](https://github.com/schemathesis/schemathesis/compare/v4.12.2...v4.13.0) - 2026-03-22
 
 ### :rocket: Added

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,36 @@
 # Frequently Asked Questions
 
+## How do I restrict the range of generated values?
+
+Schemathesis generates values across the full range permitted by the spec — including far-future dates, large integers, and unusual Unicode characters. This is intentional: servers that crash on extreme-but-valid input have real bugs. If your application already handles those cases correctly and you want to reduce noise, there are three levers:
+
+**Restrict a string format** — override the built-in strategy for any `format` keyword:
+
+```python
+from datetime import date
+from hypothesis import strategies as st
+import schemathesis
+
+today = date.today()
+schemathesis.openapi.format("date", st.dates(max_value=today).map(str))
+```
+
+See [Overriding built-in formats](guides/extending.md#overriding-built-in-formats) for more detail.
+
+**Restrict the string character set** — limit generated strings to a specific encoding, which also constrains the range of code points:
+
+```toml
+[generation]
+codec = "ascii"
+```
+
+**Disable null bytes** — some systems mishandle the `\x00` byte, causing spurious failures unrelated to your application logic:
+
+```toml
+[generation]
+allow-x00 = false
+```
+
 ## What kind of data does Schemathesis generate?
 
 Schemathesis generates three types of data:

--- a/docs/guides/extending.md
+++ b/docs/guides/extending.md
@@ -154,6 +154,21 @@ user_phone:
   format: phone  # Uses your custom strategy
 ```
 
+### Overriding built-in formats
+
+The same API overrides standard formats like `date`, `date-time`, `uuid`, and others. By default Schemathesis generates values across the full valid range — including far-future dates and extreme integers — which is intentional: many server-side bugs only surface when the input isn't sanitised before hitting a database or arithmetic operation. If your application already handles those cases and the out-of-range values are producing noise, restrict the range:
+
+```python
+from datetime import date
+from hypothesis import strategies as st
+import schemathesis
+
+today = date.today()
+schemathesis.openapi.format("date", st.dates(max_value=today).map(str))
+```
+
+After this registration, every `format: date` field in the schema draws from the restricted strategy instead of the built-in one.
+
 ## Setting Up Extensions
 
 Define your hooks:

--- a/src/schemathesis/generation/hypothesis/__init__.py
+++ b/src/schemathesis/generation/hypothesis/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections import OrderedDict
 from functools import lru_cache
 from typing import Any, Literal
@@ -210,7 +211,9 @@ def setup() -> None:
             if cached is not None:
                 return cached
 
-        strategy = _original_from_schema(schema, alphabet=alphabet, custom_formats=custom_formats)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Overriding standard format", category=Warning)
+            strategy = _original_from_schema(schema, alphabet=alphabet, custom_formats=custom_formats)
 
         if key is not None:
             _from_schema_cache_set(key, strategy)

--- a/test/specs/openapi/test_hypothesis.py
+++ b/test/specs/openapi/test_hypothesis.py
@@ -1,3 +1,5 @@
+import warnings
+from datetime import date
 from pathlib import Path
 
 import jsonschema_rs
@@ -497,6 +499,43 @@ def test_unregister_string_format_valid():
 def test_unregister_string_format_invalid():
     with pytest.raises(ValueError, match="Unknown Open API format: unknown"):
         formats.unregister_string_format("unknown")
+
+
+@pytest.mark.hypothesis_nested
+def test_builtin_format_override(ctx):
+    # See GH-3269
+    # When a built-in format is overridden with a custom strategy
+    today = date.today()
+    schemathesis.openapi.format("date", st.dates(max_value=today).map(str))
+    raw_schema = ctx.openapi.build_schema(
+        {
+            "/events": {
+                "get": {
+                    "parameters": [
+                        {
+                            "name": "start_date",
+                            "in": "query",
+                            "required": True,
+                            "schema": {"type": "string", "format": "date"},
+                        }
+                    ],
+                    "responses": {"200": {"description": "OK"}},
+                }
+            }
+        }
+    )
+    schema = schemathesis.openapi.from_dict(raw_schema)
+    operation = schema["/events"]["GET"]
+
+    @given(case=operation.as_strategy())
+    @settings(max_examples=20, deadline=None)
+    def inner(case):
+        # Then all generated values respect the override
+        assert date.fromisoformat(case.query["start_date"]) <= today
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        inner()
 
 
 @pytest.mark.hypothesis_nested


### PR DESCRIPTION
Resolves #3269 