### PR TITLE
fix: `allow-extra-parameters = false` now also suppresses unexpected properties in request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - `format: email` fields generating values rejected by `jsonschema_rs` response validation.
 - `flatmap_*` hooks raising `RuntimeError` in negative testing mode. [#3652](https://github.com/schemathesis/schemathesis/issues/3652)
+- `allow-extra-parameters = false` now also suppresses unexpected properties in request bodies.
 - Stateful checks (e.g. `use_after_free`) not triggering when run via `schema.as_state_machine()`.
 - `InvalidSchema` exceptions displayed an empty message in `pytest` output.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1103,7 +1103,7 @@ The following settings control how Schemathesis generates test data for your API
     **Type:** `Boolean`  
     **Default:** `true`  
 
-Controls whether Schemathesis produces unexpected query, header, or cookie parameters. Leave it enabled (default) to exercise `additionalProperties: false`; set it to `false` to skip generating those extras entirely.
+Controls whether Schemathesis produces unexpected query, header, cookie, or body parameters. Leave it enabled (default) to exercise `additionalProperties: false`; set it to `false` to skip generating those extras entirely.
 
     ```toml
     [generation]

--- a/src/schemathesis/generation/coverage.py
+++ b/src/schemathesis/generation/coverage.py
@@ -942,6 +942,7 @@ def cover_schema_iter(
                             ParameterLocation.QUERY,
                             ParameterLocation.HEADER,
                             ParameterLocation.COOKIE,
+                            ParameterLocation.BODY,
                         ):
                             continue
                         template = template or ctx.generate_from_schema(_get_template_schema(schema, "object"))

--- a/test/coverage/test_combinations.py
+++ b/test/coverage/test_combinations.py
@@ -196,6 +196,26 @@ def test_query_unexpected_parameters_control(ctx_factory, allow_extra_parameters
         assert CoverageScenario.OBJECT_UNEXPECTED_PROPERTIES not in scenarios
 
 
+@pytest.mark.parametrize("allow_extra_parameters", [True, False])
+def test_body_unexpected_parameters_control(ctx_factory, allow_extra_parameters):
+    schema = {
+        "type": "object",
+        "properties": {"token": {"type": "string"}},
+        "required": ["token"],
+        "additionalProperties": False,
+    }
+    ctx = ctx_factory(
+        location=ParameterLocation.BODY,
+        generation_modes=[GenerationMode.NEGATIVE],
+        allow_extra_parameters=allow_extra_parameters,
+    )
+    scenarios = {value.scenario for value in cover_schema_iter(ctx, schema) if isinstance(value, GeneratedValue)}
+    if allow_extra_parameters:
+        assert CoverageScenario.OBJECT_UNEXPECTED_PROPERTIES in scenarios
+    else:
+        assert CoverageScenario.OBJECT_UNEXPECTED_PROPERTIES not in scenarios
+
+
 @pytest.mark.parametrize(
     ("schema", "lengths"),
     [


### PR DESCRIPTION
Ref: https://github.com/schemathesis/schemathesis/discussions/3660