### PR TITLE
fix: `format: uuid` now generates RFC 4122 compliant UUIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### :bug: Fixed
 
 - `deadline=None` lost when `@settings` applied after `@lazy_schema.parametrize()`.
+- `format: uuid` now generates RFC 4122 compliant UUIDs. [#2909](https://github.com/schemathesis/schemathesis/issues/2909)
 
 ## [4.14.2](https://github.com/schemathesis/schemathesis/compare/v4.14.1...v4.14.2) - 2026-03-28
 

--- a/src/schemathesis/specs/openapi/formats.py
+++ b/src/schemathesis/specs/openapi/formats.py
@@ -156,7 +156,7 @@ def get_default_format_strategies() -> dict[str, st.SearchStrategy]:
         "binary": st.binary().map(Binary),
         "byte": st.binary().map(lambda x: b64encode(x).decode()),
         "duration": duration_values(),
-        "uuid": st.uuids().map(str),
+        "uuid": st.one_of(st.uuids(version=v) for v in [1, 2, 3, 4, 5]).map(str),
         # RFC 7230, Section 3.2.6
         "_header_name": st.text(
             min_size=1, alphabet=st.sampled_from("!#$%&'*+-.^_`|~" + string.digits + string.ascii_letters)

--- a/test/specs/openapi/test_examples.py
+++ b/test/specs/openapi/test_examples.py
@@ -2442,7 +2442,7 @@ def test_anyof_with_required_constraints(ctx):
     # Two examples produced - one per branch, each with the shared `type` field plus the branch field
     assert extracted == [
         {"media_type": "application/json", "value": {"type": "item", "name": ""}},
-        {"media_type": "application/json", "value": {"type": "item", "id": "e3e70682-c209-4cac-629f-6fbed82c07cd"}},
+        {"media_type": "application/json", "value": {"type": "item", "id": "e3e70682-c209-1cac-a29f-6fbed82c07cd"}},
     ]
 
     body_schema = list(operation.body)[0].optimized_schema

--- a/test/specs/openapi/test_hypothesis.py
+++ b/test/specs/openapi/test_hypothesis.py
@@ -1,3 +1,4 @@
+import uuid
 import warnings
 from datetime import date
 from pathlib import Path
@@ -766,3 +767,10 @@ def test_api(case):
     )
     result = testdir.runpytest("-v", "-s")
     result.assert_outcomes(passed=1)
+
+
+@given(st.data())
+@settings(max_examples=50)
+def test_uuid_format_is_rfc4122(data):
+    value = data.draw(formats.get_default_format_strategies()["uuid"])
+    assert uuid.UUID(value).variant == uuid.RFC_4122


### PR DESCRIPTION
Fixes #2909 