### PR TITLE
chore: pytest plugin now uses native subtest status labels without redundant parameter suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### :wrench: Changed
 
 - `--wait-for-schema` now retries on HTTP 503 responses. [#3672](https://github.com/schemathesis/schemathesis/issues/3672)
+- pytest plugin now uses native subtest status labels (`SUBPASSED`, `SUBFAILED`) without redundant parameter suffixes.
 
 ## [4.14.3](https://github.com/schemathesis/schemathesis/compare/v4.14.2...v4.14.3) - 2026-03-31
 

--- a/docs/explanations/pytest.md
+++ b/docs/explanations/pytest.md
@@ -78,6 +78,9 @@ def test_api(case):
 - **Test output:** Uses pytest subtests instead of parametrization
 - **Fixture support:** Schema can depend on other pytest fixtures
 
+!!! note "`--collect-only` shows one item per test function"
+    Because operations are discovered lazily at runtime, `--collect-only` cannot enumerate them upfront - this is by design.
+
 ## Error Handling and Reporting
 
 Failures from multiple Hypothesis examples are deduplicated, grouped by operation, and include reproduction steps for debugging:

--- a/src/schemathesis/pytest/plugin.py
+++ b/src/schemathesis/pytest/plugin.py
@@ -52,7 +52,6 @@ from schemathesis.schemas import APIOperation
 
 if TYPE_CHECKING:
     from _pytest.fixtures import FuncFixtureInfo
-    from _pytest.terminal import TerminalReporter
 
     from schemathesis.engine.recorder import ScenarioRecorder
     from schemathesis.pytest.reporting import PytestReportDispatcher
@@ -297,22 +296,6 @@ def pytest_pycollect_makeitem(collector: nodes.Collector, name: str, obj: Any) -
         outcome.get_result()
 
 
-@hookimpl(tryfirst=True)  # type: ignore[untyped-decorator]
-def pytest_runtest_logreport(report: pytest.TestReport) -> None:
-    if isinstance(report, SubtestReport) and report.passed:
-        report._schemathesis_ignore_in_summary = True
-
-
-@hookimpl(tryfirst=True, hookwrapper=True)  # type: ignore[untyped-decorator]
-def pytest_terminal_summary(terminalreporter: TerminalReporter) -> Generator[None, None, None]:
-    passed = terminalreporter.stats.get("passed", [])
-    if passed:
-        terminalreporter.stats["passed"] = [
-            report for report in passed if not getattr(report, "_schemathesis_ignore_in_summary", False)
-        ]
-    yield
-
-
 @hookimpl(hookwrapper=True, trylast=True)  # type: ignore[untyped-decorator]
 def pytest_report_teststatus(
     report: pytest.TestReport,
@@ -322,15 +305,14 @@ def pytest_report_teststatus(
     result = cast(PluggyResult[tuple[str, str, str] | None], outcome)
     if not isinstance(report, SubtestReport):
         return
-
-    description = report._sub_test_description()
-
-    if report.passed:
-        result.force_result(("passed", ",", f"{description} SUBPASS"))
-    elif report.skipped:
-        result.force_result(("skipped", "-", f"{description} SUBSKIP"))
-    elif report.outcome == "failed":
-        result.force_result(("failed", "u", f"{description} SUBFAIL"))
+    r = result.get_result()
+    if r is not None:
+        category, short, verbose = r
+        if isinstance(verbose, str):
+            for prefix in ("SUBPASSED", "SUBFAILED", "SUBSKIPPED", "SUBXFAIL"):
+                if verbose.startswith(prefix):
+                    result.force_result((category, short, prefix))
+                    break
 
 
 @pytest.hookimpl(tryfirst=True)  # type: ignore[untyped-decorator]

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -104,9 +104,9 @@ def test_(request, case):
     result.assert_outcomes(passed=1, failed=1)
     result.stdout.re_match_lines(
         [
-            r"test_invalid_operation.py::test_\[GET /valid\] \(label='GET /valid'\) SUBPASS +\[ 25%\]",
-            r"test_invalid_operation.py::test_\[GET /invalid\] \(label='GET /invalid'\) SUBFAIL +\[ 50%\]",
-            r"test_invalid_operation.py::test_\[GET /users\] \(label='GET /users'\) SUBPASS +\[ 75%\]",
+            r"test_invalid_operation.py::test_\[GET /valid\] SUBPASSED +\[ 25%\]",
+            r"test_invalid_operation.py::test_\[GET /invalid\] SUBFAILED +\[ 50%\]",
+            r"test_invalid_operation.py::test_\[GET /users\] SUBPASSED +\[ 75%\]",
             r"test_invalid_operation.py::test_ PASSED +\[100%\]",
         ]
     )
@@ -353,8 +353,8 @@ def test_(case):
     result.assert_outcomes(passed=2)
     result.stdout.re_match_lines(
         [
-            r"test_parametrized_fixture.py::test_\[a\]\[GET /users\] \(label='GET /users'\) SUBPASS +\[ 33%\]",
-            r"test_parametrized_fixture.py::test_\[b\]\[GET /users\] \(label='GET /users'\) SUBPASS +\[ 75%\]",
+            r"test_parametrized_fixture.py::test_\[a\]\[GET /users\] SUBPASSED +\[ 33%\]",
+            r"test_parametrized_fixture.py::test_\[b\]\[GET /users\] SUBPASSED +\[ 75%\]",
         ]
     )
 
@@ -410,7 +410,7 @@ def pytest_terminal_summary(terminalreporter) -> None:
     result = testdir.runpytest("-v")
     # And it should be the same test in the end
     # We do not assert the outcome here, because it is not reported.
-    result.stdout.re_match_lines([r"test_generation_modes.py::test_\[GET /users\] \(label='GET /users'\) SUBPASS"])
+    result.stdout.re_match_lines([r"test_generation_modes.py::test_\[GET /users\] SUBPASSED"])
 
 
 def test_error_on_no_matches(testdir):

--- a/test/test_recoverable_errors.py
+++ b/test/test_recoverable_errors.py
@@ -60,11 +60,11 @@ def test_(case):
     result.stdout.re_match_lines(
         [
             # Path-level error. no method is displayed
-            r".*test_\[/foo\] \(path='/foo'\) SUBFAIL",
+            r".*test_\[/foo\] SUBFAILED",
             # Valid operation
-            r".*test_\[GET /bar\] \(label='GET /bar'\) SUBPASS",
+            r".*test_\[GET /bar\] SUBPASSED",
             # Operation-level error
-            r".*test_\[POST /bar\] \(method='POST', path='/bar'\) SUBFAIL",
+            r".*test_\[POST /bar\] SUBFAILED",
             # The error in both failing cases
             ".*Unresolvable reference in the schema.*",
         ]


### PR DESCRIPTION
Also documents the `--collect-only` limitation. Closes #636 