### PR TITLE
feat: Pin `discriminator` property to the correct value when generating data for `oneOf`/`anyOf` schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Apply `filter_case` and `map_case` hooks in the coverage phase. [#3675](https://github.com/schemathesis/schemathesis/discussions/3675)
 - `schemathesis.pytest.parametrize()` for testing multiple named schemas in a single test function. [#1409](https://github.com/schemathesis/schemathesis/issues/1409)
 - Validate `discriminator` property values against known schema mappings in `response_schema_conformance`. [#1589](https://github.com/schemathesis/schemathesis/issues/1589)
+- Pin `discriminator` property to the correct value when generating data for `oneOf`/`anyOf` schemas. [#1589](https://github.com/schemathesis/schemathesis/issues/1589)
 
 ### :wrench: Changed
 

--- a/src/schemathesis/specs/openapi/adapter/parameters.py
+++ b/src/schemathesis/specs/openapi/adapter/parameters.py
@@ -315,6 +315,7 @@ class OpenApiComponent(ABC):
             upgrade_legacy_exclusive_bounds=(
                 self.adapter.jsonschema_validator_cls is jsonschema_rs.Draft202012Validator
             ),
+            name_to_uri=self.name_to_uri,
         )
 
         # Missing the `type` keyword may significantly slowdown data generation, ensure it is set

--- a/src/schemathesis/specs/openapi/converter.py
+++ b/src/schemathesis/specs/openapi/converter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, overload
 
-from schemathesis.core.jsonschema.bundler import BUNDLE_STORAGE_KEY
+from schemathesis.core.jsonschema.bundler import BUNDLE_STORAGE_KEY, REFERENCE_TO_BUNDLE_PREFIX
 from schemathesis.core.jsonschema.types import JsonSchema
 from schemathesis.core.transforms import deepclone
 from schemathesis.specs.openapi.patterns import is_valid_python_regex, normalize_regex, update_quantifier
@@ -17,6 +17,7 @@ def to_json_schema(
     update_quantifiers: bool = True,
     clone: bool = True,
     upgrade_legacy_exclusive_bounds: bool = False,
+    name_to_uri: dict[str, str] | None = None,
 ) -> dict[str, Any]: ...  # pragma: no cover
 
 
@@ -28,6 +29,7 @@ def to_json_schema(
     update_quantifiers: bool = True,
     clone: bool = True,
     upgrade_legacy_exclusive_bounds: bool = False,
+    name_to_uri: dict[str, str] | None = None,
 ) -> bool: ...  # pragma: no cover
 
 
@@ -38,6 +40,7 @@ def to_json_schema(
     update_quantifiers: bool = True,
     clone: bool = True,
     upgrade_legacy_exclusive_bounds: bool = False,
+    name_to_uri: dict[str, str] | None = None,
 ) -> dict[str, Any] | bool:
     if isinstance(schema, bool):
         return schema
@@ -49,6 +52,7 @@ def to_json_schema(
         is_response_schema=is_response_schema,
         update_quantifiers=update_quantifiers,
         upgrade_legacy_exclusive_bounds=upgrade_legacy_exclusive_bounds,
+        name_to_uri=name_to_uri,
     )
 
 
@@ -59,6 +63,7 @@ def _to_json_schema(
     is_response_schema: bool = False,
     update_quantifiers: bool = True,
     upgrade_legacy_exclusive_bounds: bool = False,
+    name_to_uri: dict[str, str] | None = None,
 ) -> JsonSchema:
     if isinstance(schema, bool):
         return schema
@@ -130,6 +135,9 @@ def _to_json_schema(
             schema["additionalItems"] = schema.pop("items")
         schema["items"] = prefix_items
 
+    if not is_response_schema:
+        _inject_discriminator_consts(schema, name_to_uri)
+
     for keyword, value in schema.items():
         if keyword in IN_VALUE and isinstance(value, dict):
             schema[keyword] = _to_json_schema(
@@ -138,6 +146,7 @@ def _to_json_schema(
                 is_response_schema=is_response_schema,
                 update_quantifiers=update_quantifiers,
                 upgrade_legacy_exclusive_bounds=upgrade_legacy_exclusive_bounds,
+                name_to_uri=name_to_uri,
             )
         elif keyword in IN_ITEM and isinstance(value, list):
             for idx, subschema in enumerate(value):
@@ -147,6 +156,7 @@ def _to_json_schema(
                     is_response_schema=is_response_schema,
                     update_quantifiers=update_quantifiers,
                     upgrade_legacy_exclusive_bounds=upgrade_legacy_exclusive_bounds,
+                    name_to_uri=name_to_uri,
                 )
         elif keyword in IN_CHILD and isinstance(value, dict):
             for name, subschema in value.items():
@@ -156,9 +166,50 @@ def _to_json_schema(
                     is_response_schema=is_response_schema,
                     update_quantifiers=update_quantifiers,
                     upgrade_legacy_exclusive_bounds=upgrade_legacy_exclusive_bounds,
+                    name_to_uri=name_to_uri,
                 )
 
     return schema
+
+
+def _inject_discriminator_consts(schema: dict[str, Any], name_to_uri: dict[str, str] | None) -> None:
+    """Pin the discriminator property to its expected value in each oneOf/anyOf branch.
+
+    When a schema has a `discriminator`, each branch in oneOf/anyOf is wrapped in
+    `allOf` with a `const` constraint on the discriminator property. This ensures
+    hypothesis-jsonschema generates the correct discriminator value for each branch.
+    """
+    discriminator = schema.get("discriminator")
+    if not isinstance(discriminator, dict):
+        return
+    property_name = discriminator.get("propertyName")
+    if not property_name:
+        return
+    explicit_mapping: dict[str, str] = discriminator.get("mapping") or {}
+    ref_to_value = {ref: value for value, ref in explicit_mapping.items()}
+
+    for keyword in ("anyOf", "oneOf"):
+        items = schema.get(keyword)
+        if not isinstance(items, list):
+            continue
+        for idx, item in enumerate(items):
+            if not isinstance(item, dict):
+                continue
+            ref = item.get("$ref")
+            if not isinstance(ref, str):
+                continue
+            # Resolve bundled ref (e.g. "#/x-bundled/schema1") back to original URI for schema name extraction
+            resolved_ref = ref
+            if name_to_uri and ref.startswith(f"{REFERENCE_TO_BUNDLE_PREFIX}/"):
+                bundled_name = ref[len(REFERENCE_TO_BUNDLE_PREFIX) + 1 :]
+                original_uri = name_to_uri.get(bundled_name, "")
+                if "#" in original_uri:
+                    resolved_ref = "#" + original_uri.split("#", 1)[1]
+            # Look up explicit mapping first, then fall back to schema name from ref path
+            disc_value = ref_to_value.get(resolved_ref) or resolved_ref.rstrip("/").rsplit("/", 1)[-1]
+            if not disc_value:
+                continue
+            items[idx] = {"allOf": [item, {"properties": {property_name: {"const": disc_value}}}]}
 
 
 def _upgrade_legacy_exclusive_bounds(schema: dict[str, Any]) -> None:

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -2,7 +2,7 @@ import pytest
 
 from schemathesis.core.transforms import transform
 from schemathesis.specs.openapi import converter
-from schemathesis.specs.openapi.converter import is_read_only, is_write_only, rewrite_properties
+from schemathesis.specs.openapi.converter import is_read_only, is_write_only, rewrite_properties, to_json_schema
 
 
 @pytest.mark.parametrize(
@@ -247,3 +247,80 @@ def test_nested_object_required_array_not_duplicated():
     result = transform(schema, converter.to_json_schema, nullable_keyword="nullable")
     assert result["required"] == ["propOne"]
     assert result["properties"]["propOne"]["required"] == ["innerPropOne"]
+
+
+@pytest.mark.parametrize(
+    ("schema", "expected"),
+    [
+        pytest.param(
+            {
+                "oneOf": [
+                    {"$ref": "#/components/schemas/Cat"},
+                    {"$ref": "#/components/schemas/Dog"},
+                ],
+                "discriminator": {"propertyName": "petType"},
+            },
+            {
+                "oneOf": [
+                    {"allOf": [{"$ref": "#/components/schemas/Cat"}, {"properties": {"petType": {"const": "Cat"}}}]},
+                    {"allOf": [{"$ref": "#/components/schemas/Dog"}, {"properties": {"petType": {"const": "Dog"}}}]},
+                ],
+                "discriminator": {"propertyName": "petType"},
+            },
+            id="implicit-mapping",
+        ),
+        pytest.param(
+            {
+                "anyOf": [
+                    {"$ref": "#/components/schemas/Cat"},
+                    {"$ref": "#/components/schemas/Dog"},
+                ],
+                "discriminator": {
+                    "propertyName": "petType",
+                    "mapping": {"feline": "#/components/schemas/Cat", "canine": "#/components/schemas/Dog"},
+                },
+            },
+            {
+                "anyOf": [
+                    {"allOf": [{"$ref": "#/components/schemas/Cat"}, {"properties": {"petType": {"const": "feline"}}}]},
+                    {"allOf": [{"$ref": "#/components/schemas/Dog"}, {"properties": {"petType": {"const": "canine"}}}]},
+                ],
+                "discriminator": {
+                    "propertyName": "petType",
+                    "mapping": {"feline": "#/components/schemas/Cat", "canine": "#/components/schemas/Dog"},
+                },
+            },
+            id="explicit-mapping",
+        ),
+        pytest.param(
+            {
+                "oneOf": [{"$ref": "#/components/schemas/Cat"}],
+                "discriminator": {},
+            },
+            {
+                "oneOf": [{"$ref": "#/components/schemas/Cat"}],
+                "discriminator": {},
+            },
+            id="no-property-name-skip",
+        ),
+        pytest.param(
+            {
+                "anyOf": [
+                    {"$ref": "#/components/schemas/Cat"},
+                    True,
+                ],
+                "discriminator": {"propertyName": "petType"},
+            },
+            {
+                "anyOf": [
+                    {"allOf": [{"$ref": "#/components/schemas/Cat"}, {"properties": {"petType": {"const": "Cat"}}}]},
+                    True,
+                ],
+                "discriminator": {"propertyName": "petType"},
+            },
+            id="boolean-schema-skipped",
+        ),
+    ],
+)
+def test_discriminator_const_injection(schema, expected):
+    assert to_json_schema(schema, nullable_keyword="nullable") == expected

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -728,6 +728,60 @@ def test_health_check_failed_large_base_example(ctx, cli, snapshot_cli, openapi3
     )
 
 
+@pytest.mark.parametrize(
+    ("discriminator", "valid_values"),
+    [
+        ({"propertyName": "petType"}, {"Cat", "Dog"}),
+        (
+            {
+                "propertyName": "petType",
+                "mapping": {"feline": "#/components/schemas/Cat", "canine": "#/components/schemas/Dog"},
+            },
+            {"feline", "canine", "Cat", "Dog"},
+        ),
+    ],
+    ids=["implicit", "explicit"],
+)
+def test_discriminator_const_injection_in_generation(ctx, discriminator, valid_values):
+    raw_schema = ctx.openapi.build_schema(
+        {
+            "/pets": {
+                "post": {
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "oneOf": [
+                                        {"$ref": "#/components/schemas/Cat"},
+                                        {"$ref": "#/components/schemas/Dog"},
+                                    ],
+                                    "discriminator": discriminator,
+                                }
+                            }
+                        },
+                    },
+                    "responses": {"200": {"description": "OK"}},
+                }
+            }
+        },
+        components={
+            "schemas": {
+                "Cat": {"type": "object", "properties": {"petType": {"type": "string"}}, "required": ["petType"]},
+                "Dog": {"type": "object", "properties": {"petType": {"type": "string"}}, "required": ["petType"]},
+            }
+        },
+    )
+    schema = schemathesis.openapi.from_dict(raw_schema)
+
+    @given(case=schema["/pets"]["POST"].as_strategy())
+    @settings(max_examples=10, database=None, phases=[Phase.generate])
+    def inner(case):
+        assert case.body["petType"] in valid_values
+
+    inner()
+
+
 def test_hypothesis_observability_serialization(ctx):
     # Hypothesis observability serializes all dataclass fields on generated values
     schema = ctx.openapi.build_schema({"/test": {"get": {"responses": {"200": {"description": "OK"}}}}})


### PR DESCRIPTION
Resolves #1589