### PR TITLE
fix: False positive `negative_data_rejection` for `type: number` body fields in fuzzing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.15.0...HEAD) - TBD
 
+### :bug: Fixed
+
+- False positive `negative_data_rejection` for `type: number` body fields in fuzzing. [#3697](https://github.com/schemathesis/schemathesis/issues/3697)
+
 ## [4.15.0](https://github.com/schemathesis/schemathesis/compare/v4.14.3...v4.15.0) - 2026-04-05
 
 ### :rocket: Added

--- a/src/schemathesis/specs/openapi/negative/mutations.py
+++ b/src/schemathesis/specs/openapi/negative/mutations.py
@@ -365,6 +365,9 @@ def _get_type_candidates(ctx: MutationContext, schema: Schema) -> set[str]:
     if "integer" in types and "number" in candidates:
         # Do not change "integer" to "number" as any integer is also a number
         candidates.remove("number")
+    if "number" in types and "integer" in candidates:
+        # Do not change "number" to "integer" as any integer is also a number
+        candidates.remove("integer")
     return candidates
 
 

--- a/test/cli/test_checks.py
+++ b/test/cli/test_checks.py
@@ -351,6 +351,58 @@ def test_negative_data_rejection_xml_body_string_type_no_false_positive(ctx, app
     )
 
 
+def test_negative_data_rejection_number_body_field_accepts_integer_no_false_positive(ctx, app_runner, cli):
+    # See GH-3697
+    # `type: number` in JSON Schema accepts integers — any integer is a valid number.
+    # Sending an integer (e.g., score=3) for a `type: number` field must NOT trigger
+    # AcceptedNegativeData because the server is correct to accept it.
+    app, _ = ctx.openapi.make_flask_app(
+        {
+            "/data": {
+                "post": {
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["score"],
+                                    "properties": {
+                                        "score": {"type": "number"},
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "responses": {"200": {"description": "OK"}},
+                }
+            }
+        }
+    )
+
+    @app.route("/data", methods=["POST"])
+    def data():
+        body = request.get_json(silent=True, force=True)
+        if not isinstance(body, dict):
+            return jsonify({"error": "invalid body"}), 422
+        score = body.get("score")
+        # Accept integers and floats; reject booleans (bool is a subclass of int in Python)
+        if isinstance(score, bool) or not isinstance(score, (int, float)):
+            return jsonify({"error": "score must be a number"}), 422
+        return jsonify({"ok": True}), 200
+
+    port = app_runner.run_flask_app(app)
+
+    cli.run_and_assert(
+        f"http://127.0.0.1:{port}/openapi.json",
+        "--checks=negative_data_rejection",
+        "--mode=negative",
+        "--phases=fuzzing",
+        "--max-examples=200",
+        exit_code=ExitCode.OK,
+    )
+
+
 def test_negative_data_rejection_array_of_strings_boolean_collision(ctx, app_runner, cli, snapshot_cli):
     # See GH-2913
     app, raw_schema = ctx.openapi.make_flask_app(

--- a/test/specs/openapi/test_negative.py
+++ b/test/specs/openapi/test_negative.py
@@ -101,6 +101,31 @@ def test_top_level_strategy(data, location, schema):
         assert is_valid_header(instance)
 
 
+@given(data=st.data())
+@settings(deadline=None, suppress_health_check=SUPPRESSED_HEALTH_CHECKS, max_examples=100)
+def test_number_type_excludes_integer_from_type_mutations(data):
+    # See GH-3697
+    schema = {
+        "type": "object",
+        "properties": {
+            "score": {"type": "number"},
+            "label": {"type": "string"},
+        },
+        "required": ["score", "label"],
+    }
+
+    ctx = MutationContext(
+        keywords=schema,
+        non_keywords={},
+        location=ParameterLocation.BODY,
+        media_type="application/json",
+        allow_extra_parameters=False,
+    )
+    result, metadata = change_properties(ctx, data.draw, schema)
+    if result == MutationResult.SUCCESS and metadata is not None:
+        assert metadata.description != "Invalid type integer (expected number)"
+
+
 @pytest.mark.parametrize(
     ("mutation", "schema", "location", "validate"),
     [


### PR DESCRIPTION
Ref #3697 