### PR TITLE
fix: False positive `negative_data_rejection` for `type: integer` query parameters mutated to array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### :bug: Fixed
 
 - False positive `negative_data_rejection` for `type: number` body fields in fuzzing. [#3697](https://github.com/schemathesis/schemathesis/issues/3697)
+- False positive `negative_data_rejection` for `type: integer` query parameters mutated to array. [#3697](https://github.com/schemathesis/schemathesis/issues/3697)
 
 ## [4.15.0](https://github.com/schemathesis/schemathesis/compare/v4.14.3...v4.15.0) - 2026-04-05
 

--- a/src/schemathesis/specs/openapi/checks.py
+++ b/src/schemathesis/specs/openapi/checks.py
@@ -293,22 +293,18 @@ def _body_negation_becomes_valid_after_serialization(case: Case) -> bool:
 
 
 def _single_element_array_becomes_valid_after_serialization(case: Case) -> bool:
-    """Check if single-element array negation becomes valid after serialization.
+    """Check if an array value for a scalar parameter becomes valid after serialization.
 
-    In query/header/cookie parameters, single-element arrays serialize to the same
-    string as scalar values:
-    - Array: [67] -> serialized: "67"
-    - Scalar: 67 -> serialized: "67"
+    In query/header/cookie parameters, arrays are serialized as repeated keys:
+    - Single-element [67] -> "?page=67" (identical to scalar 67)
+    - Multi-element [True, 1] -> "?page_size=True&page_size=1"
 
-    This makes single-element arrays indistinguishable from scalars after serialization.
-    If the schema expects a scalar type (integer, string, etc.), the serialized value
-    is actually valid.
+    For single-element arrays, the serialized form is indistinguishable from a scalar,
+    so the server will accept any value valid for the original schema.
 
-    Example:
-    - Schema: {"type": "integer"}
-    - Generated negative: [67] (array, should be invalid)
-    - Serialized: "67" (valid for integer after parsing)
-    - API correctly accepts it -> should not trigger negative_data_rejection
+    For multi-element arrays, some frameworks pick one value from repeated keys (e.g.
+    the last one). If any element in the array is valid for the original scalar schema,
+    the server may accept the request, making it an unreliable negative test.
 
     """
     from schemathesis.specs.openapi.adapter.parameters import OpenApiParameter
@@ -341,8 +337,7 @@ def _single_element_array_becomes_valid_after_serialization(case: Case) -> bool:
                 # This is an additional property, not a schema-defined parameter
                 continue
 
-            # Check if this is a single-element array
-            if not isinstance(param_value, list) or len(param_value) != 1:
+            if not isinstance(param_value, list) or not param_value:
                 continue
 
             # Get the parameter definition
@@ -357,11 +352,18 @@ def _single_element_array_becomes_valid_after_serialization(case: Case) -> bool:
             # Get the expected type(s) from the schema
             expected_types = get_type(schema)
 
-            # If the schema expects a scalar type (not array), then the single-element
-            # array will serialize to a valid scalar value
-            if "array" not in expected_types and expected_types:
-                # This is a single-element array for a scalar parameter
-                # After serialization, it becomes indistinguishable from a scalar
+            if "array" in expected_types or not expected_types:
+                continue
+
+            # Single-element arrays serialize identically to a scalar
+            if len(param_value) == 1:
+                return True
+
+            # Multi-element arrays serialize as repeated keys. If any element is valid
+            # for the full original schema (including enum, minimum, pattern, etc.),
+            # some frameworks may accept the request by picking that element.
+            validator = param.adapter.jsonschema_validator_cls(schema)
+            if any(validator.is_valid(element) for element in param_value):
                 return True
 
     return False

--- a/test/specs/openapi/test_checks.py
+++ b/test/specs/openapi/test_checks.py
@@ -713,6 +713,63 @@ def test_negative_data_rejection_single_element_array_serialization(ctx, respons
     assert result is None
 
 
+def test_negative_data_rejection_multi_element_array_with_valid_element(ctx, response_factory):
+    # See GH-3697
+    # Multi-element arrays in query parameters serialize as repeated keys: [True, 1] -> ?page_size=True&page_size=1
+    # Some frameworks (e.g. Django/DRF) pick one value from repeated keys. If that value is a valid integer (1),
+    # the request is accepted and should NOT trigger negative_data_rejection.
+    raw_schema = ctx.openapi.build_schema(
+        {
+            "/api/model-fk/user/": {
+                "get": {
+                    "parameters": [
+                        {
+                            "name": "page_size",
+                            "in": "query",
+                            "required": False,
+                            "schema": {"type": "integer", "minimum": 1, "maximum": 100},
+                        }
+                    ],
+                    "responses": {
+                        "200": {"description": "Success"},
+                        "400": {"description": "Bad Request"},
+                    },
+                }
+            }
+        }
+    )
+
+    schema = schemathesis.openapi.from_dict(raw_schema)
+    operation = schema["/api/model-fk/user/"]["GET"]
+
+    case = operation.Case(
+        _meta=build_metadata(
+            query=GenerationMode.NEGATIVE,
+            generation_mode=GenerationMode.NEGATIVE,
+            description="Invalid type array (expected integer)",
+            parameter="page_size",
+            parameter_location=ParameterLocation.QUERY,
+        ),
+        query={"page_size": [True, 1]},
+    )
+
+    response = response_factory.requests(status_code=200)
+
+    result = negative_data_rejection(
+        CheckContext(
+            override=None,
+            auth=None,
+            headers=None,
+            config=ChecksConfig(),
+            transport_kwargs=None,
+        ),
+        response,
+        case,
+    )
+
+    assert result is None
+
+
 def test_negative_data_rejection_path_string_numeric_serialization(ctx, response_factory):
     raw_schema = ctx.openapi.build_schema(
         {


### PR DESCRIPTION
Fixes #3697 