### PR TITLE
fix: Double JSON encoding for `content: application/json` query parameters in coverage phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - False positive `negative_data_rejection` for `type: number` body fields in fuzzing. [#3697](https://github.com/schemathesis/schemathesis/issues/3697)
 - False positive `negative_data_rejection` for `type: integer` query parameters mutated to array. [#3697](https://github.com/schemathesis/schemathesis/issues/3697)
+- Double JSON encoding for `content: application/json` query parameters in coverage phase. [#3701](https://github.com/schemathesis/schemathesis/issues/3701)
 
 ## [4.15.0](https://github.com/schemathesis/schemathesis/compare/v4.14.3...v4.15.0) - 2026-04-05
 

--- a/src/schemathesis/generation/hypothesis/builder.py
+++ b/src/schemathesis/generation/hypothesis/builder.py
@@ -528,11 +528,16 @@ class Template:
             if container_name in ("headers", "cookies") and isinstance(value, dict):
                 value = _stringify_value(value, container_name)
             if serializer is not None:
+                # Shallow-copy dict containers before serializing to avoid mutating
+                # self._template through shared references in shallow-copy kwargs
+                if isinstance(value, dict):
+                    value = dict(value)
                 value = serializer(value)
             if container_name == "query" and isinstance(value, dict):
                 value = _stringify_value(value, container_name)
             if container_name == "path_parameters" and isinstance(value, dict):
-                value = _stringify_value(quote_all(value), container_name)
+                # dict() copy prevents quote_all from mutating self._template
+                value = _stringify_value(quote_all(dict(value)), container_name)
             output[container_name] = value
         return output
 

--- a/test/coverage/test_phase.py
+++ b/test/coverage/test_phase.py
@@ -1,3 +1,4 @@
+import json
 import re
 import uuid
 from dataclasses import dataclass
@@ -3453,3 +3454,48 @@ def test_map_case_hook_applied_in_coverage_phase(ctx):
     assert all(c.query is None or c.query.get("injected") == "yes" for c in cases), (
         "map_case hook should have injected 'injected' into every query"
     )
+
+
+def test_content_json_query_params_single_encoding_in_coverage(ctx):
+    # See GH-3701
+    schema = build_schema(
+        ctx,
+        parameters=[
+            {
+                "name": "filters",
+                "in": "query",
+                "required": True,
+                "content": {"application/json": {"schema": {"type": "array", "example": []}}},
+            },
+        ],
+        request_body={
+            "required": True,
+            "content": {"application/json": {"schema": {"type": "array", "items": {"type": "string"}}}},
+        },
+    )
+    loaded = schemathesis.openapi.from_dict(schema)
+    config = ProjectConfig()
+    operation = loaded["/foo"]["post"]
+
+    cases = list(
+        generate_coverage_cases(
+            operation=operation,
+            generation_modes=[GenerationMode.POSITIVE],
+            auth_storage=None,
+            as_strategy_kwargs={},
+            generate_duplicate_query_parameters=config.phases.coverage.generate_duplicate_query_parameters,
+            unexpected_methods=config.phases.coverage.unexpected_methods,
+            generation_config=config.generation,
+        )
+    )
+
+    assert len(cases) >= 2
+    for case in cases:
+        if case.query is None:
+            continue
+        raw = case.query.get("filters")
+        if raw is None:
+            continue
+        assert isinstance(raw, str), f"Expected JSON string, got {type(raw).__name__}: {raw!r}"
+        parsed = json.loads(raw)
+        assert isinstance(parsed, list), "filters should decode to a list after single JSON encoding"


### PR DESCRIPTION
Fixes #3701