### PR TITLE
fix: False positive `positive_data_acceptance` for path parameters containing null bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Double JSON encoding for `content: application/json` query parameters in coverage phase. [#3701](https://github.com/schemathesis/schemathesis/issues/3701)
 - Sibling keywords on `$ref` properties ignored in examples phase for OAS 3.1 schemas. [#3698](https://github.com/schemathesis/schemathesis/issues/3698)
 - False positive `positive_data_acceptance` for headers with RFC 9110 control characters. [#3696](https://github.com/schemathesis/schemathesis/issues/3696)
+- False positive `positive_data_acceptance` for path parameters containing null bytes. [#3696](https://github.com/schemathesis/schemathesis/issues/3696)
 
 ## [4.15.0](https://github.com/schemathesis/schemathesis/compare/v4.14.3...v4.15.0) - 2026-04-05
 

--- a/src/schemathesis/openapi/generation/filters.py
+++ b/src/schemathesis/openapi/generation/filters.py
@@ -56,10 +56,10 @@ def is_invalid_path_parameter(value: Any, *, allow_encoded_slash: bool = False) 
         if "}" in decoded_value or "{" in decoded_value:
             return True
 
-        # Avoid situations when the path parameter contains only NULL bytes.
-        # Many webservers remove such bytes and as the result, the test can target a different API operation.
+        # Avoid NULL bytes in path parameters — many webservers strip or reject them,
+        # which can silently redirect the test to a different API operation.
         # Check decoded values as well to catch quoted forms like `%00`.
-        if len(decoded_value) == decoded_value.count("\x00"):
+        if "\x00" in decoded_value:
             return True
 
     return False

--- a/test/openapi/test_filters.py
+++ b/test/openapi/test_filters.py
@@ -64,7 +64,24 @@ def test_invalid_query_fails_with_requests(invalid_params):
 
 
 @pytest.mark.parametrize(
-    "value", ["/", "%2F", "%2f", "foo%2Fbar", "{", "}", "%7B", "%7D", "\x00", "%00", "%00%00", "\udc9b"]
+    "value",
+    [
+        "/",
+        "%2F",
+        "%2f",
+        "foo%2Fbar",
+        "{",
+        "}",
+        "%7B",
+        "%7D",
+        "\x00",
+        "%00",
+        "%00%00",
+        "\udc9b",
+        "abc%00def",
+        "abc\x00def",
+        "prefix%00suffix",
+    ],
 )
 def test_filter_path_parameters(value):
     assert not is_valid_path({"foo": value})


### PR DESCRIPTION
Fixes #3696 