### PR TITLE
fix: JUnit XML missing `unsupported_method` failures from coverage phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Sibling keywords on `$ref` properties ignored in examples phase for OAS 3.1 schemas. [#3698](https://github.com/schemathesis/schemathesis/issues/3698)
 - False positive `positive_data_acceptance` for headers with RFC 9110 control characters. [#3696](https://github.com/schemathesis/schemathesis/issues/3696)
 - False positive `positive_data_acceptance` for path parameters containing null bytes. [#3696](https://github.com/schemathesis/schemathesis/issues/3696)
+- JUnit XML missing `unsupported_method` failures from coverage phase. [#3699](https://github.com/schemathesis/schemathesis/issues/3699)
 
 ## [4.15.0](https://github.com/schemathesis/schemathesis/compare/v4.14.3...v4.15.0) - 2026-04-05
 

--- a/src/schemathesis/cli/commands/run/handlers/junitxml.py
+++ b/src/schemathesis/cli/commands/run/handlers/junitxml.py
@@ -26,7 +26,19 @@ class JunitXMLHandler(EventHandler):
     def handle_event(self, ctx: BaseExecutionContext, event: events.EngineEvent) -> None:
         if isinstance(event, events.ScenarioFinished):
             label = event.recorder.label
-            failures = list(ctx.statistic.failures.get(label, {}).values()) if event.status == Status.FAILURE else []
+            if event.status == Status.FAILURE:
+                # Look up failures by case_id across all labels — some coverage scenarios
+                # (e.g. UNSPECIFIED_HTTP_METHOD) store failures under a remapped label
+                # (the actual method+path tested) rather than the recorder label.
+                case_ids = set(event.recorder.cases.keys())
+                failures = [
+                    group
+                    for groups in ctx.statistic.failures.values()
+                    for case_id, group in groups.items()
+                    if case_id in case_ids
+                ]
+            else:
+                failures = []
             self.writer.record_scenario(
                 label=label,
                 elapsed_sec=event.elapsed_time,

--- a/test/cli/test_junitxml.py
+++ b/test/cli/test_junitxml.py
@@ -5,6 +5,7 @@ from xml.etree import ElementTree
 
 import pytest
 from _pytest.main import ExitCode
+from flask import jsonify
 
 
 @pytest.mark.operations("success")
@@ -222,3 +223,32 @@ def test_permission_denied(cli, tmp_path, schema_url, path):
     result = cli.run_and_assert(schema_url, f"--report-junit-path={xml_path}", exit_code=ExitCode.INTERRUPTED)
 
     assert "Permission denied" in result.stdout or "Permission denied" in result.stderr
+
+
+def test_coverage_unspecified_method_in_junit(cli, ctx, app_runner, tmp_path):
+    # See GH-3699
+    # When coverage phase triggers an `unsupported_method` failure via UNSPECIFIED_HTTP_METHOD,
+    # the failure must appear in JUnit XML
+    xml_path = tmp_path / "junit.xml"
+    app, _ = ctx.openapi.make_flask_app({"/users": {"get": {"responses": {"200": {"description": "OK"}}}}})
+
+    # Server accepts all methods — returns 200 instead of 405 for undocumented methods
+    @app.route("/users", methods=["GET", "DELETE", "POST", "PUT", "PATCH", "HEAD"])
+    def users():
+        return jsonify([])
+
+    port = app_runner.run_flask_app(app)
+    result = cli.run(
+        f"http://127.0.0.1:{port}/openapi.json",
+        "--phases=coverage",
+        f"--report-junit-path={xml_path}",
+        "--checks=unsupported_method",
+    )
+
+    # Exit code is 1: the check detected that undocumented methods were accepted
+    assert result.exit_code == 1
+
+    # JUnit must reflect that failure
+    tree = ElementTree.parse(xml_path)
+    root = tree.getroot()
+    assert int(root.attrib.get("failures", 0)) > 0


### PR DESCRIPTION
Fixes #3699 