### PR TITLE
feat: `schemathesis.openapi.require_security_scheme()` for scoping auth providers to specific OpenAPI security schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.15.2...HEAD) - TBD
 
+### :rocket: Added
+
+- `schemathesis.openapi.require_security_scheme()` for scoping auth providers to specific OpenAPI security schemes. [#3745](https://github.com/schemathesis/schemathesis/issues/3745)
+
 ### :bug: Fixed
 
 - False positive `negative_data_rejection` when `additionalProperties` is a schema object and `required` has exactly 2 fields.

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -279,6 +279,14 @@ class AdminAuth:
 
 **Available filters:** `path`, `method`, `name`, `tag`, `operation_id` (add `_regex` for regex matching)
 
+To apply auth only to operations that require a specific OpenAPI security scheme:
+
+```python
+schemathesis.auth.register()(SessionAuth).apply_to(
+    schemathesis.openapi.require_security_scheme("session")
+)
+```
+
 ## Applying Different Auth to Different Operations
 
 When different operations require different credentials, use multiple `[[operations]]` blocks in `schemathesis.toml`:

--- a/docs/reference/python.md
+++ b/docs/reference/python.md
@@ -191,6 +191,7 @@ Reference for Schemathesis public Python API.
       members:
       - format
       - media_type
+      - require_security_scheme
 
 ## GraphQL Extensions
 

--- a/src/schemathesis/openapi/__init__.py
+++ b/src/schemathesis/openapi/__init__.py
@@ -1,5 +1,5 @@
 from schemathesis.openapi.loaders import from_asgi, from_dict, from_file, from_path, from_url, from_wsgi
-from schemathesis.specs.openapi import format, media_type
+from schemathesis.specs.openapi import format, media_type, require_security_scheme
 
 __all__ = [
     "from_url",
@@ -10,4 +10,5 @@ __all__ = [
     "from_dict",
     "format",
     "media_type",
+    "require_security_scheme",
 ]

--- a/src/schemathesis/specs/openapi/__init__.py
+++ b/src/schemathesis/specs/openapi/__init__.py
@@ -1,9 +1,46 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from .formats import register_string_format as format
 from .formats import unregister_string_format
 from .media_types import register_media_type as media_type
+
+if TYPE_CHECKING:
+    from schemathesis.filters import HasAPIOperation, MatcherFunc
 
 __all__ = [
     "format",
     "unregister_string_format",
     "media_type",
+    "require_security_scheme",
 ]
+
+
+def require_security_scheme(name: str) -> MatcherFunc:
+    """Return a filter function matching operations that require the given security scheme.
+
+    Checks operation-level ``security`` first, then falls back to schema-level ``security``.
+
+    Args:
+        name: Security scheme name as declared in ``securitySchemes`` / ``securityDefinitions``.
+
+    Returns:
+        A :data:`~schemathesis.filters.MatcherFunc` for use with ``.apply_to()`` / ``.skip_for()``.
+
+    Example::
+
+        schemathesis.auth.register()(SessionAuth).apply_to(
+            schemathesis.openapi.require_security_scheme("session")
+        )
+
+    """
+
+    def matcher(ctx: HasAPIOperation) -> bool:
+        from schemathesis.specs.openapi.adapter.security import get_security_requirements
+
+        schemes = get_security_requirements(ctx.operation.schema.raw_schema, ctx.operation.definition.raw)
+        return name in schemes
+
+    matcher.__name__ = matcher.__qualname__ = f"require_security_scheme({name!r})"
+    return matcher

--- a/test/specs/openapi/test_filters.py
+++ b/test/specs/openapi/test_filters.py
@@ -1,0 +1,39 @@
+import schemathesis
+
+
+def test_require_security_scheme_operation_level_match(ctx, case_factory):
+    raw = ctx.openapi.build_schema(
+        {"/users": {"get": {"security": [{"session": []}], "responses": {"200": {"description": "OK"}}}}},
+        components={"securitySchemes": {"session": {"type": "http", "scheme": "bearer"}}},
+    )
+    schema = schemathesis.openapi.from_dict(raw)
+    case = case_factory(operation=schema["/users"]["get"])
+    assert schemathesis.openapi.require_security_scheme("session")(case) is True
+
+
+def test_require_security_scheme_operation_level_no_match(ctx, case_factory):
+    raw = ctx.openapi.build_schema(
+        {"/users": {"get": {"security": [{"session": []}], "responses": {"200": {"description": "OK"}}}}},
+        components={"securitySchemes": {"session": {"type": "http", "scheme": "bearer"}}},
+    )
+    schema = schemathesis.openapi.from_dict(raw)
+    case = case_factory(operation=schema["/users"]["get"])
+    assert schemathesis.openapi.require_security_scheme("other")(case) is False
+
+
+def test_require_security_scheme_schema_level_fallback(ctx, case_factory):
+    raw = ctx.openapi.build_schema(
+        {"/users": {"get": {"responses": {"200": {"description": "OK"}}}}},
+        security=[{"session": []}],
+        components={"securitySchemes": {"session": {"type": "http", "scheme": "bearer"}}},
+    )
+    schema = schemathesis.openapi.from_dict(raw)
+    case = case_factory(operation=schema["/users"]["get"])
+    assert schemathesis.openapi.require_security_scheme("session")(case) is True
+
+
+def test_require_security_scheme_no_security(ctx, case_factory):
+    raw = ctx.openapi.build_schema({"/users": {"get": {"responses": {"200": {"description": "OK"}}}}})
+    schema = schemathesis.openapi.from_dict(raw)
+    case = case_factory(operation=schema["/users"]["get"])
+    assert schemathesis.openapi.require_security_scheme("session")(case) is False


### PR DESCRIPTION
Resolves #3745 