### PR TITLE
fix: False positive `negative_data_rejection` for `multipart/form-data` fields with `format: binary` and `nullable: true` in the coverage phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - False positive `negative_data_rejection` when a `pattern` optional group wraps variable-length content and `maxLength` is present in the coverage phase.
 - False positive `positive_data_acceptance` when `propertyNames` restricts object keys and `additionalProperties` is present in the coverage phase. [#3771](https://github.com/schemathesis/schemathesis/issues/3771)
 - False positive `positive_data_acceptance` for `oneOf` body schemas where generated values satisfy multiple branches simultaneously.
+- False positive `negative_data_rejection` for `multipart/form-data` fields with `format: binary` and `nullable: true` in the coverage phase. [#3777](https://github.com/schemathesis/schemathesis/issues/3777)
 - False positive `negative_data_rejection` for `application/x-www-form-urlencoded` and `application/xml` body properties where type mutations are wire-identical (e.g. `integer` stringifies to a valid string).
 - Crash generating curl command when a NEGATIVE coverage case has a primitive body (e.g. `integer` form-urlencoded schema).
 - False positive `positive_data_acceptance` for string fields with `format: uuid` and optional-hyphen `pattern` in the coverage phase.

--- a/src/schemathesis/generation/coverage.py
+++ b/src/schemathesis/generation/coverage.py
@@ -1176,11 +1176,21 @@ def cover_schema_iter(
                         ctx.resolve_ref(s["$ref"]) if isinstance(s, dict) and "$ref" in s else s for s in value
                     ]
                     validators = _make_branch_validators(resolved_schemas, ctx)
+                    # Body fields in multipart/form-urlencoded are serialized as strings via str().
+                    # Query/path/header parameters are also stringified, but servers parse them
+                    # back to their declared type before validation, so str() doesn't make them
+                    # valid for explicitly string-typed branches in that case.
+                    stringify_body_fields = ctx.location == ParameterLocation.BODY and ctx.media_type in {
+                        ("multipart", "form-data"),
+                        ("application", "x-www-form-urlencoded"),
+                    }
                     for idx, sub_schema in enumerate(value):
                         with nctx.at(idx):
                             for value in cover_schema_iter(nctx, sub_schema, seen):
                                 # Negative value for this schema could be a positive value for another one
-                                if is_valid_for_others(value.value, idx, validators):
+                                if is_valid_for_others(
+                                    value.value, idx, validators, resolved_schemas, stringify_body_fields
+                                ):
                                     continue
                                 yield value
                 elif key == "oneOf":
@@ -1201,7 +1211,13 @@ def cover_schema_iter(
                     yield from _flip_generation_mode_for_not(cover_schema_iter(pctx, value, seen))
 
 
-def is_valid_for_others(value: Any, idx: int, validators: list[jsonschema_rs.Validator]) -> bool:
+def is_valid_for_others(
+    value: Any,
+    idx: int,
+    validators: list[jsonschema_rs.Validator],
+    schemas: list[dict | bool] | None = None,
+    will_be_serialized_to_string: bool = False,
+) -> bool:
     if contains_binary(value):
         return False
     for vidx, validator in enumerate(validators):
@@ -1210,6 +1226,19 @@ def is_valid_for_others(value: Any, idx: int, validators: list[jsonschema_rs.Val
             continue
         if validator.is_valid(value):
             return True
+        # In serialized contexts (multipart, form-urlencoded, path/query/header), non-string
+        # values are converted via str() before transmission. Only skip if the other branch
+        # explicitly requires string type — schemas without a type constraint accept strings
+        # vacuously (e.g. `minimum` doesn't apply to strings), which would be a false match.
+        if will_be_serialized_to_string and not isinstance(value, str) and schemas is not None:
+            other = schemas[vidx]
+            if isinstance(other, dict):
+                explicit_type = other.get("type")
+                has_string = explicit_type == "string" or (
+                    isinstance(explicit_type, list) and "string" in explicit_type
+                )
+                if has_string and validator.is_valid(str(value)):
+                    return True
     return False
 
 

--- a/test/coverage/test_phase.py
+++ b/test/coverage/test_phase.py
@@ -5076,6 +5076,74 @@ def test_negative_data_rejection_no_crash_with_large_dfa_pattern(ctx, response_f
             pass
 
 
+def test_negative_data_rejection_no_false_positive_for_nullable_binary_multipart(ctx, response_factory):
+    # `nullable: true` on a binary field converts to anyOf[{string/binary}, {null}].
+    # Negating the null branch generates type mutations (dict, int, bool, etc.) that get
+    # serialized to strings in multipart (str({}) -> "{}"), making them valid for the binary
+    # field. is_valid_for_others must account for wire serialization so these aren't yielded.
+    raw_schema = ctx.openapi.build_schema(
+        {
+            "/upload": {
+                "post": {
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["data"],
+                                    "properties": {
+                                        "data": {
+                                            "type": "string",
+                                            "format": "binary",
+                                            "nullable": True,
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "responses": {
+                        "200": {"description": "OK"},
+                        "400": {"description": "Bad Request"},
+                    },
+                }
+            }
+        }
+    )
+    schema = schemathesis.openapi.from_dict(raw_schema)
+    operation = schema["/upload"]["POST"]
+
+    cases = list(
+        generate_coverage_cases(
+            operation=operation,
+            generation_modes=[GenerationMode.NEGATIVE],
+            auth_storage=None,
+            as_strategy_kwargs={},
+            generate_duplicate_query_parameters=False,
+            unexpected_methods=set(),
+            generation_config=schema.config.generation,
+        )
+    )
+
+    response = response_factory.requests(status_code=200)
+    ctx_check = CheckContext(override=None, auth=None, headers=None, config=ChecksConfig(), transport_kwargs=None)
+
+    for case in cases:
+        body = case.body
+        if not isinstance(body, dict) or "data" not in body:
+            continue
+        data_val = body["data"]
+        if isinstance(data_val, (str, bytes)):
+            continue
+        # Non-string value for binary field: str(data_val) is a valid binary string in multipart,
+        # so the API will accept it — negative_data_rejection must not fire (false positive).
+        assert negative_data_rejection(ctx_check, response, case) is None, (
+            f"False positive: body {body!r} with data={data_val!r} ({type(data_val).__name__}) "
+            f"becomes a valid binary string after multipart serialization"
+        )
+
+
 def test_coverage_positive_body_nested_allof_inner_required_preserved(ctx):
     # Required fields from the second inner $ref (e.g. 'direction') must appear in POSITIVE bodies
     # when a oneOf branch resolves to allOf[{$ref: base}, {$ref: extension}].


### PR DESCRIPTION
Fixes #3777