### PR TITLE
fix: Use the matching registered serializer for multipart fields with `encoding.contentType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### :bug: Fixed
 
+- Use the matching registered serializer for multipart fields with `encoding.contentType`. [#3785](https://github.com/schemathesis/schemathesis/issues/3785)
+
 #### `positive_data_acceptance` false positives
 
 - *`example` values violating constraints (examples phase):*

--- a/src/schemathesis/transport/requests.py
+++ b/src/schemathesis/transport/requests.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import binascii
 import inspect
+import json
 import os
 from collections.abc import Mapping, MutableMapping
 from io import BytesIO
@@ -10,8 +11,8 @@ from urllib.parse import urlencode, urlparse
 
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from schemathesis.core import NotSet
-from schemathesis.core.errors import IncorrectUsage
+from schemathesis.core import NotSet, media_types
+from schemathesis.core.errors import IncorrectUsage, SerializationNotPossible
 from schemathesis.core.parameters import RAW_QUERY_STRING_KEY, RawQueryString
 from schemathesis.core.rate_limit import ratelimit
 from schemathesis.core.transforms import merge_at
@@ -292,11 +293,56 @@ def _encode_multipart(value: Any, boundary: str) -> bytes:
     return body.getvalue()
 
 
+def _collect_encoded_fields(ctx: SerializationContext) -> dict[str, str]:
+    """Return multipart field names mapped to the content-type declared via `encoding`."""
+    operation = ctx.case.operation
+    selected = ctx.case.multipart_content_types or {}
+    result: dict[str, str] = {}
+    for body in operation.body:
+        main, sub = media_types.parse(body.media_type)
+        if main not in ("*", "multipart") or sub not in ("*", "form-data", "mixed"):
+            continue
+        for name in body.definition.get("encoding", {}):
+            content_type = selected.get(name) or body.get_property_content_type(name)
+            if isinstance(content_type, str):
+                result[name] = content_type
+        break
+    return result
+
+
+def _is_already_serialized(value: Any) -> bool:
+    """Whether the value is already in a form that can be sent as a multipart part."""
+    if isinstance(value, (bytes, str, Binary)):
+        return True
+    if isinstance(value, list):
+        return all(isinstance(item, (bytes, str, Binary)) for item in value)
+    return False
+
+
+def _serialize_part_value(ctx: SerializationContext, value: Any, content_type: str) -> Any:
+    """Serialize a multipart field value using the registered serializer for its content-type."""
+    if _is_already_serialized(value):
+        return value
+    pair = REQUESTS_TRANSPORT.get_first_matching_media_type(content_type)
+    if pair is None:
+        raise SerializationNotPossible.for_media_type(content_type)
+    _, serializer = pair
+    result = serializer(ctx, value)
+    if "data" in result:
+        return result["data"]
+    if "json" in result:
+        return json.dumps(result["json"]).encode()
+    return value
+
+
 @REQUESTS_TRANSPORT.serializer("multipart/form-data", "multipart/mixed")
 def multipart_serializer(ctx: SerializationContext, value: Any) -> dict[str, Any]:
     if isinstance(value, bytes):
         return {"data": value}
     if isinstance(value, dict):
+        for name, content_type in _collect_encoded_fields(ctx).items():
+            if name in value:
+                value[name] = _serialize_part_value(ctx, value[name], content_type)
         multipart = _prepare_form_data(value)
         files, data = ctx.case.operation.prepare_multipart(multipart, ctx.case.multipart_content_types)
         return {"files": files, "data": data}

--- a/test/specs/openapi/parameters/test_multipart_encoding.py
+++ b/test/specs/openapi/parameters/test_multipart_encoding.py
@@ -1,9 +1,29 @@
+import json
+
+import pytest
+import yaml
 from hypothesis import given
 from hypothesis import strategies as st
 
 import schemathesis
+from schemathesis.core.errors import SerializationNotPossible
 from schemathesis.generation import GenerationMode
+from schemathesis.transport.asgi import ASGI_TRANSPORT
+from schemathesis.transport.requests import REQUESTS_TRANSPORT
 from schemathesis.transport.serialization import Binary
+from schemathesis.transport.wsgi import WSGI_TRANSPORT
+
+
+@pytest.fixture
+def custom_part_serializer():
+    @schemathesis.serializer("application/x-part-custom")
+    def serialize_custom(ctx, value):
+        return b"CUSTOM:" + json.dumps(value).encode()
+
+    yield
+
+    for transport in (REQUESTS_TRANSPORT, WSGI_TRANSPORT, ASGI_TRANSPORT):
+        transport.unregister_serializer("application/x-part-custom")
 
 
 def test_multipart_with_custom_encoding():
@@ -758,6 +778,203 @@ def test_multipart_optional_encoding_not_always_present():
         # Required field must always be present
         assert "required_field" in case.body
         # Optional field may or may not be present - both are valid
+
+    test()
+
+
+def test_multipart_json_encoding_serializes_object_field():
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["data"],
+                                        "properties": {
+                                            "data": {
+                                                "type": "object",
+                                                "properties": {"foo": {"type": "string"}},
+                                                "required": ["foo"],
+                                            },
+                                            "new_cert_path": {"type": "string", "format": "binary"},
+                                        },
+                                    },
+                                    "encoding": {"data": {"contentType": "application/json"}},
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        kwargs = case.as_transport_kwargs(base_url="http://example.com")
+        files = kwargs["files"]
+        assert files is not None
+        for name, payload in files:
+            if name == "data":
+                assert isinstance(payload, tuple) and len(payload) == 3, payload
+                _, value, content_type = payload
+                assert content_type == "application/json"
+                assert isinstance(value, (str, bytes)), (
+                    f"expected JSON-serialized value, got {type(value).__name__}: {value!r}"
+                )
+                assert isinstance(json.loads(value), dict)
+
+    test()
+
+
+def test_multipart_yaml_encoding_serializes_object_field():
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["meta"],
+                                        "properties": {
+                                            "meta": {
+                                                "type": "object",
+                                                "properties": {"tag": {"type": "string"}},
+                                                "required": ["tag"],
+                                            },
+                                        },
+                                    },
+                                    "encoding": {"meta": {"contentType": "application/yaml"}},
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        kwargs = case.as_transport_kwargs(base_url="http://example.com")
+        files = kwargs["files"]
+        assert files is not None
+        for name, payload in files:
+            if name == "meta":
+                _, value, content_type = payload
+                assert content_type == "application/yaml"
+                assert isinstance(value, (str, bytes))
+                parsed = yaml.safe_load(value)
+                assert isinstance(parsed, dict) and "tag" in parsed
+
+    test()
+
+
+def test_multipart_custom_serializer_encoding(custom_part_serializer):
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["payload"],
+                                        "properties": {
+                                            "payload": {
+                                                "type": "object",
+                                                "properties": {"k": {"type": "string"}},
+                                                "required": ["k"],
+                                            },
+                                        },
+                                    },
+                                    "encoding": {"payload": {"contentType": "application/x-part-custom"}},
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        kwargs = case.as_transport_kwargs(base_url="http://example.com")
+        files = kwargs["files"]
+        assert files is not None
+        for name, payload in files:
+            if name == "payload":
+                _, value, content_type = payload
+                assert content_type == "application/x-part-custom"
+                assert value.startswith(b"CUSTOM:")
+
+    test()
+
+
+def test_multipart_encoding_with_unknown_content_type_fails():
+    schema = schemathesis.openapi.from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/upload": {
+                    "post": {
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "multipart/form-data": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["meta"],
+                                        "properties": {
+                                            "meta": {
+                                                "type": "object",
+                                                "properties": {"tag": {"type": "string"}},
+                                                "required": ["tag"],
+                                            },
+                                        },
+                                    },
+                                    "encoding": {"meta": {"contentType": "application/x-unknown-foo"}},
+                                }
+                            },
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    operation = schema["/upload"]["POST"]
+
+    @given(case=operation.as_strategy())
+    def test(case):
+        with pytest.raises(SerializationNotPossible, match="application/x-unknown-foo"):
+            case.as_transport_kwargs(base_url="http://example.com")
 
     test()
 


### PR DESCRIPTION
Fixes #3785