### PR TITLE
fix: `before_call` hook setting a missing required header in the coverage phase had no effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### :bug: Fixed
 
 - Use the matching registered serializer for multipart fields with `encoding.contentType`. [#3785](https://github.com/schemathesis/schemathesis/issues/3785)
+- `before_call` hook setting a missing required header in the coverage phase had no effect. [#3784](https://github.com/schemathesis/schemathesis/issues/3784)
 
 #### `positive_data_acceptance` false positives
 

--- a/src/schemathesis/transport/prepare.py
+++ b/src/schemathesis/transport/prepare.py
@@ -45,22 +45,20 @@ def get_exclude_headers(case: Case) -> list[str]:
 
     phase_data = case.meta.phase.data
 
-    # Exclude headers that are intentionally missing
-
+    # Gate header exclusion on the current generation mode so that a `before_call`
+    # hook restoring the header (which flips the mode to positive via revalidation)
+    # stops the exclusion.
     if (
-        isinstance(phase_data, CoveragePhaseData)
-        and phase_data.scenario == CoverageScenario.MISSING_PARAMETER
-        and phase_data.parameter_location == ParameterLocation.HEADER
-        and phase_data.parameter is not None
+        not case.meta.generation.mode.is_negative
+        or phase_data.parameter_location != ParameterLocation.HEADER
+        or phase_data.parameter is None
     ):
+        return []
+
+    if isinstance(phase_data, CoveragePhaseData) and phase_data.scenario == CoverageScenario.MISSING_PARAMETER:
         return [phase_data.parameter]
 
-    if (
-        isinstance(phase_data, (FuzzingPhaseData | StatefulPhaseData))
-        and case.meta.generation.mode.is_negative
-        and phase_data.parameter_location == ParameterLocation.HEADER
-        and phase_data.parameter is not None
-    ):
+    if isinstance(phase_data, (FuzzingPhaseData, StatefulPhaseData)):
         return [phase_data.parameter]
 
     return []

--- a/test/coverage/test_phase.py
+++ b/test/coverage/test_phase.py
@@ -3431,6 +3431,50 @@ def test_missing_required_header_case_uses_invalid_template_body(ctx):
     )
 
 
+def test_missing_required_header_case_respects_before_call_hook_restoring_header(ctx):
+    raw_schema = ctx.openapi.build_schema(
+        {
+            "/items": {
+                "put": {
+                    "parameters": [
+                        {
+                            "name": "X-Required-Header",
+                            "in": "header",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        }
+                    ],
+                    "responses": {"200": {"description": "OK"}},
+                }
+            }
+        }
+    )
+    schema = schemathesis.openapi.from_dict(raw_schema)
+    operation = schema["/items"]["put"]
+
+    missing_header_case = next(
+        case
+        for case in _iter_coverage_cases(
+            operation=operation,
+            generation_modes=[GenerationMode.NEGATIVE],
+            generate_duplicate_query_parameters=False,
+            unexpected_methods=set(),
+            generation_config=schema.config.generation,
+        )
+        if case.meta.phase.data.scenario == CoverageScenario.MISSING_PARAMETER
+        and case.meta.phase.data.parameter == "X-Required-Header"
+    )
+
+    assert missing_header_case.meta.generation.mode == GenerationMode.NEGATIVE
+
+    missing_header_case.headers["X-Required-Header"] = "restored"
+
+    assert missing_header_case.meta.generation.mode == GenerationMode.POSITIVE
+
+    kwargs = missing_header_case.as_transport_kwargs(base_url="http://127.0.0.1")
+    assert kwargs["headers"].get("X-Required-Header") == "restored"
+
+
 def test_filter_case_hook_applied_in_coverage_phase(ctx):
     raw_schema = build_schema(
         ctx,


### PR DESCRIPTION
Fixes #3784 