### PR TITLE
fix: `auth` API on `LazySchema` to match `BaseSchema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.16.0...HEAD) - TBD
 
+### :bug: Fixed
+
+- `auth` API on `LazySchema` to match `BaseSchema`. [#3797](https://github.com/schemathesis/schemathesis/issues/3797)
+
 ## [4.16.0](https://github.com/schemathesis/schemathesis/compare/v4.15.2...v4.16.0) - 2026-04-26
 
 ### :rocket: Added

--- a/src/schemathesis/pytest/lazy.py
+++ b/src/schemathesis/pytest/lazy.py
@@ -10,6 +10,7 @@ from unittest import SkipTest
 import pytest
 from hypothesis.core import HypothesisHandle
 
+from schemathesis.auths import AuthStorage
 from schemathesis.core.errors import InvalidSchema
 from schemathesis.core.result import Ok, Result
 from schemathesis.filters import FilterSet, FilterValue, MatcherFunc, RegexValue, is_deprecated
@@ -89,16 +90,19 @@ def get_all_tests(
 class LazySchema:
     fixture_name: str
     filter_set: FilterSet
+    auth: AuthStorage
 
-    __slots__ = ("fixture_name", "filter_set")
+    __slots__ = ("fixture_name", "filter_set", "auth")
 
     def __init__(
         self,
         fixture_name: str,
         filter_set: FilterSet | None = None,
+        auth: AuthStorage | None = None,
     ) -> None:
         self.fixture_name = fixture_name
         self.filter_set = filter_set or FilterSet()
+        self.auth = auth if auth is not None else AuthStorage()
 
     def include(
         self,
@@ -130,7 +134,7 @@ class LazySchema:
             operation_id=operation_id,
             operation_id_regex=operation_id_regex,
         )
-        return self.__class__(fixture_name=self.fixture_name, filter_set=filter_set)
+        return self.__class__(fixture_name=self.fixture_name, filter_set=filter_set, auth=self.auth)
 
     def exclude(
         self,
@@ -168,7 +172,7 @@ class LazySchema:
             operation_id=operation_id,
             operation_id_regex=operation_id_regex,
         )
-        return self.__class__(fixture_name=self.fixture_name, filter_set=filter_set)
+        return self.__class__(fixture_name=self.fixture_name, filter_set=filter_set, auth=self.auth)
 
     def parametrize(self) -> Callable:
         def wrapper(test_func: Callable) -> Callable:
@@ -215,6 +219,8 @@ class LazySchema:
                     test_function=test_func,
                     filter_set=self.filter_set,
                 )
+                if self.auth.is_defined:
+                    schema.auth = AuthStorage(providers=list(self.auth.providers) + list(schema.auth.providers))
                 emit_openapi_auth_warnings(schema)
                 # Check if test function is a method and inject self from request.instance
                 sig = signature(test_func)

--- a/test/auth/test_pytest.py
+++ b/test/auth/test_pytest.py
@@ -588,3 +588,145 @@ def test_api(case):
     result = testdir.runpytest("-W", "always")
     # The unused OpenAPI auth scheme warning should be emitted
     result.stdout.re_match_lines([r".*WRONG_MISSING_AUTH.*"])
+
+
+def test_lazy_schema_auth_decorator(testdir):
+    testdir.make_test(
+        """
+lazy_schema = schemathesis.pytest.from_fixture("simple_schema")
+
+TOKEN = "Foo"
+
+@lazy_schema.auth()
+class TokenAuth:
+    def get(self, case, context):
+        return TOKEN
+
+    def set(self, case, data, context):
+        case.headers = case.headers or {}
+        case.headers["Authorization"] = f"Bearer {data}"
+
+@lazy_schema.parametrize()
+@settings(max_examples=2)
+def test(case):
+    assert case.headers is not None
+    assert case.headers["Authorization"] == f"Bearer {TOKEN}"
+"""
+    )
+    result = testdir.runpytest("-s")
+    result.assert_outcomes(passed=1)
+
+
+def test_lazy_schema_auth_apply(testdir):
+    testdir.make_test(
+        """
+lazy_schema = schemathesis.pytest.from_fixture("simple_schema")
+
+TOKEN = "Bar"
+
+class TokenAuth:
+    def get(self, case, context):
+        return TOKEN
+
+    def set(self, case, data, context):
+        case.headers = case.headers or {}
+        case.headers["Authorization"] = f"Bearer {data}"
+
+@lazy_schema.parametrize()
+@lazy_schema.auth(TokenAuth)
+@settings(max_examples=2)
+def test(case):
+    assert case.headers is not None
+    assert case.headers["Authorization"] == f"Bearer {TOKEN}"
+"""
+    )
+    result = testdir.runpytest("-s")
+    result.assert_outcomes(passed=1)
+
+
+def test_lazy_schema_auth_set_from_requests(testdir):
+    testdir.make_test(
+        """
+from requests.auth import HTTPBasicAuth
+
+lazy_schema = schemathesis.pytest.from_fixture("simple_schema")
+
+auth = HTTPBasicAuth("user", "pass")
+lazy_schema.auth.set_from_requests(auth)
+
+@lazy_schema.parametrize()
+@settings(max_examples=2)
+def test(case):
+    assert case.as_transport_kwargs().get("auth") is auth
+"""
+    )
+    result = testdir.runpytest("-s")
+    result.assert_outcomes(passed=1)
+
+
+def test_lazy_schema_auth_takes_precedence_over_fixture_auth(testdir):
+    testdir.make_test(
+        """
+LAZY_TOKEN = "from-lazy"
+FIXTURE_TOKEN = "from-fixture"
+
+@pytest.fixture
+def api_schema(simple_schema):
+    @simple_schema.auth()
+    class FixtureAuth:
+        def get(self, case, context):
+            return FIXTURE_TOKEN
+
+        def set(self, case, data, context):
+            case.headers = case.headers or {}
+            case.headers["Authorization"] = f"Bearer {data}"
+
+    return simple_schema
+
+lazy_schema = schemathesis.pytest.from_fixture("api_schema")
+
+@lazy_schema.auth()
+class LazyAuth:
+    def get(self, case, context):
+        return LAZY_TOKEN
+
+    def set(self, case, data, context):
+        case.headers = case.headers or {}
+        case.headers["Authorization"] = f"Bearer {data}"
+
+@lazy_schema.parametrize()
+@settings(max_examples=2)
+def test(case):
+    assert case.headers["Authorization"] == f"Bearer {LAZY_TOKEN}"
+"""
+    )
+    result = testdir.runpytest("-s")
+    result.assert_outcomes(passed=1)
+
+
+def test_lazy_schema_auth_does_not_leak_to_fixture_schema(testdir):
+    testdir.make_test(
+        """
+lazy_schema = schemathesis.pytest.from_fixture("simple_schema")
+
+TOKEN = "Baz"
+
+@lazy_schema.auth()
+class TokenAuth:
+    def get(self, case, context):
+        return TOKEN
+
+    def set(self, case, data, context):
+        case.headers = case.headers or {}
+        case.headers["Authorization"] = f"Bearer {data}"
+
+@lazy_schema.parametrize()
+@settings(max_examples=2)
+def test(case, simple_schema):
+    # The fixture's underlying schema must not have lazy-registered providers
+    assert simple_schema.auth.is_defined is False
+    assert case.headers["Authorization"] == f"Bearer {TOKEN}"
+"""
+    )
+    result = testdir.runpytest("-s")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
Fixes #3797 