### PR TITLE
fix: False positive `negative_data_rejection` for body-level type mutations on `multipart/form-data` endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.16.1...HEAD) - TBD
 
+### :bug: Fixed
+
+- False positive `negative_data_rejection` for body-level type mutations on `multipart/form-data` endpoints. [#3801](https://github.com/schemathesis/schemathesis/issues/3801)
+
 ### :wrench: Changed
 
 - Dependency inference recognizes more identifier-style path parameters (e.g. `username`, `containerGroupName`).

--- a/src/schemathesis/generation/coverage.py
+++ b/src/schemathesis/generation/coverage.py
@@ -2105,11 +2105,17 @@ def _negative_type(
         and ctx.media_type[1] != "json"
     ):
         return
-    # Form-urlencoded body-level type mutations serialize to empty body
+    # Form/multipart body-level type mutations don't yield reliable wire violations:
+    # form-urlencoded serializes to empty body; multipart renders as boundaries around
+    # str(value), which permissive servers accept as zero-part multipart.
     if (
         "object" in types
         and ctx.location == ParameterLocation.BODY
-        and ctx.media_type == ("application", "x-www-form-urlencoded")
+        and ctx.media_type
+        in (
+            ("application", "x-www-form-urlencoded"),
+            ("multipart", "form-data"),
+        )
     ):
         return
     strategies = {ty: strategy for ty, strategy in STRATEGIES_FOR_TYPE.items() if ty not in types}

--- a/test/coverage/test_phase.py
+++ b/test/coverage/test_phase.py
@@ -5188,6 +5188,64 @@ def test_negative_data_rejection_no_false_positive_for_nullable_binary_multipart
         )
 
 
+def test_negative_data_rejection_no_false_positive_for_multipart_body_type_mutations(ctx, response_factory):
+    # Non-dict body values render as malformed multipart that lenient servers accept.
+    raw_schema = ctx.openapi.build_schema(
+        {
+            "/upload": {
+                "post": {
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["data"],
+                                    "properties": {
+                                        "data": {
+                                            "type": "string",
+                                            "format": "binary",
+                                            "nullable": True,
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "responses": {
+                        "200": {"description": "OK"},
+                        "400": {"description": "Bad Request"},
+                    },
+                }
+            }
+        }
+    )
+    schema = schemathesis.openapi.from_dict(raw_schema)
+    operation = schema["/upload"]["POST"]
+
+    cases = list(
+        generate_coverage_cases(
+            operation=operation,
+            generation_modes=[GenerationMode.NEGATIVE],
+            auth_storage=None,
+            as_strategy_kwargs={},
+            generate_duplicate_query_parameters=False,
+            unexpected_methods=set(),
+            generation_config=schema.config.generation,
+        )
+    )
+
+    response = response_factory.requests(status_code=200)
+    ctx_check = CheckContext(override=None, auth=None, headers=None, config=ChecksConfig(), transport_kwargs=None)
+
+    for case in cases:
+        if isinstance(case.body, dict):
+            continue
+        assert negative_data_rejection(ctx_check, response, case) is None, (
+            f"False positive: body {case.body!r} ({type(case.body).__name__})"
+        )
+
+
 def test_coverage_positive_body_nested_allof_inner_required_preserved(ctx):
     # Required fields from the second inner $ref (e.g. 'direction') must appear in POSITIVE bodies
     # when a oneOf branch resolves to allOf[{$ref: base}, {$ref: extension}].


### PR DESCRIPTION
Fixes #3801 