### PR TITLE
fix: Runtime Error in negative generation for OpenAPI 3.1 schemas with `prefixItems`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - False `InfiniteRecursiveReference` on cycles breakable through `oneOf`/`anyOf`, top-level `allOf`, or unused `definitions`.
 - False positives from `\p{X}` Unicode property escapes inside character classes (e.g. `[\p{Alnum}_]+`).
 - Translate POSIX character classes (e.g. `[[:alnum:]_]`) to Python equivalents instead of misparsing them.
+- Runtime Error in negative generation for OpenAPI 3.1 schemas with `prefixItems`. [#3842](https://github.com/schemathesis/schemathesis/issues/3842)
 - Spurious `FlakyStrategyDefinition` from `st fuzz` when the time limit trips mid-scenario.
 - Crash in the examples phase when a body example contained `format: binary` data alongside captured pool values.
 - Resource-pool variants for path/query/header parameters skip values that violate the destination schema.

--- a/src/schemathesis/specs/openapi/_hypothesis.py
+++ b/src/schemathesis/specs/openapi/_hypothesis.py
@@ -838,6 +838,7 @@ def make_positive_strategy(
     generation_config: GenerationConfig,
     validator_cls: type[jsonschema_rs.Validator],
     name_to_uri: dict[str, str] | None = None,
+    validation_schema: JsonSchema | None = None,
 ) -> st.SearchStrategy:
     """Strategy for generating values that fit the schema."""
     custom_formats = _build_custom_formats(generation_config, GenerationMode.POSITIVE)
@@ -864,6 +865,7 @@ def make_negative_strategy(
     generation_config: GenerationConfig,
     validator_cls: type[jsonschema_rs.Validator],
     name_to_uri: dict[str, str] | None = None,
+    validation_schema: JsonSchema | None = None,
 ) -> st.SearchStrategy:
     custom_formats = _build_custom_formats(generation_config, GenerationMode.NEGATIVE)
     return negative_schema(
@@ -874,6 +876,7 @@ def make_negative_strategy(
         custom_formats=custom_formats,
         generation_config=generation_config,
         validator_cls=validator_cls,
+        validation_schema=validation_schema,
         name_to_uri=name_to_uri,
     )
 

--- a/src/schemathesis/specs/openapi/adapter/parameters.py
+++ b/src/schemathesis/specs/openapi/adapter/parameters.py
@@ -300,7 +300,10 @@ class OpenApiComponent(ABC):
 
     @property
     def validation_schema(self) -> JsonSchema:
-        """JSON schema for conformance validation — resolved but without generation-specific type injection."""
+        """JSON schema for conformance validation — resolved but without generation-specific type injection.
+
+        Keeps `prefixItems` intact so `Draft202012Validator` accepts the schema during construction.
+        """
         if self._validation_schema is NOT_SET:
             self._validation_schema = to_json_schema(
                 self.raw_schema,
@@ -309,6 +312,7 @@ class OpenApiComponent(ABC):
                 upgrade_legacy_exclusive_bounds=(
                     self.adapter.jsonschema_validator_cls is jsonschema_rs.Draft202012Validator
                 ),
+                convert_prefix_items=False,
                 name_to_uri=self.name_to_uri,
             )
         assert not isinstance(self._validation_schema, NotSet)
@@ -1024,27 +1028,28 @@ class OpenApiParameterSet(ParameterSet):
         if exclude_key in self._schema_cache:
             return self._schema_cache[exclude_key]
 
-        schema = self.schema
-        if exclude_key:
-            # Need to exclude some parameters - create a shallow copy to avoid mutating cached schema
-            schema = dict(schema)
-            if self.location == ParameterLocation.HEADER:
-                # Remove excluded headers case-insensitively
-                exclude_lower = {name.lower() for name in exclude_key}
-                schema["properties"] = {
-                    key: value for key, value in schema["properties"].items() if key.lower() not in exclude_lower
-                }
-                if "required" in schema:
-                    schema["required"] = [key for key in schema["required"] if key.lower() not in exclude_lower]
-            else:
-                # Non-header locations: remove by exact name
-                schema["properties"] = {
-                    key: value for key, value in schema["properties"].items() if key not in exclude_key
-                }
-                if "required" in schema:
-                    schema["required"] = [key for key in schema["required"] if key not in exclude_key]
-
+        schema = self._apply_exclusions(self.schema, exclude_key)
         self._schema_cache[exclude_key] = schema
+        return schema
+
+    def _apply_exclusions(self, base: dict[str, Any], exclude_key: frozenset[str]) -> dict[str, Any]:
+        if not exclude_key:
+            return base
+        # Need to exclude some parameters - create a shallow copy to avoid mutating cached schema
+        schema = dict(base)
+        if self.location == ParameterLocation.HEADER:
+            # Remove excluded headers case-insensitively
+            exclude_lower = {name.lower() for name in exclude_key}
+            schema["properties"] = {
+                key: value for key, value in schema["properties"].items() if key.lower() not in exclude_lower
+            }
+            if "required" in schema:
+                schema["required"] = [key for key in schema["required"] if key.lower() not in exclude_lower]
+        else:
+            # Non-header locations: remove by exact name
+            schema["properties"] = {key: value for key, value in schema["properties"].items() if key not in exclude_key}
+            if "required" in schema:
+                schema["required"] = [key for key in schema["required"] if key not in exclude_key]
         return schema
 
     def get_strategy(
@@ -1115,6 +1120,12 @@ class OpenApiParameterSet(ParameterSet):
             strategy = st.none()
         else:
             assert isinstance(operation.schema, OpenApiSchema)
+            # Negative filter needs `prefixItems` intact so `Draft202012Validator` can be constructed.
+            validation_schema_obj: JsonSchema | None = None
+            if strategy_factory is make_negative_strategy:
+                validation_schema_obj = self._apply_exclusions(
+                    parameters_to_validation_schema(self.items, self.location), exclude_key
+                )
             strategy = strategy_factory(
                 schema_obj,
                 operation.label,
@@ -1123,6 +1134,7 @@ class OpenApiParameterSet(ParameterSet):
                 generation_config,
                 operation.schema.adapter.jsonschema_validator_cls,
                 self.name_to_uri,
+                validation_schema=validation_schema_obj,
             )
 
             # For negative strategies, we need to handle GeneratedValue wrappers
@@ -1267,6 +1279,15 @@ def form_data_to_json_schema(parameters: Sequence[Mapping[str, Any]]) -> dict[st
 def parameters_to_json_schema(parameters: Iterable[OpenApiParameter], location: ParameterLocation) -> dict[str, Any]:
     """Convert multiple Open API parameters to a JSON Schema."""
     parameter_data = ((param.name, param.optimized_schema, param.is_required) for param in parameters)
+
+    return _merge_parameters_to_object_schema(parameter_data, location)
+
+
+def parameters_to_validation_schema(
+    parameters: Iterable[OpenApiParameter], location: ParameterLocation
+) -> dict[str, Any]:
+    """Merge parameters' validation schemas — `prefixItems` intact, suitable for Draft 2020-12 validators."""
+    parameter_data = ((param.name, param.validation_schema, param.is_required) for param in parameters)
 
     return _merge_parameters_to_object_schema(parameter_data, location)
 

--- a/src/schemathesis/specs/openapi/converter.py
+++ b/src/schemathesis/specs/openapi/converter.py
@@ -17,6 +17,7 @@ def to_json_schema(
     update_quantifiers: bool = True,
     clone: bool = True,
     upgrade_legacy_exclusive_bounds: bool = False,
+    convert_prefix_items: bool = True,
     name_to_uri: dict[str, str] | None = None,
 ) -> dict[str, Any]: ...  # pragma: no cover
 
@@ -29,6 +30,7 @@ def to_json_schema(
     update_quantifiers: bool = True,
     clone: bool = True,
     upgrade_legacy_exclusive_bounds: bool = False,
+    convert_prefix_items: bool = True,
     name_to_uri: dict[str, str] | None = None,
 ) -> bool: ...  # pragma: no cover
 
@@ -40,6 +42,7 @@ def to_json_schema(
     update_quantifiers: bool = True,
     clone: bool = True,
     upgrade_legacy_exclusive_bounds: bool = False,
+    convert_prefix_items: bool = True,
     name_to_uri: dict[str, str] | None = None,
 ) -> dict[str, Any] | bool:
     if isinstance(schema, bool):
@@ -52,6 +55,7 @@ def to_json_schema(
         is_response_schema=is_response_schema,
         update_quantifiers=update_quantifiers,
         upgrade_legacy_exclusive_bounds=upgrade_legacy_exclusive_bounds,
+        convert_prefix_items=convert_prefix_items,
         name_to_uri=name_to_uri,
     )
 
@@ -63,6 +67,7 @@ def _to_json_schema(
     is_response_schema: bool = False,
     update_quantifiers: bool = True,
     upgrade_legacy_exclusive_bounds: bool = False,
+    convert_prefix_items: bool = True,
     name_to_uri: dict[str, str] | None = None,
 ) -> JsonSchema:
     if not isinstance(schema, dict):
@@ -126,9 +131,9 @@ def _to_json_schema(
 
     ensure_required_properties(schema)
 
-    # Convert JSON Schema Draft 2020-12 prefixItems to Draft 4/7 items array form
-    # hypothesis-jsonschema only supports Draft 4/6/7
-    if "prefixItems" in schema:
+    # Convert prefixItems -> items[array] for hypothesis-jsonschema (Draft 4/7-only).
+    # Skipped when the consumer needs `prefixItems` to stay intact (e.g. for Draft 2020-12 validators).
+    if convert_prefix_items and "prefixItems" in schema:
         prefix_items = schema.pop("prefixItems")
         if "items" in schema:
             # When both prefixItems and items exist, items becomes additionalItems
@@ -149,6 +154,7 @@ def _to_json_schema(
                 is_response_schema=is_response_schema,
                 update_quantifiers=update_quantifiers,
                 upgrade_legacy_exclusive_bounds=upgrade_legacy_exclusive_bounds,
+                convert_prefix_items=convert_prefix_items,
                 name_to_uri=name_to_uri,
             )
         elif keyword in IN_ITEM and isinstance(value, list):
@@ -159,6 +165,7 @@ def _to_json_schema(
                     is_response_schema=is_response_schema,
                     update_quantifiers=update_quantifiers,
                     upgrade_legacy_exclusive_bounds=upgrade_legacy_exclusive_bounds,
+                    convert_prefix_items=convert_prefix_items,
                     name_to_uri=name_to_uri,
                 )
         elif keyword in IN_CHILD and isinstance(value, dict):
@@ -169,6 +176,7 @@ def _to_json_schema(
                     is_response_schema=is_response_schema,
                     update_quantifiers=update_quantifiers,
                     upgrade_legacy_exclusive_bounds=upgrade_legacy_exclusive_bounds,
+                    convert_prefix_items=convert_prefix_items,
                     name_to_uri=name_to_uri,
                 )
 
@@ -305,6 +313,7 @@ IN_ITEM = frozenset(
         "allOf",
         "anyOf",
         "oneOf",
+        "prefixItems",
     )
 )
 IN_CHILD = frozenset(

--- a/src/schemathesis/specs/openapi/negative/__init__.py
+++ b/src/schemathesis/specs/openapi/negative/__init__.py
@@ -135,6 +135,7 @@ def negative_schema(
     *,
     custom_formats: dict[str, st.SearchStrategy[str]],
     validator_cls: type[jsonschema_rs.Validator],
+    validation_schema: JsonSchema | None = None,
     name_to_uri: dict[str, str] | None = None,
 ) -> st.SearchStrategy:
     """A strategy for instances that DO NOT match the input schema.
@@ -142,11 +143,20 @@ def negative_schema(
     It is used to cover the input space that is not possible to cover with the "positive" strategy.
 
     Returns a strategy that produces GeneratedValue instances with mutation metadata.
+
+    `validation_schema`, when provided, keeps `prefixItems` intact and is used only to build the
+    runtime validator; falls back to `schema`.
     """
     # The mutated schema is passed to `from_schema` and guarded against producing instances valid against
     # the original schema.
     cache_key = CacheKey(operation_name, location, schema, validator_cls, frozenset(custom_formats))
-    validator = get_validator(cache_key)
+    # Build the validator from the form with `prefixItems` intact so meta-validation accepts it.
+    validator_cache_key = (
+        cache_key
+        if validation_schema is None or validation_schema is schema
+        else CacheKey(operation_name, location, validation_schema, validator_cls, frozenset(custom_formats))
+    )
+    validator = get_validator(validator_cache_key)
     keywords, non_keywords = split_schema(cache_key)
 
     # For unconstrained binary/byte schemas, skip the validation filter entirely.

--- a/test/specs/openapi/test_negative.py
+++ b/test/specs/openapi/test_negative.py
@@ -474,6 +474,47 @@ def test_openapi_31_legacy_exclusive_bounds_in_negative_generation(ctx):
     test()
 
 
+def test_openapi_31_prefix_items_query_param_negative_generation(ctx):
+    # Draft 2020-12 `prefixItems` must not crash the negative-path validator with
+    # `items is not of types boolean, object` from meta-validation.
+    schema_dict = ctx.openapi.build_schema(
+        {
+            "/box": {
+                "parameters": [
+                    {
+                        "name": "box",
+                        "in": "query",
+                        "schema": {
+                            "type": "array",
+                            "minItems": 4,
+                            "maxItems": 4,
+                            "prefixItems": [
+                                {"type": "number", "minimum": -180.0, "maximum": 180.0},
+                                {"type": "number", "minimum": -90.0, "maximum": 90.0},
+                                {"type": "number", "minimum": -180.0, "maximum": 180.0},
+                                {"type": "number", "minimum": -90.0, "maximum": 90.0},
+                            ],
+                            "items": {"type": "number", "minimum": -180.0, "maximum": 180.0},
+                        },
+                    }
+                ],
+                "get": {"responses": {"200": {"description": "OK"}}},
+            },
+        },
+        version="3.1.0",
+    )
+
+    schema = schemathesis.openapi.from_dict(schema_dict)
+    operation = schema["/box"]["GET"]
+
+    @given(case=operation.as_strategy(generation_mode=GenerationMode.NEGATIVE))
+    @settings(max_examples=1, suppress_health_check=list(HealthCheck))
+    def test(case):
+        pass
+
+    test()
+
+
 @pytest.mark.hypothesis_nested
 def test_optional_query_param_negation(ctx):
     # When all query parameters are optional


### PR DESCRIPTION
Fixes #3842 