### PR TITLE
fix: Set `filename` on binary `multipart/form-data` parts; use `encoding.headers.Content-Disposition` if present, field name otherwise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - False positive `use_after_free` on a second DELETE — DELETE is idempotent (RFC 7231 §4.3.5).
 - Include the prior DELETE in `use_after_free` reproduce when it is a sibling step.
 - False positive `positive_data_acceptance` when a runtime pool body variant was missing required fields. [#3949](https://github.com/schemathesis/schemathesis/issues/3949)
+- Set `filename` on binary `multipart/form-data` parts; use `encoding.headers.Content-Disposition` if present, field name otherwise. [#3951](https://github.com/schemathesis/schemathesis/issues/3951)
 
 ### :wrench: Changed
 

--- a/src/schemathesis/specs/openapi/adapter/formdata.py
+++ b/src/schemathesis/specs/openapi/adapter/formdata.py
@@ -64,15 +64,23 @@ def prepare_multipart_v3(
 
         if property_schema:
             if isinstance(value, list):
-                if content_type:
+                items_format = (property_schema.get("items") or {}).get("format")
+                if items_format in ("binary", "base64"):
+                    filename = (body_param.get_property_filename(name) if body_param else None) or name
+                    if content_type:
+                        files.extend((name, (filename, item, content_type)) for item in value)
+                    else:
+                        files.extend((name, (filename, item)) for item in value)
+                elif content_type:
                     files.extend((name, (None, item, content_type)) for item in value)
                 else:
                     files.extend((name, item) for item in value)
             elif property_schema.get("format") in ("binary", "base64"):
+                filename = (body_param.get_property_filename(name) if body_param else None) or name
                 if content_type:
-                    files.append((name, (None, value, content_type)))
+                    files.append((name, (filename, value, content_type)))
                 else:
-                    files.append((name, value))
+                    files.append((name, (filename, value)))
             elif content_type:
                 files.append((name, (None, value, content_type)))
             else:

--- a/src/schemathesis/specs/openapi/adapter/parameters.py
+++ b/src/schemathesis/specs/openapi/adapter/parameters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
@@ -619,6 +620,17 @@ class OpenApiBody(OpenApiComponent):
         encoding = self.definition.get("encoding", {})
         property_encoding = encoding.get(property_name, {})
         return property_encoding.get("contentType")
+
+    def get_property_filename(self, property_name: str) -> str | None:
+        """Get filename from encoding.headers.Content-Disposition for a form property."""
+        encoding = self.definition.get("encoding", {})
+        headers = encoding.get(property_name, {}).get("headers", {})
+        cd = headers.get("Content-Disposition", {})
+        value = cd.get("example") or (cd.get("schema") or {}).get("example")
+        if not value:
+            return None
+        match = re.search(r'filename="([^"]*)"', value) or re.search(r"filename=(\S+)", value)
+        return match.group(1) if match else None
 
     def get_strategy(
         self,

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -254,9 +254,142 @@ def test_unknown_multipart_fields_openapi3(ctx):
     )
     serialized = REQUESTS_TRANSPORT.serialize_case(case)
     assert serialized["files"] == [
-        ("data", b"\x92B"),
+        ("data", ("data", b"\x92B")),
         ("note", (None, "foo")),
         ("unknown", (None, "seen")),
+    ]
+
+
+@pytest.mark.parametrize(
+    "encoding,expected_filename",
+    [
+        # No encoding: field name is used as filename for binary parts
+        (None, "attachment"),
+        # encoding.headers.Content-Disposition.schema.example provides filename
+        (
+            {
+                "attachment": {
+                    "headers": {
+                        "Content-Disposition": {
+                            "schema": {
+                                "type": "string",
+                                "example": 'form-data; name="attachment"; filename="test.pdf"',
+                            }
+                        }
+                    }
+                }
+            },
+            "test.pdf",
+        ),
+        # encoding.headers.Content-Disposition.example (no schema wrapping)
+        (
+            {
+                "attachment": {
+                    "headers": {
+                        "Content-Disposition": {
+                            "example": 'form-data; name="attachment"; filename="doc.pdf"',
+                        }
+                    }
+                }
+            },
+            "doc.pdf",
+        ),
+    ],
+    ids=["field-name-fallback", "schema-example", "header-example"],
+)
+def test_multipart_binary_field_filename(ctx, encoding, expected_filename):
+    content: dict = {
+        "schema": {
+            "type": "object",
+            "properties": {"attachment": {"type": "string", "format": "binary"}},
+        }
+    }
+    if encoding is not None:
+        content["encoding"] = encoding
+    schema = ctx.openapi.build_schema(
+        {
+            "/test": {
+                "post": {
+                    "requestBody": {
+                        "required": True,
+                        "content": {"multipart/form-data": content},
+                    },
+                    "responses": {"200": {"description": "OK"}},
+                },
+            },
+        }
+    )
+    schema = schemathesis.openapi.from_dict(schema)
+    case = schema["/test"]["POST"].Case(body={"attachment": b"\x92\x42"}, media_type="multipart/form-data")
+    serialized = REQUESTS_TRANSPORT.serialize_case(case)
+    assert serialized["files"] == [("attachment", (expected_filename, b"\x92B"))]
+
+
+@pytest.mark.parametrize(
+    "encoding,expected_filename",
+    [
+        # No encoding: field name is used as filename for binary list items
+        (None, "files"),
+        # encoding.headers.Content-Disposition.schema.example provides filename
+        (
+            {
+                "files": {
+                    "headers": {
+                        "Content-Disposition": {
+                            "schema": {
+                                "type": "string",
+                                "example": 'form-data; name="files"; filename="upload.bin"',
+                            }
+                        }
+                    }
+                }
+            },
+            "upload.bin",
+        ),
+        # encoding.headers.Content-Disposition.example (no schema wrapping)
+        (
+            {
+                "files": {
+                    "headers": {
+                        "Content-Disposition": {
+                            "example": 'form-data; name="files"; filename="data.bin"',
+                        }
+                    }
+                }
+            },
+            "data.bin",
+        ),
+    ],
+    ids=["field-name-fallback", "schema-example", "header-example"],
+)
+def test_multipart_binary_list_filename(ctx, encoding, expected_filename):
+    content: dict = {
+        "schema": {
+            "type": "object",
+            "properties": {"files": {"type": "array", "items": {"type": "string", "format": "binary"}}},
+        }
+    }
+    if encoding is not None:
+        content["encoding"] = encoding
+    schema = ctx.openapi.build_schema(
+        {
+            "/test": {
+                "post": {
+                    "requestBody": {
+                        "required": True,
+                        "content": {"multipart/form-data": content},
+                    },
+                    "responses": {"200": {"description": "OK"}},
+                },
+            },
+        }
+    )
+    schema = schemathesis.openapi.from_dict(schema)
+    case = schema["/test"]["POST"].Case(body={"files": [b"\x01", b"\x02"]}, media_type="multipart/form-data")
+    serialized = REQUESTS_TRANSPORT.serialize_case(case)
+    assert serialized["files"] == [
+        ("files", (expected_filename, b"\x01")),
+        ("files", (expected_filename, b"\x02")),
     ]
 
 


### PR DESCRIPTION
Fixes #3951