### PR TITLE
fix: JUnit and Allure reports marked all test cases as skipped when a schema had no inline examples, even though Coverage or Fuzzing phases ran successfully afterwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Recognize nested foreign-key body fields independently of the spec's `paths` ordering.
 - Drop spec examples invalidated by inferred constraints from the example mixer.
 - False positive `negative_data_rejection` for integer/number query parameters when an array element is a numeric string. [#3931](https://github.com/schemathesis/schemathesis/issues/3931)
+- JUnit and Allure reports marked all test cases as skipped when a schema had no inline examples, even though Coverage or Fuzzing phases ran successfully afterwards. [#3738](https://github.com/schemathesis/schemathesis/issues/3738)
 - False positive `negative_data_rejection` on 405 responses from routing-level rejection.
 - False positive `response_headers_conformance` for Swagger 2.0 array headers serialised via `collectionFormat`.
 - False positive `use_after_free` on a second DELETE - DELETE is idempotent (RFC 7231 §4.3.5).

--- a/src/schemathesis/cli/commands/run/handlers/allure.py
+++ b/src/schemathesis/cli/commands/run/handlers/allure.py
@@ -62,6 +62,10 @@ class AllureHandler(EventHandler):
             self.writer.record_error(label=event.label, message=event.info.format())
 
     def shutdown(self, ctx: BaseExecutionContext) -> None:
+        for label in ctx.statistic.tested_operations:
+            result = self.writer._results.get(label)
+            if result is not None and result.status == "passed":
+                self.writer._skip_reasons.pop(label, None)
         self.writer.close()
 
 

--- a/src/schemathesis/cli/commands/run/handlers/junitxml.py
+++ b/src/schemathesis/cli/commands/run/handlers/junitxml.py
@@ -69,6 +69,9 @@ class JunitXMLHandler(EventHandler):
             self.writer.record_error(label=event.label, message=event.info.format())
 
     def shutdown(self, ctx: BaseExecutionContext) -> None:
+        for label, test_case in self.writer._test_cases.items():
+            if label in ctx.statistic.tested_operations:
+                test_case.skipped = []
         self.writer.close()
 
 

--- a/test/cli/test_allure.py
+++ b/test/cli/test_allure.py
@@ -91,6 +91,28 @@ def test_allure_stateful_phase_produces_result(ctx, cli, tmp_path):
         assert not any(lbl["name"] == "feature" for lbl in data["labels"])
 
 
+def test_examples_phase_skip_cleared_when_coverage_runs(ctx, cli, tmp_path):
+    # When the Examples phase skips an operation (schema has no inline examples)
+    # but the Coverage phase subsequently runs and produces real results,
+    # the Allure report must NOT mark the result as skipped and must not
+    # populate statusDetails with the skip reason.
+    api = ctx.openapi.apps.success()
+    allure_dir = tmp_path / "allure-results"
+    cli.run_and_assert(
+        api.schema_url,
+        f"--report-allure-path={allure_dir}",
+        "--phases=examples,coverage",
+        "--checks=all",
+    )
+    result_files = list(allure_dir.glob("*-result.json"))
+    assert result_files
+    for data in (json.loads(f.read_text()) for f in result_files):
+        # Coverage ran real requests — status must not be skipped
+        assert data["status"] != "skipped"
+        # And the skip reason must not leak into statusDetails
+        assert data.get("statusDetails", {}).get("message") != "No examples in schema"
+
+
 def test_allure_layer_label(ctx, cli, tmp_path):
     api = ctx.openapi.apps.success()
     allure_dir = tmp_path / "allure-results"

--- a/test/cli/test_junitxml.py
+++ b/test/cli/test_junitxml.py
@@ -223,6 +223,27 @@ def test_skipped(ctx, cli, tmp_path):
     assert extract_message(testcases[0][0], f"127.0.0.1:{api.port}") == "No examples in schema"
 
 
+def test_examples_phase_skip_cleared_when_coverage_runs(ctx, cli, tmp_path):
+    # When the Examples phase skips an operation (schema has no inline examples)
+    # but the Coverage phase subsequently runs and produces real results,
+    # the JUnit report must NOT mark the test case as skipped.
+    api = ctx.openapi.apps.success()
+    xml_path = tmp_path / "junit.xml"
+    cli.run(
+        api.schema_url,
+        f"--report-junit-path={xml_path}",
+        "--phases=examples,coverage",
+        "--checks=all",
+    )
+    tree = ElementTree.parse(xml_path)
+    testsuite = tree.getroot()[0]
+    testcases = list(testsuite)
+    assert testcases[0].tag == "testcase"
+    assert testcases[0].attrib["name"] == "GET /api/success"
+    # Coverage ran real requests — the earlier skip must have been cleared
+    assert not testcases[0].findall("skipped")
+
+
 @pytest.mark.parametrize("path", ["junit.xml", "does-not-exist/junit.xml"])
 @pytest.mark.skipif(platform.system() == "Windows", reason="Unclear how to trigger the permission error on Windows")
 def test_permission_denied(ctx, cli, tmp_path, path):


### PR DESCRIPTION
Fixes #3738 