### PR TITLE
fix: Retry slow schema endpoints (read timeouts) under `--wait-for-schema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Emit a populated positive baseline for `type: array` parameters so item-level keywords reach coverage.
 - Drop wildcard `*/*` from Swagger 2.0 `consumes` so coverage requests carry a concrete `Content-Type`.
 - Treat 409 Conflict as a valid rejection status for `negative_data_rejection`.
+- Retry slow schema endpoints (read timeouts) under `--wait-for-schema`. [#4058](https://github.com/schemathesis/schemathesis/issues/4058)
 
 ## [4.18.3](https://github.com/schemathesis/schemathesis/compare/v4.18.2...v4.18.3) - 2026-05-12
 

--- a/src/schemathesis/core/loaders.py
+++ b/src/schemathesis/core/loaders.py
@@ -105,7 +105,9 @@ def load_from_url(
         retried = retry(
             wait=wait_fixed(WAIT_FOR_SCHEMA_INTERVAL),
             stop=stop_after_delay(wait_for_schema),
-            retry=retry_if_exception_type((requests.exceptions.ConnectionError, _ServiceUnavailableError)),
+            retry=retry_if_exception_type(
+                (requests.exceptions.ConnectionError, requests.exceptions.Timeout, _ServiceUnavailableError)
+            ),
             reraise=True,
         )(_func)
 

--- a/test/loaders/test_common.py
+++ b/test/loaders/test_common.py
@@ -1,8 +1,10 @@
 """Tests for common schema loading logic shared by all loaders."""
 
+import time
 from contextlib import suppress
 
 import pytest
+from flask import Flask, jsonify
 
 import schemathesis
 from schemathesis.core.transport import USER_AGENT
@@ -70,3 +72,23 @@ def test_auth_loader_options(ctx):
     api = ctx.openapi.apps.success()
     schemathesis.openapi.from_url(api.schema_url, auth=("test", "test"))
     assert api.schema_requests[0].headers["Authorization"] == "Basic dGVzdDp0ZXN0"
+
+
+def test_wait_for_schema_retries_on_read_timeout(ctx, app_runner):
+    # A slow-to-respond server (read timeout) must be retried within the wait budget,
+    # the same way connection refused or HTTP 503 is.
+    schema = ctx.openapi.build_schema({"/x": {"get": {"responses": {"200": {"description": "OK"}}}}})
+    call_count = [0]
+    app = Flask(__name__)
+
+    @app.route("/openapi.json")
+    def openapi_spec():
+        call_count[0] += 1
+        if call_count[0] == 1:
+            time.sleep(0.5)
+        return jsonify(schema)
+
+    url = app_runner.openapi_url(app)
+    loaded = schemathesis.openapi.from_url(url, wait_for_schema=5, timeout=0.2)
+    assert loaded.raw_schema == schema
+    assert call_count[0] == 2


### PR DESCRIPTION
Resolves #4058