### PR TITLE
fix(Dockerfile): install sqlite-libs in runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ COPY --from=python-builder /opt/python /opt/python
 
 COPY --from=app-builder /opt/venv /opt/venv
 
-RUN apk add --no-cache ca-certificates libgcc libstdc++
+RUN apk add --no-cache ca-certificates libgcc libstdc++ sqlite-libs
 
 RUN addgroup --gid 1000 -S schemathesis && \
     adduser --uid 1000 -D -S schemathesis -G schemathesis -s /sbin/nologin


### PR DESCRIPTION
## Summary

The `runtime` stage in the published Docker image installs `ca-certificates libgcc libstdc++` but **not** `sqlite-libs`. The `python-builder` stage builds CPython 3.14t with SQLite support (its apk-add list includes `sqlite-dev`), so `_sqlite3.cpython-314t-*.so` is produced and copied into the final image — but without `libsqlite3.so.0` at runtime the extension can't load. Any `import sqlite3` crashes; `pyrate-limiter`'s package-level import chain triggers it through `pyrate_limiter/utils.py:1`, which makes `--rate-limit` unusable.

This has been broken in every image since v4.11.0 (when the build switched from `uv python install 3.14t` to compiling Python from source). v4.10.0 was the last working release.

## Reproducer

```bash
docker run --rm schemathesis/schemathesis:4.18.4 run --rate-limit=1/s http://example.com
```

### Before (unpatched `schemathesis/schemathesis:4.18.4`)

```
Traceback (most recent call last):
  File "/opt/venv/bin/schemathesis", line 6, in <module>
    sys.exit(schemathesis())
             ~~~~~~~~~~~~^^
  File "/opt/venv/lib/python3.14t/site-packages/click/core.py", line 1514, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  ... (click parse chain) ...
  File "/opt/venv/lib/python3.14t/site-packages/schemathesis/cli/validation.py", line 87, in validate_rate_limit
    rate_limit.parse_units(raw_value)
  File "/opt/venv/lib/python3.14t/site-packages/schemathesis/core/rate_limit.py", line 22, in parse_units
    from pyrate_limiter import Duration
  File "/opt/venv/lib/python3.14t/site-packages/pyrate_limiter/__init__.py", line 9, in <module>
    from .buckets import InMemoryBucket as InMemoryBucket
  File "/opt/venv/lib/python3.14t/site-packages/pyrate_limiter/buckets/__init__.py", line 4, in <module>
    from .in_memory_bucket import InMemoryBucket as InMemoryBucket
  File "/opt/venv/lib/python3.14t/site-packages/pyrate_limiter/buckets/in_memory_bucket.py", line 7, in <module>
    from ..utils import binary_search
  File "/opt/venv/lib/python3.14t/site-packages/pyrate_limiter/utils.py", line 1, in <module>
    import sqlite3
  File "/opt/python/lib/python3.14t/sqlite3/__init__.py", line 57, in <module>
    from sqlite3.dbapi2 import *
  File "/opt/python/lib/python3.14t/sqlite3/dbapi2.py", line 27, in <module>
    from _sqlite3 import *
ImportError: Error loading shared library libsqlite3.so.0: No such file or
directory (needed by /opt/python/lib/python3.14t/lib-dynload/_sqlite3.cpython-314t-x86_64-linux-musl.so)
```

### After (locally built from this branch)

```
Schemathesis v4.18.4
━━━━━━━━━━━━━━━━━━━━


 ❌  Failed to load specification from http://example.com after 0.24s

 Schema Loading Error

 The provided API schema does not appear to be a valid OpenAPI schema
```

`--rate-limit=1/s` is parsed cleanly, the CLI advances into normal schema loading, and the only failure is the unrelated and expected "example.com is not an OpenAPI document".

## Patch

```diff
- RUN apk add --no-cache ca-certificates libgcc libstdc++
+ RUN apk add --no-cache ca-certificates libgcc libstdc++ sqlite-libs
```

(one line, runtime stage, ~1.5 MB added to the final image.)

## Verified

- Bisected: v4.10.0 OK (uv-managed Python bundles SQLite), v4.11.0+ broken (source-built Python without the runtime shared lib).
- v4.11.0, v4.12.0, v4.13.0, v4.14.0, v4.15.0, v4.16.0, v4.17.0, v4.18.0, v4.18.1, v4.18.2, v4.18.3, v4.18.4 all reproduce.
- Patched image: `import sqlite3` succeeds, `import pyrate_limiter` succeeds, `--rate-limit=1/s` parses, CLI proceeds.

Closes #4098.
