### PR TITLE
fix: Runtime Error on hook-driven revalidation of OpenAPI 3.1 parameters with `prefixItems`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### :bug: Fixed
 
+- Runtime Error on hook-driven revalidation of OpenAPI 3.1 parameters with `prefixItems`. [#4099](https://github.com/schemathesis/schemathesis/issues/4099)
 - Send `formData` Swagger 2.0 parameters as form payloads when `consumes` only declares non-form media types.
 - Generate positive body cases for schemas inheriting `additionalProperties: false` through deep `allOf` chains.
 - Missing `sqlite-libs` in docker images.

--- a/src/schemathesis/generation/case.py
+++ b/src/schemathesis/generation/case.py
@@ -253,12 +253,12 @@ class Case:
                 if _contains_bytes(value):
                     return False
                 if alternative.media_type == self.media_type:
-                    return make_validator(alternative.optimized_schema, validator_cls).is_valid(value)
+                    return make_validator(alternative.validation_schema, validator_cls).is_valid(value)
         # Validate other locations against container schema
         container = getattr(self.operation, location.container_name)
         if isinstance(value, CaseInsensitiveDict):
             value = dict(value)
-        return make_validator(container.schema, validator_cls).is_valid(value)
+        return make_validator(container.validation_schema, validator_cls).is_valid(value)
 
     def _hash_container(self, value: object) -> int:
         """Create a hash representing the current state of a container.

--- a/src/schemathesis/specs/openapi/adapter/parameters.py
+++ b/src/schemathesis/specs/openapi/adapter/parameters.py
@@ -1132,7 +1132,16 @@ class OpenApiParameterSet(ParameterSet):
     items: list[OpenApiParameter]
     location: ParameterLocation
 
-    __slots__ = ("items", "location", "adapter", "_schema", "_schema_cache", "_strategy_cache", "_strict_validator")
+    __slots__ = (
+        "items",
+        "location",
+        "adapter",
+        "_schema",
+        "_validation_schema",
+        "_schema_cache",
+        "_strategy_cache",
+        "_strict_validator",
+    )
 
     def __init__(
         self,
@@ -1145,6 +1154,7 @@ class OpenApiParameterSet(ParameterSet):
         self.adapter = adapter
         self.items = items or []
         self._schema: dict | NotSet = NOT_SET
+        self._validation_schema: dict | NotSet = NOT_SET
         self._schema_cache: dict[frozenset[str], dict[str, Any]] = {}
         self._strategy_cache: dict[tuple[frozenset[str], GenerationMode, int | None], st.SearchStrategy] = {}
         self._strict_validator: jsonschema_rs.Validator | NotSet = NOT_SET
@@ -1162,6 +1172,14 @@ class OpenApiParameterSet(ParameterSet):
             self._schema = parameters_to_json_schema(self.items, self.location)
         assert not isinstance(self._schema, NotSet)
         return self._schema
+
+    @property
+    def validation_schema(self) -> dict[str, Any]:
+        # Suitable for Draft 2020-12 validators — keeps `prefixItems` intact.
+        if self._validation_schema is NOT_SET:
+            self._validation_schema = parameters_to_validation_schema(self.items, self.location)
+        assert not isinstance(self._validation_schema, NotSet)
+        return self._validation_schema
 
     @property
     def name_to_uri(self) -> dict[str, str]:

--- a/test/python/test_case_metadata.py
+++ b/test/python/test_case_metadata.py
@@ -195,6 +195,50 @@ def test_nested_dict_modification_detected(ctx):
     assert case.meta.generation.mode == GenerationMode.NEGATIVE
 
 
+def test_hook_modifies_query_with_prefix_items_revalidates(ctx):
+    # OpenAPI 3.1 query schemas with `prefixItems` must not crash Draft 2020-12 revalidation.
+    schema = ctx.openapi.load_schema(
+        {
+            "/box": {
+                "parameters": [
+                    {
+                        "name": "box",
+                        "in": "query",
+                        "schema": {
+                            "type": "array",
+                            "minItems": 4,
+                            "maxItems": 4,
+                            "prefixItems": [
+                                {"type": "number", "minimum": -180.0, "maximum": 180.0},
+                                {"type": "number", "minimum": -90.0, "maximum": 90.0},
+                                {"type": "number", "minimum": -180.0, "maximum": 180.0},
+                                {"type": "number", "minimum": -90.0, "maximum": 90.0},
+                            ],
+                            "items": {"type": "number", "minimum": -180.0, "maximum": 180.0},
+                        },
+                    },
+                ],
+                "get": {"responses": {"200": {"description": "OK"}}},
+            },
+        },
+        version="3.1.0",
+    )
+    operation = schema["/box"]["GET"]
+
+    meta = make_positive_meta(ParameterLocation.QUERY)
+    case = Case(
+        operation=operation,
+        method="GET",
+        path="/box",
+        query={"box": [0, 0, 1, 1]},
+        meta=meta,
+    )
+
+    # Hook-style reassignment marks the container dirty and triggers revalidation.
+    case.query = {"box": [0, 0, 1, 1]}
+    assert case.meta.generation.mode == GenerationMode.POSITIVE
+
+
 def test_hook_adds_required_field_metadata_updates(ctx):
     # See GH-3073
     schema = ctx.openapi.load_schema(


### PR DESCRIPTION
Fixes #4099 