### PR TITLE
fix: False positive `negative_data_rejection` when a `before_call` hook reassigns request parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### :bug: Fixed
 
 - Runtime Error on hook-driven revalidation of OpenAPI 3.1 parameters with `prefixItems`. [#4099](https://github.com/schemathesis/schemathesis/issues/4099)
+- False positive `negative_data_rejection` when a `before_call` hook reassigns request parameters. [#4101](https://github.com/schemathesis/schemathesis/issues/4101)
 - Pad negative-mode arrays to satisfy `minItems` so per-item violations fire instead of length violations.
 - Send `formData` Swagger 2.0 parameters as form payloads when `consumes` only declares non-form media types.
 - Generate positive body cases for schemas inheriting `additionalProperties: false` through deep `allOf` chains.

--- a/src/schemathesis/generation/case.py
+++ b/src/schemathesis/generation/case.py
@@ -215,6 +215,9 @@ class Case:
             value = getattr(self, location.container_name)
             hash_value = self._hash_container(value)
             self._meta.update_validated_hash(location, hash_value)
+            # Snapshot the wire-form hash so revalidation can tell whether the
+            # container is still the unmodified value produced by generation.
+            self._meta._initial_hashes[location] = hash_value
 
     def _check_modifications(self) -> None:
         """Detect in-place modifications by comparing container hashes."""

--- a/src/schemathesis/generation/meta.py
+++ b/src/schemathesis/generation/meta.py
@@ -200,10 +200,18 @@ class CaseMetadata:
     # Resource-bound (location, parameter_name) slots the engine wanted to fill from the pool
     # but couldn't (no captured instance). Lets the analyzer compute chain rate.
     pool_misses: tuple[tuple[str, str], ...]
+    # Typed (pre-serialization) container snapshots captured at generation time.
+    # Coverage stringifies query/path values for the wire; this preserves the
+    # original typed form so revalidation matches the schema's abstraction level.
+    raw_containers: dict[ParameterLocation, Any]
 
     # Dirty tracking for revalidation
     _dirty: set[ParameterLocation]
     _last_validated_hashes: dict[ParameterLocation, int]
+    # Initial container hashes captured once after generation; never updated.
+    # Lets revalidation detect whether a container still matches its wire-form
+    # snapshot (so the typed `raw_containers` value remains authoritative).
+    _initial_hashes: dict[ParameterLocation, int]
 
     __slots__ = (
         "generation",
@@ -211,8 +219,10 @@ class CaseMetadata:
         "phase",
         "pool_draws",
         "pool_misses",
+        "raw_containers",
         "_dirty",
         "_last_validated_hashes",
+        "_initial_hashes",
     )
 
     def __init__(
@@ -222,15 +232,18 @@ class CaseMetadata:
         phase: PhaseInfo,
         pool_draws: tuple[PoolDraw, ...] = (),
         pool_misses: tuple[tuple[str, str], ...] = (),
+        raw_containers: dict[ParameterLocation, Any] | None = None,
     ) -> None:
         self.generation = generation
         self.components = components
         self.phase = phase
         self.pool_draws = pool_draws
         self.pool_misses = pool_misses
+        self.raw_containers = raw_containers if raw_containers is not None else {}
         # Initialize dirty tracking
         self._dirty = set()
         self._last_validated_hashes = {}
+        self._initial_hashes = {}
 
     def mark_dirty(self, location: ParameterLocation) -> None:
         """Mark a component as modified and needing revalidation."""
@@ -286,6 +299,7 @@ class CaseMetadata:
                 for draw in self.pool_draws
             ],
             "pool_misses": [list(miss) for miss in self.pool_misses],
+            "raw_containers": {loc.name: value for loc, value in self.raw_containers.items()},
         }
 
     @classmethod
@@ -349,12 +363,16 @@ class CaseMetadata:
                 mutations=_load_mutations(phase_data_raw),
             )
         phase = PhaseInfo(name=TestPhase(data["phase"]["name"]), data=phase_data)
+        raw_containers = {
+            ParameterLocation[loc_name]: value for loc_name, value in data.get("raw_containers", {}).items()
+        }
         return cls(
             generation=generation,
             components=components,
             phase=phase,
             pool_draws=pool_draws,
             pool_misses=pool_misses,
+            raw_containers=raw_containers,
         )
 
 

--- a/src/schemathesis/specs/openapi/coverage/_operation.py
+++ b/src/schemathesis/specs/openapi/coverage/_operation.py
@@ -16,7 +16,7 @@ from schemathesis.core import NOT_SET, NotSet, media_types
 from schemathesis.core.errors import InvalidSchema, MalformedMediaType
 from schemathesis.core.jsonschema import make_validator
 from schemathesis.core.media_types import FORM_MEDIA_TYPES, MEDIA_TYPE_STRATEGIES, find_media_type_strategy
-from schemathesis.core.parameters import ParameterLocation
+from schemathesis.core.parameters import CONTAINER_TO_LOCATION, ParameterLocation
 from schemathesis.core.transforms import deepclone
 from schemathesis.generation import GenerationMode
 from schemathesis.generation.case import Case
@@ -418,6 +418,16 @@ def iter_coverage_cases(
         phase: PhaseInfo,
         raw: dict[str, Any],
     ) -> CaseMetadata:
+        # Preserve typed parameter containers so revalidation can validate against
+        # the schema's abstraction level, not the stringified wire form on the case.
+        # Body is excluded — it doesn't go through parameter stringification.
+        raw_containers: dict[ParameterLocation, Any] = {
+            location: value
+            for name, value in raw.items()
+            if (location := CONTAINER_TO_LOCATION.get(name)) is not None
+            and location in components
+            and location != ParameterLocation.BODY
+        }
         # Filter operation-level draws/misses to only those whose slot actually appears in
         # the yielded request. Coverage variants that omit an optional resource-bound slot,
         # or synthesised probes that drop one parameter while keeping a pooled path param,
@@ -428,6 +438,7 @@ def iter_coverage_cases(
             phase=phase,
             pool_draws=_filter_draws_for_case(raw, correlated, correlated_draws),
             pool_misses=_filter_misses_for_case(raw, correlated_misses),
+            raw_containers=raw_containers,
         )
 
     inferred_properties_per_location: dict[ParameterLocation, dict[str, Any] | None] = {}

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -226,11 +226,19 @@ class OpenApiSchema(BaseSchema):
         validator_cls = self.adapter.jsonschema_validator_cls
         for location in list(meta._dirty):
             value = getattr(case, location.container_name)
-            is_valid = case._validate_component(location, value, validator_cls)
+            current_hash = case._hash_container(value)
+            # When the container still equals its generated form, validate the typed
+            # snapshot — coverage stringifies query/path values for the wire and the
+            # validation schema is expressed in the typed form.
+            if current_hash == meta._initial_hashes.get(location) and location in meta.raw_containers:
+                validation_value = meta.raw_containers[location]
+            else:
+                validation_value = value
+            is_valid = case._validate_component(location, validation_value, validator_cls)
             if location in meta.components:
                 new_mode = GenerationMode.POSITIVE if is_valid else GenerationMode.NEGATIVE
                 meta.components[location] = ComponentInfo(mode=new_mode)
-            meta.update_validated_hash(location, case._hash_container(value))
+            meta.update_validated_hash(location, current_hash)
             meta.clear_dirty(location)
         if meta.components:
             if all(info.mode.is_positive for info in meta.components.values()):

--- a/test/python/test_case_metadata.py
+++ b/test/python/test_case_metadata.py
@@ -239,6 +239,47 @@ def test_hook_modifies_query_with_prefix_items_revalidates(ctx):
     assert case.meta.generation.mode == GenerationMode.POSITIVE
 
 
+def test_hook_self_assigns_stringified_query_keeps_positive(ctx):
+    # See GH-4101 — stringified query containers must validate against the typed
+    # snapshot so a no-op hook reassignment doesn't flip the case to NEGATIVE.
+    schema = ctx.openapi.load_schema(
+        {
+            "/point": {
+                "parameters": [
+                    {
+                        "name": "lat",
+                        "in": "query",
+                        "required": True,
+                        "schema": {"type": "number", "minimum": -90, "maximum": 90},
+                    },
+                    {
+                        "name": "lon",
+                        "in": "query",
+                        "required": True,
+                        "schema": {"type": "number", "minimum": -180, "maximum": 180},
+                    },
+                ],
+                "get": {"responses": {"200": {"description": "OK"}}},
+            },
+        },
+        version="3.1.0",
+    )
+    operation = schema["/point"]["GET"]
+
+    meta = make_positive_meta(ParameterLocation.QUERY)
+    meta.raw_containers[ParameterLocation.QUERY] = {"lat": 0, "lon": 0}
+    case = Case(
+        operation=operation,
+        method="GET",
+        path="/point",
+        query={"lat": "0", "lon": "0"},
+        meta=meta,
+    )
+
+    case.query = case.query
+    assert case.meta.generation.mode == GenerationMode.POSITIVE
+
+
 def test_hook_adds_required_field_metadata_updates(ctx):
     # See GH-3073
     schema = ctx.openapi.load_schema(


### PR DESCRIPTION
Fixes #4101