### PR TITLE
docs: fix typo in coverage operation comment

### DIFF
--- a/src/schemathesis/specs/openapi/coverage/_operation.py
+++ b/src/schemathesis/specs/openapi/coverage/_operation.py
@@ -153,7 +153,7 @@ def _stringify_value(val: Any, container_name: str) -> Any:
         return str(val)
     if isinstance(val, list):
         if container_name == "query":
-            # Having a list here ensures there will be multiple query parameters wit the same name
+            # Having a list here ensures there will be multiple query parameters with the same name
             return [_stringify_value(item, container_name) for item in val]
         # use comma-separated values style for arrays
         return ",".join(str(_stringify_value(sub, container_name)) for sub in val)


### PR DESCRIPTION
Fixes a small typo in a code comment in `_operation.py`: "wit the same name" → "with the same name".

Comment-only change, no behavior impact.