### PR TITLE
fix: Schema loading crash for external `$ref` paths containing URI-reserved characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### :bug: Fixed
 
+- Schema loading crash for external `$ref` paths containing URI-reserved characters (e.g. `paths/{id}/op.yaml`). [#4152](https://github.com/schemathesis/schemathesis/issues/4152)
 - Out-of-memory in coverage phase on wide, deeply-nested OpenAPI schemas (e.g. AWS Glue, Microsoft Graph).
 - Surface a clean schema error for body `$ref` strings without a `/` separator.
 - RecursionError in coverage phase on multi-branch `allOf` schemas that `canonicalish` cannot simplify.

--- a/src/schemathesis/core/jsonschema/resolver.py
+++ b/src/schemathesis/core/jsonschema/resolver.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
-from urllib.parse import urldefrag, urljoin
+from urllib.parse import quote, urldefrag, urljoin, urlsplit, urlunsplit
 from urllib.request import urlopen
 
 import jsonschema_rs
@@ -64,6 +64,24 @@ class Resolver:
         return value
 
 
+# RFC 3986 §3.3 path characters plus `%` so already percent-encoded sequences pass through.
+_SAFE_URI_PATH_CHARS = "/:@!$&'()*+,;=%-._~"
+
+
+def _quote_unsafe_uri_path(uri: str) -> str:
+    """Percent-encode reserved characters in a URI's path component.
+
+    `urljoin` does not percent-encode, so a relative `$ref` like
+    `./paths/{id}/op.yaml` produces a URI with raw `{`/`}` that
+    `jsonschema_rs.Registry` rejects as an invalid URI reference.
+    """
+    parts = urlsplit(uri)
+    quoted_path = quote(parts.path, safe=_SAFE_URI_PATH_CHARS)
+    if quoted_path == parts.path:
+        return uri
+    return urlunsplit(parts._replace(path=quoted_path))
+
+
 def _normalize_location(location: str) -> str:
     """Convert a plain filesystem path to a `file://` URI so relative refs resolve via urljoin.
 
@@ -71,7 +89,7 @@ def _normalize_location(location: str) -> str:
     a scheme that `urljoin` does not treat as relative-aware.
     """
     if "://" in location or location.startswith("urn:"):
-        return location
+        return _quote_unsafe_uri_path(location)
     return Path(os.path.abspath(location)).as_uri()
 
 

--- a/test/core/jsonschema/test_resolver_adapter.py
+++ b/test/core/jsonschema/test_resolver_adapter.py
@@ -82,3 +82,20 @@ def test_resolve_reference_translates_missing_references_to_ref_resolution_error
         resolve_reference(resolver, "https://example.com/missing.json")
 
     assert exc.value.__notes__ == ["https://example.com/missing.json"]
+
+
+def test_resolve_reference_to_file_path_with_uri_reserved_characters(tmp_path):
+    # Split-file OpenAPI layouts mirror path templates; refs like 'paths/{id}/op.yaml' must resolve.
+    target_dir = tmp_path / "paths" / "{id}"
+    target_dir.mkdir(parents=True)
+    target_file = target_dir / "op.yaml"
+    target_file.write_text("$defs:\n  value:\n    type: string\n")
+
+    root_file = tmp_path / "root.yaml"
+    root_schema = {"$ref": "paths/{id}/op.yaml#/$defs/value"}
+    root_file.write_text(json.dumps(root_schema))
+
+    resolver = make_root_resolver(root_schema, location=root_file.as_uri())
+    _, resolved = resolve_reference(resolver, root_schema["$ref"])
+
+    assert resolved == {"type": "string"}

--- a/test/loaders/test_openapi.py
+++ b/test/loaders/test_openapi.py
@@ -77,6 +77,40 @@ def test_number_deserializing(ctx, testdir):
     assert isinstance(value, float)
 
 
+def test_split_file_schema_with_uri_reserved_path_chars(tmp_path):
+    # Split-file OpenAPI layouts mirror path templates; refs like './paths/{id}/op.yaml' must resolve.
+    target_dir = tmp_path / "paths" / "{id}"
+    target_dir.mkdir(parents=True)
+    (target_dir / "op.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "get": {
+                    "operationId": "getItem",
+                    "parameters": [{"name": "id", "in": "path", "required": True, "schema": {"type": "string"}}],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        )
+    )
+    root = tmp_path / "openapi.yaml"
+    root.write_text(
+        yaml.safe_dump(
+            {
+                "openapi": "3.0.0",
+                "info": {"title": "repro", "version": "1.0"},
+                "paths": {"/items/{id}": {"$ref": "./paths/{id}/op.yaml"}},
+            }
+        )
+    )
+
+    schema = schemathesis.openapi.from_path(str(root))
+    operation = schema["/items/{id}"]["GET"]
+
+    assert operation.label == "GET /items/{id}"
+    assert operation.definition.raw["operationId"] == "getItem"
+    assert [(p.name, p.location) for p in operation.iter_parameters()] == [("id", "path")]
+
+
 def test_unsupported_type():
     # When Schemathesis can't detect the Open API spec version
     with pytest.raises(


### PR DESCRIPTION
Fixes #4152 