### PR TITLE
fix: Revert "Out-of-range negatives for integer fields with `format: int32` / `int64` during the coverage phase"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@
 - Set `Content-Type: application/json` on JSON-serialized nested `multipart/form-data` parts.
 - Emit a non-empty alphabetic string (e.g. `AAA`) as the string-type negative for non-string parameters so `?q=` no longer collapses to absent on the wire.
 - Skip report aggregation for crashed xdist workers instead of failing the whole controller with `AttributeError`.
-- Out-of-range negatives for integer fields with `format: int32` / `int64` during the coverage phase.
 - Emit `maxLength` negatives for string schemas whose `format` makes the exact length unsatisfiable when `maxLength` exceeds 100.
 
 ## [4.19.0](https://github.com/schemathesis/schemathesis/compare/v4.18.5...v4.19.0) - 2026-05-19

--- a/src/schemathesis/specs/openapi/coverage/_schema.py
+++ b/src/schemathesis/specs/openapi/coverage/_schema.py
@@ -87,12 +87,6 @@ VALIDATED_FORMATS = frozenset(
     }
 )
 
-# Signed-integer format ranges (OpenAPI). Used to emit out-of-range values as negative cases.
-INTEGER_FORMAT_BOUNDS: dict[str, tuple[int, int]] = {
-    "int32": (-(2**31), 2**31 - 1),
-    "int64": (-(2**63), 2**63 - 1),
-}
-
 _FORMAT_VALIDATORS: dict[tuple[str, type], jsonschema_rs.Validator] = {}
 
 
@@ -1254,8 +1248,6 @@ def cover_schema_iter(
                     # Binary formats accept any bytes - no meaningful format violations
                     if value not in ("binary", "byte"):
                         yield from _negative_format(ctx, schema, value)
-                elif key == "format" and "integer" in types and value in INTEGER_FORMAT_BOUNDS:
-                    yield from _negative_integer_format(ctx, value, seen)
                 elif key == "maximum":
                     next = value + 1
                     if seen.insert(next):
@@ -2758,18 +2750,6 @@ def _negative_format(
         description=f"Value not matching the '{format}' format",
         location=ctx.current_path,
     )
-
-
-def _negative_integer_format(ctx: CoverageContext, format: str, seen: HashSet) -> Generator[GeneratedValue, None, None]:
-    lower, upper = INTEGER_FORMAT_BOUNDS[format]
-    for value, side in ((upper + 1, "upper"), (lower - 1, "lower")):
-        if seen.insert(value):
-            yield NegativeValue(
-                value,
-                scenario=CoverageScenario.INVALID_FORMAT,
-                description=f"Value outside '{format}' {side} bound",
-                location=ctx.current_path,
-            )
 
 
 def _is_non_integer_float(x: float) -> bool:

--- a/test/coverage/test_combinations.py
+++ b/test/coverage/test_combinations.py
@@ -454,48 +454,6 @@ def test_negative_maxlength_above_buffer(nctx, max_length):
     assert len(above_max[0]) == max_length + 1
 
 
-@pytest.mark.parametrize(
-    ("format", "expected"),
-    [
-        ("int32", {2**31, -(2**31) - 1}),
-        ("int64", {2**63, -(2**63) - 1}),
-    ],
-)
-def test_negative_integer_format_overflow(nctx, format, expected):
-    schema = {"type": "integer", "format": format}
-    overflow = {
-        value.value
-        for value in cover_schema_iter(nctx, schema)
-        if isinstance(value, GeneratedValue) and value.scenario is CoverageScenario.INVALID_FORMAT
-    }
-    assert overflow == expected
-
-
-def test_negative_integer_format_with_explicit_bounds(nctx):
-    # Explicit bounds tighter than the format do not suppress format-overflow negatives.
-    schema = {"type": "integer", "format": "int32", "minimum": -100, "maximum": 100}
-    values = {
-        value.value
-        for value in cover_schema_iter(nctx, schema)
-        if isinstance(value, GeneratedValue)
-        and value.scenario
-        in (CoverageScenario.INVALID_FORMAT, CoverageScenario.VALUE_ABOVE_MAXIMUM, CoverageScenario.VALUE_BELOW_MINIMUM)
-    }
-    assert {101, -101, 2**31, -(2**31) - 1}.issubset(values)
-
-
-@pytest.mark.parametrize("format", ["int16", "uint32", "weird", "binary"])
-def test_negative_integer_format_unknown_no_emission(nctx, format):
-    # Only OpenAPI-standard integer formats produce overflow negatives.
-    schema = {"type": "integer", "format": format}
-    overflow = [
-        value
-        for value in cover_schema_iter(nctx, schema)
-        if isinstance(value, GeneratedValue) and value.scenario is CoverageScenario.INVALID_FORMAT
-    ]
-    assert overflow == []
-
-
 @pytest.mark.parametrize("multiple_of", [None, 2])
 @pytest.mark.parametrize(
     ("schema", "values", "with_multiple_of"),


### PR DESCRIPTION
This reverts commit b0f1127029f2807322ba240753e445579bca514a.