### PR TITLE
fix: Apply `tls-verify` and `tls-cert` to dynamic auth token requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Skip coverage boundary-length variants that are structurally impossible for the declared `pattern`.
 
+### :bug: Fixed
+
+- Apply `tls-verify` and `tls-cert` to dynamic auth token requests. [#4199](https://github.com/schemathesis/schemathesis/issues/4199)
+
 ## [4.20.0](https://github.com/schemathesis/schemathesis/compare/v4.19.0...v4.20.0) - 2026-05-24
 
 ### :rocket: Added

--- a/src/schemathesis/specs/openapi/auths.py
+++ b/src/schemathesis/specs/openapi/auths.py
@@ -136,10 +136,18 @@ class DynamicTokenAuthProvider:
 
     def _fetch_http(self, ctx: AuthContext) -> str:
         url = get_full_path(ctx.operation.schema.get_base_url() + "/", self.path)
-        timeout = ctx.operation.schema.config.request_timeout_for(operation=ctx.operation)
+        config = ctx.operation.schema.config
+        timeout = config.request_timeout_for(operation=ctx.operation)
+        verify = config.tls_verify_for(operation=ctx.operation)
+        cert = config.request_cert_for(operation=ctx.operation)
         body, headers = self._build_body()
+        kwargs: dict[str, Any] = {}
+        if verify is not None:
+            kwargs["verify"] = verify
+        if cert is not None:
+            kwargs["cert"] = cert
         try:
-            response = requests.request(self.method, url, data=body, headers=headers, timeout=timeout)
+            response = requests.request(self.method, url, data=body, headers=headers, timeout=timeout, **kwargs)
         except requests.exceptions.RequestException as exc:
             raise AuthenticationError(
                 "DynamicTokenAuthProvider",

--- a/test/auth/test_dynamic_auth.py
+++ b/test/auth/test_dynamic_auth.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import socket
 
 import pytest
+import requests
 from flask import Response as FlaskResponse
 from flask import jsonify, request
 
@@ -107,6 +108,29 @@ def test_get_raises_on_error(auth_operation, path, extract_from, extract_selecto
     )
     with pytest.raises(AuthenticationError, match=match):
         provider.get(auth_operation.Case(), ctx)
+
+
+def test_fetch_http_forwards_tls_config(ctx, app_runner, mocker):
+    app, _ = ctx.openapi.make_flask_app({"/data": {"get": {"responses": {"200": {"description": "OK"}}}}})
+
+    @app.route("/api/auth", methods=["POST"])
+    def auth():
+        return jsonify({"access_token": "test-token"})
+
+    spy = mocker.patch("requests.request", wraps=requests.request)
+    schema = schemathesis.openapi.from_url(app_runner.openapi_url(app))
+    schema.config.tls_verify = False
+    operation = schema["/data"]["GET"]
+    provider = DynamicTokenAuthProvider(
+        path="/api/auth",
+        method="post",
+        payload=None,
+        extract_from="body",
+        extract_selector="/access_token",
+        _applier=HttpBearerAuthProvider(bearer=""),
+    )
+    assert provider.get(operation.Case(), AuthContext(operation=operation, app=None)) == "test-token"
+    assert spy.call_args[1]["verify"] is False
 
 
 def test_get_raises_on_connection_error(ctx, cli, app_runner):


### PR DESCRIPTION
Fixes #4199 