### PR TITLE
fix: `UnicodeEncodeError` when failure or error output contains lone Unicode surrogate characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### :bug: Fixed
 
 - Missing boundary negative in the coverage phase for boolean `exclusiveMinimum` / `exclusiveMaximum`.
+- `UnicodeEncodeError` when failure or error output contains lone Unicode surrogate characters. [#4229](https://github.com/schemathesis/schemathesis/issues/4229)
 
 ## [4.21.0](https://github.com/schemathesis/schemathesis/compare/v4.20.3...v4.21.0) - 2026-06-01
 

--- a/src/schemathesis/core/failures.py
+++ b/src/schemathesis/core/failures.py
@@ -11,7 +11,7 @@ from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any
 
 from schemathesis.core.compat import BaseExceptionGroup
-from schemathesis.core.output import prepare_response_payload
+from schemathesis.core.output import escape_surrogates, prepare_response_payload
 from schemathesis.core.transport import Response
 
 if TYPE_CHECKING:
@@ -366,4 +366,4 @@ def format_failures(
     _curl = "\n".join(f"    {line}" for line in curl.splitlines())
     output += "\n" + formatter(MessageBlock.CURL, f"\nReproduce with:\n\n{_curl}")
 
-    return output
+    return escape_surrogates(output)

--- a/src/schemathesis/core/output/__init__.py
+++ b/src/schemathesis/core/output/__init__.py
@@ -9,6 +9,12 @@ if TYPE_CHECKING:
 TRUNCATED = "// Output truncated..."
 
 
+def escape_surrogates(text: str) -> str:
+    # Lone surrogates (e.g. echoed back by a server) are valid `str` but cannot be UTF-8 encoded
+    # for terminal or report output; escape them instead of letting the write crash.
+    return text.encode("utf-8", "backslashreplace").decode("utf-8")
+
+
 def truncate_json(data: Any, *, config: OutputConfig, max_lines: int | None = None) -> str:
     # Convert JSON to string with indentation
     indent = 4

--- a/src/schemathesis/engine/errors.py
+++ b/src/schemathesis/engine/errors.py
@@ -26,6 +26,7 @@ from schemathesis.core.errors import (
     get_request_error_message,
     split_traceback,
 )
+from schemathesis.core.output import escape_surrogates
 
 if TYPE_CHECKING:
     import hypothesis.errors
@@ -212,7 +213,7 @@ class EngineErrorInfo:
         if suggestion is not None:
             message.append(f"\nTip: {suggestion}")
 
-        return "\n".join(message)
+        return escape_surrogates("\n".join(message))
 
 
 def scalar_name_from_error(exception: hypothesis.errors.InvalidArgument) -> str:

--- a/test/cli/test_surrogate_output.py
+++ b/test/cli/test_surrogate_output.py
@@ -1,0 +1,52 @@
+import json
+
+from flask import Response
+
+import schemathesis
+from schemathesis.cli.output import DEFAULT_INTERNAL_ERROR_MESSAGE
+
+
+def test_lone_surrogate_in_check_message(cli, ctx):
+    # `response.json()` decodes the server's ASCII `\uXXXX` escape into a real lone surrogate;
+    # a check surfacing it must not crash the failure renderer when written to a UTF-8 terminal.
+    app, _ = ctx.openapi.make_flask_app({"/echo": {"post": {"responses": {"200": {"description": "OK"}}}}})
+
+    @app.route("/echo", methods=["POST"])
+    def echo():
+        return Response(json.dumps({"error": "rejected: \udc4b"}), status=400, content_type="application/json")
+
+    with ctx.restore_checks():
+
+        @schemathesis.check
+        def surface_rejected_value(ctx, response, case):
+            if response.status_code >= 400:
+                raise AssertionError(f"server said: {response.json()['error']}")
+
+        result = cli.run_openapi_app(app, "--checks=surface_rejected_value", "--max-examples=5")
+
+    assert result.exception is None or isinstance(result.exception, SystemExit), result.exception
+    assert DEFAULT_INTERNAL_ERROR_MESSAGE not in result.stdout, result.stdout
+    assert "server said: rejected:" in result.stdout, result.stdout
+
+
+def test_lone_surrogate_in_engine_error(cli, ctx):
+    # A check raising a non-`Failure` exception surfaces as an engine error; its message carries
+    # the lone surrogate into the ERRORS renderer, which must not crash on a UTF-8 terminal.
+    app, _ = ctx.openapi.make_flask_app({"/echo": {"post": {"responses": {"200": {"description": "OK"}}}}})
+
+    @app.route("/echo", methods=["POST"])
+    def echo():
+        return Response(json.dumps({"error": "rejected: \udc4b"}), status=400, content_type="application/json")
+
+    with ctx.restore_checks():
+
+        @schemathesis.check
+        def explode_on_value(ctx, response, case):
+            if response.status_code >= 400:
+                raise RuntimeError(f"boom: {response.json()['error']}")
+
+        result = cli.run_openapi_app(app, "--checks=explode_on_value", "--max-examples=5")
+
+    assert result.exception is None or isinstance(result.exception, SystemExit), result.exception
+    assert DEFAULT_INTERNAL_ERROR_MESSAGE not in result.stdout, result.stdout
+    assert "boom:" in result.stdout, result.stdout


### PR DESCRIPTION
Fixes #4229 