### PR TITLE
docs: fix example output in extending-cli to match format strings

### DIFF
--- a/docs/guides/extending-cli.md
+++ b/docs/guides/extending-cli.md
@@ -135,10 +135,10 @@ schemathesis run \
 
 **Output:**
 ```
-Starting test case #1
-✓ Test case #1 passed
-Starting test case #2
-✗ Test case #2 failed
+Starting test #1
+✓ Test #1 passed
+Starting test #2
+✗ Test #2 failed
 
 Counter Summary:
   Total events: 125


### PR DESCRIPTION
## What

The example output block in `docs/guides/extending-cli.md` showed:

```
Starting test case #1
✓ Test case #1 passed
Starting test case #2
✗ Test case #2 failed
```

But the format strings directly above it use:

```python
ctx.add_summary_line(f"Starting test #{self.test_cases}")
ctx.add_summary_line(f"✓ Test #{self.test_cases} passed")
ctx.add_summary_line(f"✗ Test #{self.test_cases} failed")
```

These would actually produce `Starting test #1`, `✓ Test #1 passed`, and `✗ Test #1 failed` — without the word `case`.

## Why

The mismatch would confuse a reader trying to follow the example and verify what output to expect from their own CLI extension.

## How verified

Traced each `ctx.add_summary_line(f"...")` call to its corresponding line in the output block. The fix removes the extra word `case` from the output block to match the format strings exactly.