### PR TITLE
Fix session cookie leakage between generated requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.21.1...HEAD) - TBD
 
+### :bug: Fixed
+
+- Prevent response cookies from leaking between generated requests when Schemathesis reuses an engine-managed `requests.Session`.
+
 ## [4.21.1](https://github.com/schemathesis/schemathesis/compare/v4.21.0...v4.21.1) - 2026-06-06
 
 ### :bug: Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### :bug: Fixed
 
-- Prevent response cookies from leaking between generated requests when Schemathesis reuses an engine-managed `requests.Session`.
+- Response cookies leaking between generated test cases, causing false authentication failures.
 
 ## [4.21.1](https://github.com/schemathesis/schemathesis/compare/v4.21.0...v4.21.1) - 2026-06-06
 

--- a/src/schemathesis/engine/context.py
+++ b/src/schemathesis/engine/context.py
@@ -190,10 +190,7 @@ class EngineContext:
 
 def make_session(config: ProjectConfig, *, operation: APIOperation | None = None) -> requests.Session:
     """Build a `requests.Session` configured from project config."""
-    import requests
-
-    class ManagedCookiesSession(requests.Session):
-        _schemathesis_managed_cookies = True
+    from schemathesis.transport.requests import ManagedCookiesSession
 
     session = ManagedCookiesSession()
     session.headers = {}

--- a/src/schemathesis/engine/context.py
+++ b/src/schemathesis/engine/context.py
@@ -192,7 +192,10 @@ def make_session(config: ProjectConfig, *, operation: APIOperation | None = None
     """Build a `requests.Session` configured from project config."""
     import requests
 
-    session = requests.Session()
+    class ManagedCookiesSession(requests.Session):
+        _schemathesis_managed_cookies = True
+
+    session = ManagedCookiesSession()
     session.headers = {}
     session.verify = config.tls_verify_for(operation=operation)
     auth = config.auth_for(operation=operation)

--- a/src/schemathesis/transport/requests.py
+++ b/src/schemathesis/transport/requests.py
@@ -9,6 +9,7 @@ from io import BytesIO
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlencode, urlparse
 
+import requests
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 from typing_extensions import override
 
@@ -25,9 +26,11 @@ from schemathesis.transport.prepare import get_exclude_headers, prepare_body, pr
 from schemathesis.transport.serialization import Binary, serialize_binary, serialize_json, serialize_xml, serialize_yaml
 
 if TYPE_CHECKING:
-    import requests
-
     from schemathesis.generation.case import Case
+
+
+class ManagedCookiesSession(requests.Session):
+    """`requests.Session` whose response cookies are dropped between generated requests."""
 
 
 def _normalize_query_component(params: Any) -> str:
@@ -130,8 +133,6 @@ class RequestsTransport(BaseTransport["requests.Session"]):
 
     @override
     def send(self, case: Case, *, session: requests.Session | None = None, **kwargs: Any) -> Response:
-        import requests
-
         config = case.operation.schema.config
 
         max_redirects = kwargs.pop("max_redirects", None) or config.max_redirects_for(operation=case.operation)
@@ -179,8 +180,6 @@ class RequestsTransport(BaseTransport["requests.Session"]):
                 if "Authorization" in excluded_headers:
                     current_session_auth = session.auth
                     session.auth = None
-            if getattr(session, "_schemathesis_managed_cookies", False):
-                current_session_cookies = session.cookies.copy()
             close_session = False
         if max_redirects is not None:
             session.max_redirects = max_redirects
@@ -219,9 +218,8 @@ class RequestsTransport(BaseTransport["requests.Session"]):
                 session.auth = current_session_auth
             if close_session:
                 session.close()
-            if current_session_cookies is not None:
+            elif isinstance(session, ManagedCookiesSession):
                 session.cookies.clear()
-                session.cookies.update(current_session_cookies)
 
 
 def validate_vanilla_requests_kwargs(data: dict[str, Any]) -> None:

--- a/src/schemathesis/transport/requests.py
+++ b/src/schemathesis/transport/requests.py
@@ -179,6 +179,8 @@ class RequestsTransport(BaseTransport["requests.Session"]):
                 if "Authorization" in excluded_headers:
                     current_session_auth = session.auth
                     session.auth = None
+            if getattr(session, "_schemathesis_managed_cookies", False):
+                current_session_cookies = session.cookies.copy()
             close_session = False
         if max_redirects is not None:
             session.max_redirects = max_redirects
@@ -217,6 +219,9 @@ class RequestsTransport(BaseTransport["requests.Session"]):
                 session.auth = current_session_auth
             if close_session:
                 session.close()
+            if current_session_cookies is not None:
+                session.cookies.clear()
+                session.cookies.update(current_session_cookies)
 
 
 def validate_vanilla_requests_kwargs(data: dict[str, Any]) -> None:

--- a/test/engine/test_context.py
+++ b/test/engine/test_context.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import threading
 
 import pytest
-import requests
+from flask import make_response, request
 
+import schemathesis
 from schemathesis.core.result import Ok
 from schemathesis.engine.context import EngineContext
 from schemathesis.engine.health import TIGHTENED_TIMEOUT_SECONDS
@@ -69,18 +70,25 @@ def test_get_transport_kwargs_override_reverts_after_completion(ctx):
     assert engine.get_transport_kwargs(operation=operation)["timeout"] == 5.0
 
 
-def test_managed_session_does_not_keep_response_cookies(ctx, mocker, response_factory):
-    schema, operation = _build_schema_and_operation(ctx)
+def test_managed_session_does_not_leak_response_cookies(ctx, app_runner):
+    received_cookies = []
+
+    app, _ = ctx.openapi.make_flask_app({"/cookie": {"get": {"responses": {"200": {"description": "OK"}}}}})
+
+    @app.route("/cookie")
+    def cookie():
+        received_cookies.append(request.cookies.get("session"))
+        response = make_response("")
+        response.set_cookie("session", "leaked")
+        return response
+
+    schema = schemathesis.openapi.from_url(app_runner.openapi_url(app))
+    operation = next(result.ok() for result in schema.get_all_operations() if isinstance(result, Ok))
     engine = EngineContext(schema=schema, stop_event=threading.Event())
     kwargs = engine.get_transport_kwargs(operation=operation)
-    session = kwargs["session"]
 
-    def request(self, **_: object) -> requests.Response:
-        self.cookies.set("session", "abc", domain="127.0.0.1", path="/")
-        return response_factory.requests()
+    operation.Case().call(**kwargs)
+    operation.Case().call(**kwargs)
 
-    mocker.patch("requests.Session.request", request)
-
-    operation.Case().call(base_url="http://127.0.0.1", **kwargs)
-
-    assert not session.cookies
+    # The cookie set by the first response must not be replayed on the second request.
+    assert received_cookies == [None, None]

--- a/test/engine/test_context.py
+++ b/test/engine/test_context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import threading
 
 import pytest
+import requests
 
 from schemathesis.core.result import Ok
 from schemathesis.engine.context import EngineContext
@@ -66,3 +67,20 @@ def test_get_transport_kwargs_override_reverts_after_completion(ctx):
     assert engine.get_transport_kwargs(operation=operation)["timeout"] == TIGHTENED_TIMEOUT_SECONDS
     engine.health.record_completion(operation_label=operation.label)
     assert engine.get_transport_kwargs(operation=operation)["timeout"] == 5.0
+
+
+def test_managed_session_does_not_keep_response_cookies(ctx, mocker, response_factory):
+    schema, operation = _build_schema_and_operation(ctx)
+    engine = EngineContext(schema=schema, stop_event=threading.Event())
+    kwargs = engine.get_transport_kwargs(operation=operation)
+    session = kwargs["session"]
+
+    def request(self, **_: object) -> requests.Response:
+        self.cookies.set("session", "abc", domain="127.0.0.1", path="/")
+        return response_factory.requests()
+
+    mocker.patch("requests.Session.request", request)
+
+    operation.Case().call(base_url="http://127.0.0.1", **kwargs)
+
+    assert not session.cookies


### PR DESCRIPTION

### Description

This change prevents cookies set by one response from being carried into later generated requests when Schemathesis reuses an engine-managed requests.Session. That stops auth cookies like session from accidentally authenticating follow-up cases and causing false positives such as “API accepts invalid authentication.”
### Checklist

- [x] Added failing tests for the change
- [x] All new and existing tests pass
- [x] Added changelog entry
- [x] Updated README/documentation, if necessary
