### PR TITLE
fix: False positive `positive_data_acceptance` for array parameters with a percent-encoded `,`/`|` separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.21.6...HEAD) - TBD
 
+### :bug: Fixed
+
+- False positive `positive_data_acceptance` for array parameters with a percent-encoded `,`/`|` separator. [#4246](https://github.com/schemathesis/schemathesis/issues/4246)
+
 ### :racing_car: Performance
 
 - Faster stateful dependency analysis on large schemas.

--- a/src/schemathesis/core/parameters.py
+++ b/src/schemathesis/core/parameters.py
@@ -1,5 +1,6 @@
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
+from urllib.parse import quote
 
 # Attribute name on `Case` / `APIOperation` holding generated values for a parameter location.
 ContainerName: TypeAlias = Literal["path_parameters", "query", "headers", "cookies", "body"]
@@ -21,6 +22,54 @@ class RawQueryString(str):
 
 # Internal key used to carry raw query string payloads for OpenAPI 3.2 `in: querystring`.
 RAW_QUERY_STRING_KEY = "x-schemathesis-raw-query-string"
+
+
+# `DelimitedValue`/`EncodedPath` are `str` subclasses; flatten containers holding them with
+# `plain_str_values` before any jsonschema_rs call, which rejects `str` subclasses.
+class DelimitedValue(str):
+    """A delimiter-joined array/object parameter.
+
+    The string is the logical form; `encoded` is the wire form (each element percent-encoded,
+    delimiter left literal) so a server can split it unambiguously.
+    """
+
+    encoded: str
+    __slots__ = ("encoded",)
+
+    def __new__(cls, logical: str, encoded: str) -> "DelimitedValue":
+        instance = super().__new__(cls, logical)
+        instance.encoded = encoded
+        return instance
+
+
+class EncodedPath(str):
+    """A fully percent-encoded path parameter value. Re-quoting it is a no-op."""
+
+    __slots__ = ()
+
+
+def plain_str_values(container: dict[str, Any]) -> dict[str, Any]:
+    """Downcast `str` subclasses to plain `str`; jsonschema_rs rejects subclasses."""
+    converted = None
+    for key, value in container.items():
+        if type(value) is not str and isinstance(value, str):
+            if converted is None:
+                converted = dict(container)
+            converted[key] = str(value)
+    return converted if converted is not None else container
+
+
+def split_delimited_query(params: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Split off pre-encoded delimited values, returning their `key=value` chunk and the rest."""
+    raw_parts = [
+        f"{quote(str(key), safe='')}={value.encoded}"
+        for key, value in params.items()
+        if isinstance(value, DelimitedValue)
+    ]
+    if not raw_parts:
+        return "", params
+    rest = {key: value for key, value in params.items() if not isinstance(value, DelimitedValue)}
+    return "&".join(raw_parts), rest
 
 
 class ParameterLocation(str, Enum):

--- a/src/schemathesis/generation/case.py
+++ b/src/schemathesis/generation/case.py
@@ -13,7 +13,7 @@ from schemathesis.core import NOT_SET, SCHEMATHESIS_TEST_CASE_HEADER, Body, NotS
 from schemathesis.core.errors import IncorrectUsage
 from schemathesis.core.failures import Failure, FailureGroup, failure_report_title, format_failures
 from schemathesis.core.jsonschema import make_validator
-from schemathesis.core.parameters import CONTAINER_TO_LOCATION, ParameterLocation
+from schemathesis.core.parameters import CONTAINER_TO_LOCATION, ParameterLocation, plain_str_values
 from schemathesis.core.transport import HttpMethod, Response, prepare_urlencoded
 from schemathesis.core.validation import has_invalid_characters, is_latin_1_encodable
 from schemathesis.engine import Status
@@ -265,6 +265,8 @@ class Case(Generic[OperationT]):
         container = getattr(self.operation, location.container_name)
         if isinstance(value, CaseInsensitiveDict):
             value = dict(value)
+        if isinstance(value, dict):
+            value = plain_str_values(value)
         return make_validator(container.validation_schema, validator_cls).is_valid(value)
 
     def _hash_container(self, value: object) -> int:

--- a/src/schemathesis/resources/repository.py
+++ b/src/schemathesis/resources/repository.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import jsonschema_rs
 
-from schemathesis.core.parameters import ParameterLocation
+from schemathesis.core.parameters import ParameterLocation, plain_str_values
 from schemathesis.core.transforms import UNRESOLVABLE, Unresolvable, resolve_pointer, resolve_pointer_all
 from schemathesis.core.transport import status_code_matches
 from schemathesis.resources.descriptors import Cardinality, ResourceDescriptor, ResourceFieldRef
@@ -220,6 +220,9 @@ class ResourceRepository:
         Maintains diversity by limiting instances per context and evicting
         oldest contexts when capacity is reached.
         """
+        # Delimited markers carry transport-only data; resource identifiers use the plain form.
+        data = plain_str_values(data)
+        context = plain_str_values(context) if context else context
         # Create a stable key for the context
         context_key = jsonschema_rs.canonical.json.to_string(context) if context else ""
 

--- a/src/schemathesis/specs/openapi/checks.py
+++ b/src/schemathesis/specs/openapi/checks.py
@@ -15,7 +15,7 @@ from schemathesis.core import media_types, string_to_boolean
 from schemathesis.core.failures import AcceptedNegativeData, Failure
 from schemathesis.core.jsonschema import FANCY_REGEX_OPTIONS, get_type, make_validator, maybe_resolve_bundled
 from schemathesis.core.mutations import OperatorKind
-from schemathesis.core.parameters import ParameterLocation
+from schemathesis.core.parameters import ParameterLocation, plain_str_values
 from schemathesis.core.transport import Response
 from schemathesis.generation.case import Case
 from schemathesis.generation.meta import CoveragePhaseData, CoverageScenario, FuzzingPhaseData
@@ -601,6 +601,8 @@ def _non_body_negative_values_match_schema(case: Case) -> bool:
         if not container:
             continue
         v = dict(value) if location == ParameterLocation.HEADER else value
+        if isinstance(v, dict):
+            v = plain_str_values(v)
         try:
             if not container.get_strict_validator().is_valid(v):
                 # At least one parameter is invalid

--- a/src/schemathesis/specs/openapi/extra_data_source.py
+++ b/src/schemathesis/specs/openapi/extra_data_source.py
@@ -12,7 +12,7 @@ from schemathesis.core.errors import InvalidSchema, MalformedMediaType
 from schemathesis.core.jsonschema import make_validator, schema_with_bundle
 from schemathesis.core.jsonschema.bundler import BundleError
 from schemathesis.core.jsonschema.types import JsonSchema
-from schemathesis.core.parameters import ParameterLocation
+from schemathesis.core.parameters import ParameterLocation, plain_str_values
 from schemathesis.generation import GenerationMode
 from schemathesis.resources import ExtraDataSource, PoolDraw, PoolPick
 from schemathesis.resources.repository import ResourceInstance, ResourceRepository
@@ -784,7 +784,7 @@ class OpenApiExtraDataSource(ExtraDataSource):
         if not resource_params:
             resource_params = dict(case.path_parameters)
 
-        variant_key = jsonschema_rs.canonical.json.to_string(resource_params)
+        variant_key = jsonschema_rs.canonical.json.to_string(plain_str_values(resource_params))
         self.usage_tracker.record_successful_delete(variant_key)
 
         # Tombstone + evict the deleted resource: subsequent pool draws skip it, and the

--- a/src/schemathesis/specs/openapi/serialization.py
+++ b/src/schemathesis/specs/openapi/serialization.py
@@ -6,7 +6,7 @@ from typing import Any
 from urllib.parse import quote
 
 from schemathesis.core.jsonschema import maybe_resolve_bundled
-from schemathesis.core.parameters import RAW_QUERY_STRING_KEY, RawQueryString
+from schemathesis.core.parameters import RAW_QUERY_STRING_KEY, DelimitedValue, RawQueryString
 from schemathesis.specs.openapi.checks import _COLLECTION_FORMAT_DELIMITERS
 
 Generated = dict[str, Any]
@@ -181,7 +181,7 @@ def _serialize_path_openapi3(
             if explode:
                 yield delimited_object(name)
         if type_ == "array":
-            yield delimited(name, delimiter=",")
+            yield delimited_encoded(name, delimiter=",")
     if style == "label":
         if type_ == "object":
             yield label_object(name, explode=explode)
@@ -227,11 +227,11 @@ def _serialize_query_openapi3(
                     yield extracted_object(name)
     elif type_ == "array" and explode is False:
         if style == "pipeDelimited":
-            yield delimited(name, delimiter="|")
+            yield delimited_encoded(name, delimiter="|")
         if style == "spaceDelimited":
-            yield delimited(name, delimiter=" ")
+            yield delimited_encoded(name, delimiter=" ")
         if style is None or style == "form":  # "form" is the default style
-            yield delimited(name, delimiter=",")
+            yield delimited_encoded(name, delimiter=",")
 
 
 def _schema_has_nested_object_properties(schema: dict[str, Any] | None) -> bool:
@@ -298,9 +298,10 @@ def _serialize_swagger2(definitions: DefinitionList) -> Generator[Callable | Non
     """Different collection formats for Open API 2.0."""
     for definition in definitions:
         name = definition["name"]
+        location = definition["in"]
         collection_format = definition.get("collectionFormat", "csv")
         type_ = definition.get("type")
-        if definition["in"] == "header":
+        if location == "header":
             # Headers should be coerced to a string so we can check it for validity later
             yield to_string(name)
         if type_ in ("array", "object"):
@@ -312,6 +313,8 @@ def _serialize_swagger2(definitions: DefinitionList) -> Generator[Callable | Non
                 inner_format = items.get("collectionFormat", "csv")
                 inner = _COLLECTION_FORMAT_DELIMITERS.get(inner_format, ",")
                 yield delimited_nested(name, outer=outer, inner=inner)
+            elif location in ("query", "path"):
+                yield delimited_encoded(name, delimiter=outer)
             else:
                 yield delimited(name, delimiter=outer)
 
@@ -365,6 +368,21 @@ def to_json(item: Generated, name: str) -> None:
 @conversion
 def delimited(item: Generated, name: str, delimiter: str) -> None:
     item[name] = delimiter.join(map(str, force_iterable(item[name] if item[name] is not None else ())))
+
+
+# Wire form of each delimiter. Comma and pipe are valid query/path characters and stay literal;
+# whitespace delimiters must be percent-encoded to survive in a URL.
+_WIRE_DELIMITERS = {",": ",", "|": "|", " ": "%20", "\t": "%09"}
+
+
+@conversion
+def delimited_encoded(item: Generated, name: str, delimiter: str) -> None:
+    """Join query/path items, percent-encoding each but keeping the delimiter literal and splittable."""
+    values = list(map(str, force_iterable(item[name] if item[name] is not None else ())))
+    logical = delimiter.join(values)
+    wire = _WIRE_DELIMITERS.get(delimiter, quote(delimiter, safe=""))
+    encoded = wire.join(quote(value, safe="") for value in values)
+    item[name] = DelimitedValue(logical, encoded)
 
 
 @conversion

--- a/src/schemathesis/transport/requests.py
+++ b/src/schemathesis/transport/requests.py
@@ -16,7 +16,7 @@ from typing_extensions import override
 from schemathesis.core import Body, NotSet, media_types
 from schemathesis.core.errors import IncorrectUsage, SerializationNotPossible
 from schemathesis.core.jsonschema import maybe_resolve_bundled, schema_with_bundle
-from schemathesis.core.parameters import RAW_QUERY_STRING_KEY, RawQueryString
+from schemathesis.core.parameters import RAW_QUERY_STRING_KEY, RawQueryString, split_delimited_query
 from schemathesis.core.rate_limit import ratelimit
 from schemathesis.core.transforms import merge_at
 from schemathesis.core.transport import DEFAULT_RESPONSE_TIMEOUT, Response
@@ -98,6 +98,9 @@ class RequestsTransport(BaseTransport["requests.Session"]):
             marker_value = params.get(RAW_QUERY_STRING_KEY)
             if isinstance(marker_value, RawQueryString):
                 raw_query = str(params.pop(RAW_QUERY_STRING_KEY))
+            delimited_raw, params = split_delimited_query(params)
+            if delimited_raw:
+                raw_query = delimited_raw if raw_query is None else _merge_query_components(raw_query, delimited_raw)
         if raw_query is not None:
             params = _merge_query_components(raw_query, params)
 

--- a/src/schemathesis/transport/serialization.py
+++ b/src/schemathesis/transport/serialization.py
@@ -10,6 +10,7 @@ from schemathesis.core import Body
 from schemathesis.core.errors import UnboundPrefix
 from schemathesis.core.jsonschema.resolver import Resolver, make_root_resolver, resolve_reference
 from schemathesis.core.jsonschema.types import JsonValue
+from schemathesis.core.parameters import DelimitedValue, EncodedPath
 from schemathesis.core.transforms import transform
 
 
@@ -22,7 +23,13 @@ def quote_all(parameters: dict[str, Any]) -> dict[str, Any]:
     # Which is not desired as we need to test precisely the original path structure.
 
     for key, value in parameters.items():
-        if isinstance(value, str):
+        if isinstance(value, EncodedPath):
+            # Already fully encoded by a prior pass; re-quoting would collapse delimiters.
+            continue
+        if isinstance(value, DelimitedValue):
+            # Items are already percent-encoded; the delimiter must stay literal.
+            parameters[key] = EncodedPath(value.encoded)
+        elif isinstance(value, str):
             # Unquote first to keep quoting idempotent for already-escaped inputs.
             # E.g. "%2E" should stay escaped and not become a raw "."
             decoded = unquote(value)

--- a/src/schemathesis/transport/wsgi.py
+++ b/src/schemathesis/transport/wsgi.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 from typing_extensions import override
 
 from schemathesis.core import Body, NotSet
-from schemathesis.core.parameters import RAW_QUERY_STRING_KEY, RawQueryString
+from schemathesis.core.parameters import RAW_QUERY_STRING_KEY, RawQueryString, split_delimited_query
 from schemathesis.core.rate_limit import ratelimit
 from schemathesis.core.transforms import merge_at
 from schemathesis.core.transport import Response
@@ -56,9 +56,14 @@ class WSGITransport(BaseTransport["werkzeug.Client"]):
         query_string: dict[str, Any] | str | None = case.query
         if isinstance(query_string, dict):
             query_string = dict(query_string)
+            raw_query = None
             marker_value = query_string.get(RAW_QUERY_STRING_KEY)
             if isinstance(marker_value, RawQueryString):
                 raw_query = str(query_string.pop(RAW_QUERY_STRING_KEY))
+            delimited_raw, query_string = split_delimited_query(query_string)
+            if delimited_raw:
+                raw_query = delimited_raw if raw_query is None else _merge_query_components(raw_query, delimited_raw)
+            if raw_query is not None:
                 query_string = _merge_query_components(raw_query, query_string)
 
         data = {

--- a/test/specs/openapi/test_serializing.py
+++ b/test/specs/openapi/test_serializing.py
@@ -296,10 +296,10 @@ def test_cookie_serialization_styles_openapi3(ctx, testdir, schema, explode, exp
 @pytest.mark.parametrize(
     ("schema", "style", "explode", "expected"),
     [
-        (ARRAY_SCHEMA, "simple", False, {"color": quote("blue,black,brown")}),
-        (NULLABLE_ARRAY_SCHEMA, "simple", False, {"color": quote("blue,black,brown")}),
-        (ARRAY_SCHEMA, "simple", True, {"color": quote("blue,black,brown")}),
-        (NULLABLE_ARRAY_SCHEMA, "simple", True, {"color": quote("blue,black,brown")}),
+        (ARRAY_SCHEMA, "simple", False, {"color": "blue,black,brown"}),
+        (NULLABLE_ARRAY_SCHEMA, "simple", False, {"color": "blue,black,brown"}),
+        (ARRAY_SCHEMA, "simple", True, {"color": "blue,black,brown"}),
+        (NULLABLE_ARRAY_SCHEMA, "simple", True, {"color": "blue,black,brown"}),
         (OBJECT_SCHEMA, "simple", False, {"color": CommaDelimitedObject("r,100,g,200,b,150")}),
         (NULLABLE_OBJECT_SCHEMA, "simple", False, {"color": CommaDelimitedObject("r,100,g,200,b,150")}),
         (OBJECT_SCHEMA, "simple", True, {"color": DelimitedObject("r=100,g=200,b=150")}),
@@ -642,6 +642,87 @@ def test_querystring_json_serialization_is_sent_as_raw_query(ctx, data):
     kwargs = case.as_transport_kwargs(base_url="http://127.0.0.1:1")
     decoded = json.loads(unquote(kwargs["params"]))
     assert decoded == {"numbers": [1, 2], "flag": None}
+
+
+DELIMITED_ARRAY_SCHEMA = {"type": "array", "minItems": 2, "maxItems": 2, "items": {"type": "string", "enum": ["a,b"]}}
+
+
+@pytest.mark.hypothesis_nested
+@pytest.mark.parametrize(
+    ("paths", "version", "operation_path", "expected_url"),
+    [
+        (
+            {
+                "/teapot": {
+                    "get": {
+                        "parameters": [
+                            {
+                                "name": "tags",
+                                "in": "query",
+                                "required": True,
+                                "explode": False,
+                                "schema": DELIMITED_ARRAY_SCHEMA,
+                            }
+                        ],
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+            "3.0.2",
+            "/teapot",
+            "http://127.0.0.1:1/teapot?tags=a%2Cb,a%2Cb",
+        ),
+        (
+            {
+                "/teapot/{tags}": {
+                    "get": {
+                        "parameters": [
+                            {"name": "tags", "in": "path", "required": True, "schema": DELIMITED_ARRAY_SCHEMA}
+                        ],
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+            "3.0.2",
+            "/teapot/{tags}",
+            "http://127.0.0.1:1/teapot/a%2Cb,a%2Cb",
+        ),
+        (
+            {
+                "/teapot": {
+                    "get": {
+                        "parameters": [
+                            {
+                                "name": "tags",
+                                "in": "query",
+                                "required": True,
+                                "collectionFormat": "csv",
+                                **DELIMITED_ARRAY_SCHEMA,
+                            }
+                        ],
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+            "2.0",
+            "/teapot",
+            "http://127.0.0.1:1/teapot?tags=a%2Cb,a%2Cb",
+        ),
+    ],
+    ids=["openapi-form", "openapi-simple-path", "swagger-csv"],
+)
+def test_array_parameter_keeps_delimiter_literal(ctx, paths, version, operation_path, expected_url):
+    # Items are percent-encoded but the separator stays literal, so a server can split the array back.
+    schema = ctx.openapi.load_schema(paths, version=version)
+
+    @given(case=schema[operation_path]["GET"].as_strategy())
+    @settings(max_examples=5)
+    def test(case):
+        kwargs = case.as_transport_kwargs(base_url="http://127.0.0.1:1")
+        prepared = requests.Request("GET", kwargs["url"], params=kwargs["params"]).prepare()
+        assert prepared.url == expected_url
+
+    test()
 
 
 def make_array_schema(location, style):


### PR DESCRIPTION
Fixes #4246 