### PR TITLE
fix: Encode spaces in path parameters as `%20` instead of `+`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.21.8...HEAD) - TBD
 
+### :bug: Fixed
+
+- Encode spaces in path parameters as `%20` instead of `+`. [#4252](https://github.com/schemathesis/schemathesis/issues/4252)
+
 ## [4.21.8](https://github.com/schemathesis/schemathesis/compare/v4.21.7...v4.21.8) - 2026-06-16
 
 ### :bug: Fixed

--- a/src/schemathesis/specs/openapi/coverage/_schema.py
+++ b/src/schemathesis/specs/openapi/coverage/_schema.py
@@ -39,7 +39,7 @@ except ImportError:
 from collections.abc import Callable, Generator, Iterator
 from json.encoder import JSONEncoder, encode_basestring_ascii
 from typing import Any, TypeGuard, TypeVar, cast
-from urllib.parse import quote_plus
+from urllib.parse import quote
 
 import jsonschema_rs
 from hypothesis import strategies as st
@@ -2837,7 +2837,8 @@ def quote_path_parameter(value: Any) -> str:
         elif value == "..":
             return "%2E%2E"
         else:
-            return quote_plus(value)
+            # Percent-encode for path segments (space -> "%20"); "+" is literal in a path, not a space.
+            return quote(value, safe="")
     if isinstance(value, list):
         return ",".join(map(str, value))
     return str(value)

--- a/src/schemathesis/transport/serialization.py
+++ b/src/schemathesis/transport/serialization.py
@@ -4,7 +4,7 @@ import re
 from io import StringIO
 from typing import TYPE_CHECKING, Any
 from unicodedata import normalize
-from urllib.parse import quote_plus, unquote
+from urllib.parse import quote, unquote
 
 from schemathesis.core import Body
 from schemathesis.core.errors import UnboundPrefix
@@ -38,7 +38,8 @@ def quote_all(parameters: dict[str, Any]) -> dict[str, Any]:
             elif decoded == "..":
                 parameters[key] = "%2E%2E"
             else:
-                parameters[key] = quote_plus(decoded)
+                # Percent-encode for path segments (space -> "%20"); "+" is literal in a path, not a space.
+                parameters[key] = quote(decoded, safe="")
     return parameters
 
 

--- a/test/coverage/test_phase.py
+++ b/test/coverage/test_phase.py
@@ -35,7 +35,12 @@ from schemathesis.generation.meta import CoverageScenario, TestPhase
 from schemathesis.resources import PoolDraw, PoolPick
 from schemathesis.specs.openapi.checks import negative_data_rejection
 from schemathesis.specs.openapi.coverage._operation import iter_coverage_cases
-from schemathesis.specs.openapi.coverage._schema import CoverageContext, _negative_format, cover_schema_iter
+from schemathesis.specs.openapi.coverage._schema import (
+    CoverageContext,
+    _negative_format,
+    cover_schema_iter,
+    quote_path_parameter,
+)
 from schemathesis.transport.prepare import prepare_request
 from test.utils import assert_requests_call
 
@@ -1486,6 +1491,20 @@ def test_path_parameters_without_schema(ctx, cli, snapshot_cli):
         )
         == snapshot_cli
     )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2 m above gnd", "2%20m%20above%20gnd"),
+        (".", "%2E"),
+        ("..", "%2E%2E"),
+        ("a+b", "a%2Bb"),
+    ],
+)
+def test_quote_path_parameter_space(value, expected):
+    # GH-4252: coverage-phase path values must percent-encode spaces, not form-encode them
+    assert quote_path_parameter(value) == expected
 
 
 def test_path_parameter_dots(ctx):

--- a/test/generation/test_hypothesis.py
+++ b/test/generation/test_hypothesis.py
@@ -892,11 +892,25 @@ def test_optional_form_data(ctx):
         ("%2e", "%2E"),
         ("%2E%2E", "%2E%2E"),
         ("%2e%2e", "%2E%2E"),
+        # Spaces in path segments must percent-encode, not form-encode (GH-4252)
+        ("2 m above gnd", "2%20m%20above%20gnd"),
+        ("a+b", "a%2Bb"),
     ],
 )
 def test_path_parameters_quotation(value, expected):
     # See GH-1036
     assert quote_all({"foo": value})["foo"] == expected
+
+
+def test_path_parameter_space_encoded_in_url(ctx):
+    # GH-4252: a space in a path segment must reach the wire as "%20", never "+"
+    schema = ctx.openapi.load_schema(
+        {"/forecast/{level}": {"get": {"responses": {"200": {"description": "OK"}}}}},
+        version="3.1.0",
+    )
+    operation = schema["/forecast/{level}"]["GET"]
+    case = operation.Case(path_parameters=quote_all({"level": "2 m above gnd"}))
+    assert schema.build_request_url(case, "http://127.0.0.1") == "http://127.0.0.1/forecast/2%20m%20above%20gnd"
 
 
 @pytest.mark.parametrize("expected", ["null", "true", "false"])


### PR DESCRIPTION
Fixes #4252 