### PR TITLE
fix: False positive `negative_data_rejection` for boolean query/path parameters in the coverage phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.21.9...HEAD) - TBD
 
+### :bug: Fixed
+
+- False positive `negative_data_rejection` for boolean query/path parameters in the coverage phase. [#4254](https://github.com/schemathesis/schemathesis/issues/4254)
+
 ## [4.21.9](https://github.com/schemathesis/schemathesis/compare/v4.21.8...v4.21.9) - 2026-06-19
 
 ### :bug: Fixed

--- a/src/schemathesis/specs/openapi/coverage/_schema.py
+++ b/src/schemathesis/specs/openapi/coverage/_schema.py
@@ -2791,6 +2791,14 @@ def _is_not_numeric_string(x: str) -> bool:
         return True
 
 
+# Wire values that lenient query/path parsers coerce to a boolean.
+BOOLEAN_WIRE_VALUES = frozenset({"0", "1", "true", "false"})
+
+
+def _is_not_boolean_coercible(x: Any) -> bool:
+    return str(x).strip().lower() not in BOOLEAN_WIRE_VALUES
+
+
 def is_valid_header_value(value: object) -> bool:
     value = str(value)
     if not is_latin_1_encodable(value):
@@ -2917,6 +2925,12 @@ def _negative_type(
     if ctx.location in (ParameterLocation.PATH, ParameterLocation.QUERY) and ("integer" in types or "number" in types):
         if "string" in strategies:
             strategies["string"] = strategies["string"].filter(_is_not_numeric_string)
+    # For path/query parameters, 0/1/true/false serialize to wire values lenient parsers
+    # accept as booleans, making them indistinguishable from a valid boolean.
+    if ctx.location in (ParameterLocation.PATH, ParameterLocation.QUERY) and "boolean" in types:
+        for ty in ("integer", "number", "string"):
+            if ty in strategies:
+                strategies[ty] = strategies[ty].filter(_is_not_boolean_coercible)
     if ctx.location in (ParameterLocation.QUERY, ParameterLocation.PATH):
         strategies.pop("object", None)
     # Form-urlencoded property-level mutations with null/array/object serialize to empty

--- a/test/coverage/test_combinations.py
+++ b/test/coverage/test_combinations.py
@@ -161,8 +161,10 @@ class AnyNumber:
         (True, []),
         ({}, []),
         ({"type": "null"}, [0, "false", "AAA", ["null", "null"]]),
-        ({"type": "boolean"}, [0, "null", "AAA", ["null", "null"]]),
-        ({"type": ["boolean", "null"]}, [0, "AAA", ["null", "null"]]),
+        # 0/1 coerce to booleans in lenient query/path parsers, so the numeric type violations
+        # are non-coercible values instead.
+        ({"type": "boolean"}, [AnyNumber(), AnyNumber(), "null", "AAA", ["null", "null"]]),
+        ({"type": ["boolean", "null"]}, [AnyNumber(), AnyNumber(), "AAA", ["null", "null"]]),
         # canonicalish drops `type` when `enum` is present; infer it from the values so type
         # violations still appear alongside the enum violation. The enum-negative "AAA"
         # collides with the type-negative "AAA" and dedupes to one entry.

--- a/test/coverage/test_phase.py
+++ b/test/coverage/test_phase.py
@@ -37,6 +37,7 @@ from schemathesis.specs.openapi.checks import negative_data_rejection
 from schemathesis.specs.openapi.coverage._operation import iter_coverage_cases
 from schemathesis.specs.openapi.coverage._schema import (
     CoverageContext,
+    HashSet,
     _negative_format,
     cover_schema_iter,
     quote_path_parameter,
@@ -2388,6 +2389,22 @@ def test_negative_query_parameter(ctx, schema, expected, required):
     run_negative_test(operation, test, generate_duplicate_query_parameters=True)
 
     assert urls == expected
+
+
+@pytest.mark.parametrize("location", [ParameterLocation.QUERY, ParameterLocation.PATH])
+def test_negative_boolean_not_coercible_wire_value(ctx_factory, location):
+    # Lenient parsers coerce 0/1/true/false to booleans, so those wire values are not type violations for a boolean parameter
+    nctx = ctx_factory(location=location, generation_modes=[GenerationMode.NEGATIVE])
+    schema = {"type": "boolean", "default": False}
+    values = [
+        generated.value
+        for generated in cover_schema_iter(nctx, schema, HashSet())
+        if generated.scenario == CoverageScenario.INCORRECT_TYPE
+    ]
+
+    coercible = {"0", "1", "true", "false"}
+    rendered = {str(value).lower() for value in values}
+    assert not (rendered & coercible), f"Boolean-coercible negatives generated: {values}"
 
 
 def test_negative_data_rejection(ctx, cli, snapshot_cli):


### PR DESCRIPTION
Fixes #4254 