### PR TITLE
fix: Crash for multipart `format: binary` bodies in `positive_data_acceptance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Drop the `tenacity` dependency in favor of the standard library.
 - Drop the unnecessary `httpx` dependency.
 
+### :bug: Fixed
+
+- Crash for multipart `format: binary` bodies in `positive_data_acceptance`. [#4268](https://github.com/schemathesis/schemathesis/issues/4268)
+
 ## [4.21.10](https://github.com/schemathesis/schemathesis/compare/v4.21.9...v4.21.10) - 2026-06-20
 
 ### :bug: Fixed

--- a/src/schemathesis/specs/openapi/checks.py
+++ b/src/schemathesis/specs/openapi/checks.py
@@ -41,6 +41,7 @@ from schemathesis.specs.openapi._auth_retry import (
 )
 from schemathesis.specs.openapi.utils import expand_status_codes
 from schemathesis.transport.prepare import prepare_path
+from schemathesis.transport.serialization import contains_binary
 
 if TYPE_CHECKING:
     from schemathesis.engine.recorder import ScenarioRecorder
@@ -707,6 +708,9 @@ def _additional_properties_hint(case: Case) -> str | None:
             return None
 
         stripped = {k: v for k, v in case.body.items() if k not in extra}
+        # `format: binary` fields hold raw bytes the JSON Schema validator cannot accept.
+        if contains_binary(stripped):
+            return None
         if not validator_cls(alternative.optimized_schema, pattern_options=FANCY_REGEX_OPTIONS).is_valid(stripped):
             return None
 

--- a/test/engine/test_engine.py
+++ b/test/engine/test_engine.py
@@ -5,6 +5,7 @@ import sys
 from dataclasses import asdict
 from unittest.mock import ANY
 
+import flask
 import pytest
 from fastapi import FastAPI
 
@@ -20,6 +21,7 @@ from schemathesis.generation import GenerationMode
 from schemathesis.generation.hypothesis.builder import add_examples
 from schemathesis.specs.openapi.checks import (
     content_type_conformance,
+    positive_data_acceptance,
     response_schema_conformance,
     status_code_conformance,
 )
@@ -519,6 +521,54 @@ def test_internal_exceptions(ctx, mocker):
     exceptions = [error.value.__class__.__name__ for error in stream.find_all(events.NonFatalError)]
     assert "ValueError" in exceptions
     assert len(exceptions) == 1
+
+
+def test_positive_data_acceptance_multipart_binary(ctx, app_runner):
+    # `format: binary` fields hold raw bytes the JSON Schema validator cannot accept.
+    app, _ = ctx.openapi.make_flask_app(
+        {
+            "/upload": {
+                "put": {
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "immagineFile": {"type": "string", "format": "binary"},
+                                        "librettoFile": {"type": "string", "format": "binary"},
+                                    },
+                                    "required": ["immagineFile"],
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {"description": "OK"},
+                        "422": {"description": "Unprocessable Entity"},
+                    },
+                }
+            }
+        }
+    )
+
+    @app.route("/upload", methods=["PUT"])
+    def upload():
+        allowed = {"immagineFile", "librettoFile"}
+        if (set(flask.request.form.keys()) | set(flask.request.files.keys())) - allowed:
+            return flask.jsonify({"error": "Unexpected fields"}), 422
+        return flask.jsonify({"ok": True}), 200
+
+    schema = schemathesis.openapi.from_url(app_runner.openapi_url(app))
+    stream = EventStream(
+        schema,
+        checks=[positive_data_acceptance],
+        phases=[PhaseName.FUZZING],
+        max_examples=50,
+        deterministic=True,
+        seed=1,
+    ).execute()
+    stream.assert_no_errors()
 
 
 def test_fuzzing_phase_failure_requires_a_surfaced_failure(ctx):


### PR DESCRIPTION
Fixes #4268 