### PR TITLE
fix: False positive `negative_data_rejection` when a `before_call` hook overwrites an invalid parameter with a valid value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.22.0...HEAD) - TBD
 
+### :bug: Fixed
+
+- False positive `negative_data_rejection` when a `before_call` hook overwrites an invalid parameter with a valid value. [#4277](https://github.com/schemathesis/schemathesis/issues/4277)
+
 ## [4.22.0](https://github.com/schemathesis/schemathesis/compare/v4.21.10...v4.22.0) - 2026-06-30
 
 ### :rocket: Added

--- a/src/schemathesis/generation/case.py
+++ b/src/schemathesis/generation/case.py
@@ -230,6 +230,10 @@ class Case(Generic[OperationT]):
             # Snapshot the wire-form hash so revalidation can tell whether the
             # container is still the unmodified value produced by generation.
             self._meta._initial_hashes[location] = hash_value
+            # Snapshot the wire-form values so revalidation can tell, per key, which
+            # ones a hook overwrote and validate those against their live values.
+            if isinstance(value, Mapping):
+                self._meta._initial_containers[location] = dict(value)
 
     def _check_modifications(self) -> None:
         """Detect in-place modifications by comparing container hashes."""
@@ -366,11 +370,17 @@ class Case(Generic[OperationT]):
 
         """
         hook_context = HookContext(operation=self.operation)
+        # Sync the modification baseline to the current container state so revalidation reacts
+        # only to edits a `before_call` hook makes, not to auth/overrides applied earlier in place.
+        if self._meta is not None:
+            for location in self._meta.components:
+                self._meta.update_validated_hash(location, self._hash_container(getattr(self, location.container_name)))
         dispatch_before_call(GLOBAL_HOOK_DISPATCHER, context=hook_context, case=self, kwargs=kwargs)
 
-        # Revalidate metadata if dirty before freezing (captures user modifications)
+        # Detect in-place container edits the hook made, then revalidate before freezing so
+        # stale generation-time metadata reflects the values actually sent.
+        self._check_modifications()
         if self._meta and self._meta.is_dirty():
-            self._check_modifications()
             self._revalidate_metadata()
 
         # Freeze metadata to prevent revalidation after request preparation transforms the body

--- a/src/schemathesis/generation/meta.py
+++ b/src/schemathesis/generation/meta.py
@@ -219,6 +219,10 @@ class CaseMetadata:
     # Lets revalidation detect whether a container still matches its wire-form
     # snapshot (so the typed `raw_containers` value remains authoritative).
     _initial_hashes: dict[ParameterLocation, int] = field(default_factory=dict, init=False)
+    # Initial wire-form container snapshots captured once after generation; never updated.
+    # Lets revalidation tell, per key, whether a value still equals its generated wire
+    # form (use the typed snapshot) or was overwritten by a hook (validate the live value).
+    _initial_containers: dict[ParameterLocation, Any] = field(default_factory=dict, init=False)
 
     def mark_dirty(self, location: ParameterLocation) -> None:
         """Mark a component as modified and needing revalidation."""

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -240,9 +240,13 @@ class OpenApiSchema(BaseSchema):
             if current_hash == meta._initial_hashes.get(location) and raw is not None:
                 validation_value = raw
             elif isinstance(value, Mapping) and isinstance(raw, Mapping):
-                # Auth/overrides add keys after generation; validate generated keys against the typed
-                # snapshot (query/path serialize to strings) and only added keys against the live value.
-                validation_value = {key: raw[key] if key in raw else current for key, current in value.items()}
+                # A key still equal to its generated wire form validates against the typed snapshot;
+                # a key a hook overwrote (or one auth/overrides added) validates against its live value.
+                original = meta._initial_containers.get(location, {})
+                validation_value = {
+                    key: raw[key] if key in raw and key in original and original[key] == current else current
+                    for key, current in value.items()
+                }
             else:
                 validation_value = value
             is_valid = case._validate_component(location, validation_value, validator_cls)

--- a/test/cli/test_negative_metadata.py
+++ b/test/cli/test_negative_metadata.py
@@ -218,3 +218,70 @@ def test_removed_auth_parameter_not_reapplied_with_credentials(ctx):
     auth_removed = [r for r in api.requests if "Authorization" not in r.headers]
     assert auth_removed, "no auth-removal mutation fired in 50 examples"
     assert not failures, f"unexpected negative_data_rejection failures: {failures}"
+
+
+def test_hook_modified_path_parameter_no_false_positive(ctx, cli):
+    # GH-4277: a before_call hook clamps an out-of-range path param to a valid value;
+    # that valid value must not be reported as schema-violating.
+    app, _ = ctx.openapi.make_flask_app(
+        {
+            "/{z}/{x}/{y}.png": {
+                "get": {
+                    "parameters": [
+                        {
+                            "name": "z",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "integer", "minimum": 2, "maximum": 6},
+                        },
+                        {
+                            "name": "x",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "integer", "minimum": 0, "maximum": 63},
+                        },
+                        {
+                            "name": "y",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "integer", "minimum": 0, "maximum": 63},
+                        },
+                    ],
+                    "responses": {"200": {"description": "OK"}, "422": {"description": "OK"}},
+                }
+            }
+        }
+    )
+
+    @app.route("/<z>/<x>/<y>")
+    def tile(z, x, y):
+        return jsonify({"ok": True})
+
+    module = ctx.write_pymodule(
+        """
+@schemathesis.hook
+def before_call(context, case, **kwargs):
+    pp = case.path_parameters
+    for name in ("x", "y"):
+        try:
+            pp[name] = min(max(int(pp[name]), 0), 63)
+        except (KeyError, TypeError, ValueError):
+            pp[name] = 0
+    try:
+        z = int(pp["z"])
+    except (KeyError, TypeError, ValueError):
+        z = None
+    if z is None or not 2 <= z <= 6:
+        pp["z"] = 2
+        """
+    )
+
+    result = cli.run_openapi_app(
+        app,
+        "--checks=negative_data_rejection",
+        "--phases=coverage",
+        "--continue-on-failure",
+        hooks=module,
+    )
+    assert "API accepted schema-violating request" not in result.stdout, result.stdout
+    assert result.exit_code == ExitCode.OK, result.stdout


### PR DESCRIPTION
Fixes #4277 