### PR TITLE
Add Xquik OpenAPI loader fixture

### DIFF
--- a/test/data/xquik_openapi.yaml
+++ b/test/data/xquik_openapi.yaml
@@ -1,0 +1,63 @@
+openapi: 3.1.0
+info:
+  title: Xquik API
+  version: "1.0"
+servers:
+  - url: https://xquik.com
+security:
+  - apiKey: []
+paths:
+  /api/v1/x/tweets/search:
+    get:
+      operationId: searchTweets
+      summary: Search X posts
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Tweet"
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
+  schemas:
+    Tweet:
+      type: object
+      required:
+        - id
+        - text
+        - authorHandle
+        - createdAt
+      properties:
+        id:
+          type: string
+        text:
+          type: string
+        authorHandle:
+          type: string
+        createdAt:
+          type: string
+          format: date-time

--- a/test/loaders/test_openapi.py
+++ b/test/loaders/test_openapi.py
@@ -111,6 +111,19 @@ def test_split_file_schema_with_uri_reserved_path_chars(tmp_path):
     assert [(p.name, p.location) for p in operation.iter_parameters()] == [("id", "path")]
 
 
+def test_xquik_openapi_fixture():
+    schema = schemathesis.openapi.from_path("test/data/xquik_openapi.yaml")
+    operation = schema["/api/v1/x/tweets/search"]["GET"]
+
+    assert operation.label == "GET /api/v1/x/tweets/search"
+    assert operation.definition.raw["operationId"] == "searchTweets"
+    assert [(p.name, p.location.value) for p in operation.iter_parameters()] == [
+        ("x-api-key", "header"),
+        ("q", "query"),
+        ("limit", "query"),
+    ]
+
+
 def test_unsupported_type():
     # When Schemathesis can't detect the Open API spec version
     with pytest.raises(


### PR DESCRIPTION
## Summary
- Add a compact Xquik OpenAPI 3.1 fixture for loader coverage.
- Assert Schemathesis exposes the search operation, operation id, and generated parameters.

## Validation
- Focused pytest loader test passed locally with the target test extras.
