### PR TITLE
fix: False positive `negative_data_rejection` for body schemas with `additionalProperties: false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Crash `dictionary changed size during iteration` with multiple workers under free-threaded Python.
 - Crash on schemas embedding a JSON Schema resource that declares its own `$schema` dialect.
 - False positive `positive_data_acceptance` for required array query parameters generated as empty.
+- False positive `negative_data_rejection` for body schemas with `additionalProperties: false`. [#4332](https://github.com/schemathesis/schemathesis/issues/4332)
 - Generation error for request bodies with `prefixItems` in OpenAPI 3.1 schemas.
 - Crash `Cannot sample from a length-zero sequence` for array `items` with an empty `enum`.
 - False positive `positive_data_acceptance` for array `items` with `enum` entries violating the item schema.

--- a/src/schemathesis/specs/openapi/negative/mutations.py
+++ b/src/schemathesis/specs/openapi/negative/mutations.py
@@ -951,8 +951,7 @@ def negate_constraints(
         # Pin one keyword as required-to-negate so the case isn't all-pass at low feature mask.
         candidate = draw(st.sampled_from([key for key, value in copied.items() if is_mutation_candidate(key, value)]))
         candidates.append(candidate)
-        if candidate in DEPENDENCIES:
-            candidates.append(DEPENDENCIES[candidate])
+        candidates.extend(DEPENDENCIES.get(candidate, ()))
     for key, value in copied.items():
         if is_mutation_candidate(key, value):
             if key in candidates or enabled_keywords.is_enabled(key):
@@ -963,8 +962,7 @@ def negate_constraints(
                 if key != "format":
                     negated = schema.setdefault("not", {})
                     negated[key] = value
-                    if key in DEPENDENCIES:
-                        dependency = DEPENDENCIES[key]
+                    for dependency in DEPENDENCIES.get(key, ()):
                         if dependency not in negated and dependency in copied:
                             negated[dependency] = copied[dependency]
         else:
@@ -995,7 +993,13 @@ def negate_constraints(
     return MutationResult.FAILURE, None
 
 
-DEPENDENCIES = {"exclusiveMaximum": "maximum", "exclusiveMinimum": "minimum"}
+# Keywords whose meaning depends on siblings, which must travel into `not` alongside them.
+# Stripped of `properties`/`patternProperties`, `additionalProperties` reads as "no properties at all".
+DEPENDENCIES = {
+    "exclusiveMaximum": ("maximum",),
+    "exclusiveMinimum": ("minimum",),
+    "additionalProperties": ("properties", "patternProperties"),
+}
 
 
 def ident(x: T) -> T:

--- a/test/specs/openapi/negative/test_deep_distribution.py
+++ b/test/specs/openapi/negative/test_deep_distribution.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 
+import jsonschema_rs
 import pytest
+from hypothesis import HealthCheck, Phase, given, settings
 
 import schemathesis
 from schemathesis.core.jsonschema import _is_valid_uuid
@@ -117,6 +119,51 @@ def test_value_channel_produces_format_uuid_near_miss(ctx):
             if isinstance(value, str) and len(value) == 36 and value.count("-") == 4 and not _is_valid_uuid(value):
                 return
     pytest.fail("no uuid-shaped near-miss found across runner output")
+
+
+BODY_WITH_NO_ADDITIONAL_PROPERTIES = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["email"],
+    "properties": {"email": {"type": "string", "format": "email"}},
+}
+
+
+@pytest.mark.hypothesis_nested
+def test_additional_properties_negation_stays_invalid(ctx):
+    # See GH-4332. Negating `additionalProperties` drops the `properties` context it is defined
+    # against, so the mutated schema still admits bodies valid against the original.
+    # 500 examples because only a small fraction of draws pick this keyword combination.
+    schema = ctx.openapi.load_schema(
+        {
+            "/reset": {
+                "post": {
+                    "requestBody": {
+                        "required": True,
+                        "content": {"application/json": {"schema": BODY_WITH_NO_ADDITIONAL_PROPERTIES}},
+                    },
+                    "responses": {"200": {"description": "OK"}},
+                }
+            }
+        }
+    )
+    validator = jsonschema_rs.Draft4Validator(BODY_WITH_NO_ADDITIONAL_PROPERTIES, validate_formats=True)
+
+    @given(case=schema["/reset"]["POST"].as_strategy(generation_mode=schemathesis.GenerationMode.NEGATIVE))
+    @settings(
+        max_examples=500,
+        deadline=None,
+        derandomize=True,
+        suppress_health_check=list(HealthCheck),
+        phases=[Phase.generate],
+    )
+    def test(case):
+        body = case.body
+        if not isinstance(body, (dict, list, str, int, float, bool)) and body is not None:
+            return
+        assert not validator.is_valid(body), f"False positive: body {body!r} is valid against the schema"
+
+    test()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #4332 