### PR TITLE
fix: Fuzz dictionaries not applied to body fields nested under `oneOf`/`anyOf`/`allOf` or `if`/`then`/`else`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/schemathesis/schemathesis/compare/v4.24.0...HEAD) - TBD
 
+### :bug: Fixed
+
+- Fuzz dictionaries not applied to body fields nested under `oneOf`/`anyOf`/`allOf` or `if`/`then`/`else`. [#4347](https://github.com/schemathesis/schemathesis/issues/4347)
+
 ### :wrench: Changed
 
 - Data generation for `enum`, `const`, and bare `type` schemas moved to `jsonschema-rs`; faster as a side effect.

--- a/src/schemathesis/generation/dictionaries.py
+++ b/src/schemathesis/generation/dictionaries.py
@@ -323,21 +323,36 @@ def resolve_body_bindings(
 
 def _resolve_body_leaf_schema(schema: JsonSchema, pointer: str) -> JsonSchema | None:
     # `pointer` always comes from `parse_body_path`, so it is `/`-prefixed and non-empty.
-    current: JsonSchema = schema
-    for segment in pointer[1:].split("/"):
-        if not isinstance(current, dict):
-            return None
-        if segment == "*":
-            items = current.get("items")
-            if not isinstance(items, (dict, bool)):
-                return None
-            current = items
-        else:
-            properties = current.get("properties")
-            if not isinstance(properties, dict) or segment not in properties:
-                return None
-            current = properties[segment]
-    return current if isinstance(current, (dict, bool)) else None
+    return _walk_leaf_schema(schema, pointer[1:].split("/"))
+
+
+def _walk_leaf_schema(current: JsonSchema, segments: list[str]) -> JsonSchema | None:
+    if not segments:
+        return current if isinstance(current, (dict, bool)) else None
+    if not isinstance(current, dict):
+        return None
+    segment, *rest = segments
+    if segment == "*":
+        items = current.get("items")
+        if isinstance(items, (dict, bool)):
+            found = _walk_leaf_schema(items, rest)
+            if found is not None:
+                return found
+    else:
+        properties = current.get("properties")
+        if isinstance(properties, dict) and segment in properties:
+            found = _walk_leaf_schema(properties[segment], rest)
+            if found is not None:
+                return found
+    # The field may live inside a subschema, so descend combinator branches with the same path.
+    for keyword in ("oneOf", "anyOf", "allOf"):
+        branches = current.get(keyword)
+        if isinstance(branches, list):
+            for branch in branches:
+                found = _walk_leaf_schema(branch, segments)
+                if found is not None:
+                    return found
+    return None
 
 
 def build_body_dictionary_overlay_strategy(

--- a/test/specs/openapi/test_dictionary_generation.py
+++ b/test/specs/openapi/test_dictionary_generation.py
@@ -619,6 +619,64 @@ def test_body_binding_top_level_field(ctx):
 
 
 @pytest.mark.hypothesis_nested
+@pytest.mark.parametrize("combinator", ["oneOf", "anyOf", "allOf"])
+def test_body_binding_field_under_combinator(ctx, combinator):
+    object_schema = {
+        "type": "object",
+        "properties": {"region": {"type": "string"}},
+        "required": ["region"],
+    }
+    schema = _load_schema_with_dictionaries(
+        ctx,
+        {
+            "dictionaries": {"region": {"values": ["DE", "GB", "US"]}},
+            "parameters": {"body.region": {"dictionary": "region"}},
+        },
+        _path_with_body({combinator: [object_schema]}),
+    )
+    operation = schema["/items"]["POST"]
+    seen: set[str] = set()
+
+    @given(case=operation.as_strategy())
+    @settings(max_examples=10, derandomize=True, database=None, suppress_health_check=list(HealthCheck))
+    def collect(case):
+        seen.add(case.body.get("region") if isinstance(case.body, dict) else None)
+
+    collect()
+    assert seen == {"DE", "GB", "US"}
+
+
+@pytest.mark.hypothesis_nested
+def test_body_binding_field_under_conditional(ctx):
+    schema = _load_schema_with_dictionaries(
+        ctx,
+        {
+            "dictionaries": {"region": {"values": ["DE", "GB", "US"]}},
+            "parameters": {"body.region": {"dictionary": "region"}},
+        },
+        _path_with_body(
+            {
+                "type": "object",
+                "properties": {"kind": {"const": "x"}},
+                "required": ["kind"],
+                "if": {"properties": {"kind": {"const": "x"}}},
+                "then": {"properties": {"region": {"type": "string"}}, "required": ["region"]},
+            }
+        ),
+    )
+    operation = schema["/items"]["POST"]
+    seen: set[str] = set()
+
+    @given(case=operation.as_strategy())
+    @settings(max_examples=10, derandomize=True, database=None, suppress_health_check=list(HealthCheck))
+    def collect(case):
+        seen.add(case.body.get("region") if isinstance(case.body, dict) else None)
+
+    collect()
+    assert seen == {"DE", "GB", "US"}
+
+
+@pytest.mark.hypothesis_nested
 def test_body_binding_nested_field(ctx):
     schema = _load_schema_with_dictionaries(
         ctx,


### PR DESCRIPTION
Fixes #4347