### PR TITLE
fix: Intermittent "Path parameter is not defined" on specs split across many external files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Internal error on truncated runtime expressions like `$response.` in Open API links.
 - Read unquoted `on`, `off`, `yes` and `no` in YAML documents as strings, per YAML 1.2.
 - Coverage phase emitting nothing for `allOf` schemas with no equivalent flat form.
+- Intermittent "Path parameter is not defined" on specs split across many external files. [#4414](https://github.com/schemathesis/schemathesis/issues/4414)
 
 ### :racing_car: Performance
 

--- a/src/schemathesis/core/jsonschema/bundler.py
+++ b/src/schemathesis/core/jsonschema/bundler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -13,8 +14,10 @@ from schemathesis.core.transforms import decode_pointer
 
 BUNDLE_STORAGE_KEY = "x-bundled"
 REFERENCE_TO_BUNDLE_PREFIX = f"#/{BUNDLE_STORAGE_KEY}"
-# Cache for bundled parameters: parameter object id -> (bundled definition, name_to_uri mapping)
-BundleCache = dict[int, tuple[dict[str, Any], dict[str, str]]]
+# Cache for bundled parameters: parameter object id -> (parameter, bundled definition, name_to_uri mapping).
+# The parameter is stored so that its address stays reserved - otherwise a freed parameter's address can be
+# handed to an unrelated one, which would then hit the wrong entry.
+BundleCache = dict[int, tuple[Mapping[str, Any], dict[str, Any], dict[str, str]]]
 
 
 class BundleError(Exception):

--- a/src/schemathesis/specs/openapi/adapter/parameters.py
+++ b/src/schemathesis/specs/openapi/adapter/parameters.py
@@ -1562,12 +1562,13 @@ def _bundle_parameter(
     parameter: Mapping,
     resolver: Resolver,
     bundler: Bundler,
-    bundle_cache: dict[int, tuple[dict[str, Any], dict[str, str]]],
+    bundle_cache: BundleCache,
 ) -> tuple[dict[str, Any], dict[str, str]]:
     """Bundle a parameter definition to make it self-contained."""
     param_id = id(parameter)
-    if param_id in bundle_cache:
-        cached_definition, cached_name_to_uri = bundle_cache[param_id]
+    cached = bundle_cache.get(param_id)
+    if cached is not None:
+        _, cached_definition, cached_name_to_uri = cached
         return deepclone(cached_definition), dict(cached_name_to_uri)
 
     parameter_resolver, definition = maybe_resolve_with_resolver(parameter, resolver)
@@ -1612,7 +1613,9 @@ def _bundle_parameter(
 
     definition_ = cast(dict, definition)
     result = definition_, name_to_uri
-    bundle_cache[param_id] = (deepclone(definition_), dict(name_to_uri))
+    # Keeping `parameter` alive reserves its address, so no later parameter can be allocated onto it
+    # and pick up this entry.
+    bundle_cache[param_id] = (parameter, deepclone(definition_), dict(name_to_uri))
     return result
 
 

--- a/test/specs/openapi/test_dereferencing.py
+++ b/test/specs/openapi/test_dereferencing.py
@@ -1,3 +1,4 @@
+import gc
 import json
 import platform
 from pathlib import Path
@@ -11,8 +12,9 @@ from werkzeug.exceptions import InternalServerError
 
 import schemathesis
 from schemathesis.core.errors import InvalidSchema
-from schemathesis.core.jsonschema.resolver import resolve_reference
+from schemathesis.core.jsonschema.resolver import load_file_uri, resolve_reference
 from schemathesis.core.result import Ok
+from schemathesis.core.transforms import get_template_fields
 from schemathesis.generation.modes import GenerationMode
 from schemathesis.specs.openapi.stateful import dependencies
 from test.utils import as_param, get_schema_path, integer
@@ -1466,3 +1468,44 @@ def test_embedded_schema_dialect_declaration(ctx, version, body_schema):
         assert isinstance(case.body, dict)
 
     test()
+
+
+def test_external_path_items_reparsed_after_document_eviction(ctx):
+    # See GH-4414. Specs with many external files evict documents mid-run; re-reading them must not
+    # let one operation pick up another's path parameter.
+    count = 100
+    schema_path = ctx.openapi.write_schema(
+        {f"/items/{index}/{{op{index}_id}}": {"$ref": f"./paths/op{index}.json"} for index in range(count)},
+        version="3.0.3",
+    )
+    directory = Path(str(schema_path)).parent / "paths"
+    directory.mkdir()
+    for index in range(count):
+        (directory / f"op{index}.json").write_text(
+            json.dumps(
+                {
+                    "get": {
+                        "parameters": [
+                            {"name": f"op{index}_id", "in": "path", "required": True, "schema": {"type": "string"}}
+                        ],
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            )
+        )
+
+    schema = schemathesis.openapi.from_path(str(schema_path))
+
+    corrupted = []
+    for _ in range(3):
+        for result in schema.get_all_operations():
+            assert isinstance(result, Ok)
+            operation = result.ok()
+            names = {parameter.name for parameter in operation.path_parameters}
+            if names != get_template_fields(operation.path):
+                corrupted.append((operation.label, sorted(names)))
+        # Eviction is size-driven, so drop the cached documents outright to reach the same state
+        # without a spec large enough to overflow it.
+        load_file_uri.cache_clear()
+        gc.collect()
+    assert corrupted == []


### PR DESCRIPTION
Fixes #4414 