### PR TITLE
fix: key parameter bundle cache on resolved reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@
 - Runtime error in `negative_data_rejection` for empty array path parameters.
 - Coverage phase generating Unicode characters where the validator reads `\d` and `\w` as ASCII.
 - Internal error on truncated runtime expressions like `$response.` in Open API links.
+- Intermittent `Path parameter is not defined` errors on multi-file schemas, caused by the parameter bundle cache being keyed on object identity. [#4414](https://github.com/schemathesis/schemathesis/issues/4414)
 
 ### :racing_car: Performance
 
 - Cache canonical-form strategies across operations.
+- Share bundled parameters between operations that reference the same definition.
 
 ### :wrench: Changed
 

--- a/src/schemathesis/core/jsonschema/bundler.py
+++ b/src/schemathesis/core/jsonschema/bundler.py
@@ -13,8 +13,8 @@ from schemathesis.core.transforms import decode_pointer
 
 BUNDLE_STORAGE_KEY = "x-bundled"
 REFERENCE_TO_BUNDLE_PREFIX = f"#/{BUNDLE_STORAGE_KEY}"
-# Cache for bundled parameters: parameter object id -> (bundled definition, name_to_uri mapping)
-BundleCache = dict[int, tuple[dict[str, Any], dict[str, str]]]
+# Cache for bundled parameters: resolved `$ref` URI -> (bundled definition, name_to_uri mapping)
+BundleCache = dict[str, tuple[dict[str, Any], dict[str, str]]]
 
 
 class BundleError(Exception):

--- a/src/schemathesis/specs/openapi/adapter/parameters.py
+++ b/src/schemathesis/specs/openapi/adapter/parameters.py
@@ -25,7 +25,7 @@ from schemathesis.core.jsonschema import (
     schema_with_bundle,
 )
 from schemathesis.core.jsonschema.bundler import BUNDLE_STORAGE_KEY, BundleCache
-from schemathesis.core.jsonschema.resolver import Resolver
+from schemathesis.core.jsonschema.resolver import Resolver, resolve_reference_uri
 from schemathesis.core.jsonschema.types import JsonSchema, JsonSchemaObject, JsonValue, get_type
 from schemathesis.core.media_types import FORM_MEDIA_TYPES
 from schemathesis.core.parameters import HEADER_LOCATIONS, ParameterLocation
@@ -1556,13 +1556,17 @@ def _bundle_parameter(
     parameter: Mapping,
     resolver: Resolver,
     bundler: Bundler,
-    bundle_cache: dict[int, tuple[dict[str, Any], dict[str, str]]],
+    bundle_cache: BundleCache,
 ) -> tuple[dict[str, Any], dict[str, str]]:
     """Bundle a parameter definition to make it self-contained."""
-    param_id = id(parameter)
-    if param_id in bundle_cache:
-        cached_definition, cached_name_to_uri = bundle_cache[param_id]
-        return deepclone(cached_definition), dict(cached_name_to_uri)
+    # Key on the parameter's resolved `$ref` URI
+    reference = parameter.get("$ref")
+    cache_key = resolve_reference_uri(resolver.base_uri, reference) if isinstance(reference, str) else None
+    if cache_key is not None:
+        cached = bundle_cache.get(cache_key)
+        if cached is not None:
+            cached_definition, cached_name_to_uri = cached
+            return deepclone(cached_definition), dict(cached_name_to_uri)
 
     parameter_resolver, definition = maybe_resolve_with_resolver(parameter, resolver)
     schema = definition.get("schema")
@@ -1606,7 +1610,8 @@ def _bundle_parameter(
 
     definition_ = cast(dict, definition)
     result = definition_, name_to_uri
-    bundle_cache[param_id] = (deepclone(definition_), dict(name_to_uri))
+    if cache_key is not None:
+        bundle_cache[cache_key] = (deepclone(definition_), dict(name_to_uri))
     return result
 
 

--- a/test/specs/openapi/test_schemas.py
+++ b/test/specs/openapi/test_schemas.py
@@ -189,3 +189,38 @@ def test_non_string_parameter_location(ctx):
     operation = schema["/test"]["PUT"]
     # Should not raise TypeError: unhashable type: 'dict'
     assert list(operation.iter_parameters()) == []
+
+
+def test_referenced_parameters_share_one_bundle_cache_entry(ctx):
+    # The bundle cache must key on the definition a parameter refers to, not on the
+    # identity of the dict that refers to it. Both operations below cite the same
+    # parameter, but each citation is a separate dict, so an `id()`-keyed cache stores
+    # two entries for one definition.
+    #
+    # That key is also unsound: it outlives the dict it names, and once the dict is
+    # freed CPython can reuse its address for an unrelated parameter, which then gets
+    # the wrong definition back -- silently dropping a path parameter and reporting a
+    # valid spec as invalid.
+    schema = ctx.openapi.load_schema(
+        {
+            "/alpha/{item_id}": {
+                "get": {
+                    "parameters": [{"$ref": "#/components/parameters/ItemId"}],
+                    "responses": {"200": {"description": "OK"}},
+                }
+            },
+            "/beta/{item_id}": {
+                "get": {
+                    "parameters": [{"$ref": "#/components/parameters/ItemId"}],
+                    "responses": {"200": {"description": "OK"}},
+                }
+            },
+        },
+        version="3.0.0",
+        components={
+            "parameters": {"ItemId": {"name": "item_id", "in": "path", "required": True, "schema": {"type": "string"}}}
+        },
+    )
+    list(schema.get_all_operations())
+
+    assert len(schema._bundle_cache) == 1


### PR DESCRIPTION
Fixes [#4414](https://github.com/schemathesis/schemathesis/issues/4414)

`_bundle_parameter` cached bundled parameter definitions in a dict keyed on
`id(parameter)` while keeping no reference to the dicts it keyed on. The cache
lives on the schema and outlives the parse that filled it, but parameter dicts
reached through a `$ref` are rebuilt on every parse and freed straight after.
CPython then reuses those addresses, a later parameter lands on a stale entry,
and the cache returns a different parameter's definition.

The affected operation loses its own path parameter. schemathesis creates
a placeholder injected in its place and adds this parameter to an unrelated
route. As a result, `create_test` reports `Path parameter '<name>' is not defined`
against a schema that declares it correctly. Because it is driven by allocator
behaviour, it varies run to run on a byte-identical schema with a pinned seed.

This keys on the parameter's resolved `$ref` URI instead — the definition itself 
rather than the object citing it. `resolve_reference_uri` already computes and 
memoises it, so the key is a cheap string. `maybe_resolve_with_resolver` follows 
the `$ref` chain and discards siblings, so the bundled result depends only on that 
URI. Inline parameters are not cached: they are unique to their operation, so there 
is nothing to share, and hashing their contents would cost more than the bundling 
it saves.

**It also makes the cache work.** `_bundle_parameter` is called with the citation.
The `{"$ref": ...}` dict inside each path item — not the definition it resolves to. 
Every citation is a distinct object, so twenty operations referencing one parameter 
produced twenty entries and no hits. Measured over 6 parses of a 68-operation 
schema (408 calls)

| key | hits |
|---|---|
| `id()` | 22 (5.4%), and most of those were the bug |
| resolved `$ref` URI | 300 (73.5%), all correct |

Parsing that schema goes from 0.122s to 0.056s over 6 parses. Also, the cache 
stops growing. For this test case, we had produced 379 entries after 6 parses. 
Now we maintain a stable 14 entries.

### Verification

- The reproduction in #4414 goes from 149–316 spurious injected path parameters to **0**.
- Parse output is byte-identical to running with the cache disabled entirely, across 3 parses of the schema that surfaced this.
- Full suite test results): **9740 passed 5 skipped, 3 xfailed, 378 warnings**. These are the same skipped and expected failures as HEAD of master. 

### Checklist

- [x] Added failing tests for the change
- [x] All new and existing tests pass
- [x] Added changelog entry
- [x] ~~Updated README/documentation, if necessary~~ no user-facing API change

### Note on the test

`test_referenced_parameters_share_one_bundle_cache_entry` asserts the invariant directly rather than trying to provoke address reuse, so it is deterministic and will not flake in CI. On `master` it fails with output that states the problem by itself — two integer keys holding identical values:

```
{4503752704: ({'name': 'item_id', 'in': 'path', 'required': True, 'schema': {'type': 'string'}}, {}),
 4503656832: ({'name': 'item_id', 'in': 'path', 'required': True, 'schema': {'type': 'string'}}, {})}
```

It sits directly below `test_non_string_parameter_location`, which already covers the `isinstance(location, str)` branch this bug exploited to make parameters disappear.