### PR TITLE
fix: Missing negative cases for parameter combinations when a parameter's schema uses `$ref`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Skipping a path parameter's only negative value, leaving the operation without negative cases.
 - Dropping the remaining wrong-type cases for a parameter once one type had no violation to send.
 - Generation hanging on a `maxLength` violation for a pattern whose repeated group spans two lengths.
+- Missing negative cases for parameter combinations when a parameter's schema uses `$ref`. [#4499](https://github.com/schemathesis/schemathesis/issues/4499)
 
 #### Others
 

--- a/src/schemathesis/specs/openapi/coverage/_operation.py
+++ b/src/schemathesis/specs/openapi/coverage/_operation.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, TypeGuard, cast
 
 from schemathesis.core import NOT_SET, NotSet, media_types
 from schemathesis.core.errors import InvalidSchema, MalformedMediaType
-from schemathesis.core.jsonschema import make_validator
+from schemathesis.core.jsonschema import BUNDLE_STORAGE_KEY, make_validator
 from schemathesis.core.media_types import FORM_MEDIA_TYPES, MEDIA_TYPE_STRATEGIES, find_media_type_strategy
 from schemathesis.core.parameters import CONTAINER_TO_LOCATION, ParameterLocation
 from schemathesis.core.timing import Instant
@@ -1008,15 +1008,25 @@ def iter_coverage_cases(
         def _combination_schema(
             combination: dict[str, Any], _required: set[str], _parameter_set: ParameterSet
         ) -> dict[str, Any]:
-            return {
-                "properties": {
-                    parameter.name: parameter.optimized_schema
-                    for parameter in _parameter_set
-                    if parameter.name in combination
-                },
+            properties = {
+                parameter.name: parameter.optimized_schema
+                for parameter in _parameter_set
+                if parameter.name in combination
+            }
+            schema: dict[str, Any] = {
+                "properties": properties,
                 "required": list(_required),
                 "additionalProperties": False,
             }
+            # Each parameter keeps its bundled definitions next to itself, but their references point at
+            # the document root - which is this schema, not the parameter it came from.
+            bundle: dict[str, Any] = {}
+            for property_schema in properties.values():
+                if isinstance(property_schema, dict):
+                    bundle.update(property_schema.get(BUNDLE_STORAGE_KEY) or {})
+            if bundle:
+                schema[BUNDLE_STORAGE_KEY] = bundle
+            return schema
 
         def _yield_negative(
             subschema: dict[str, Any], _location: ParameterLocation, is_required: bool

--- a/test/coverage/test_phase.py
+++ b/test/coverage/test_phase.py
@@ -9903,3 +9903,44 @@ def test_unique_items_array_is_not_filled_by_repetition(pctx):
 
     for value in cover_schema_iter(pctx, schema, HashSet()):
         assert len(set(value.value)) == len(value.value), value.value[:3]
+
+
+def test_ref_parameter_schema_keeps_combination_coverage(ctx):
+    # Parameter combinations are generated from a synthesized schema, where a `$ref` still has to resolve.
+    enum = {"type": "string", "enum": ["a", "b"]}
+
+    def descriptions(first, second):
+        raw = ctx.openapi.build_schema(
+            {
+                "/r": {
+                    "get": {
+                        "parameters": [
+                            {"name": "q", "in": "query", "required": True, "schema": first},
+                            {"name": "r", "in": "query", "required": False, "schema": second},
+                        ],
+                        "responses": {"default": {"description": "OK"}},
+                    }
+                }
+            },
+            components={"schemas": {"E": enum}},
+        )
+        operation = schemathesis.openapi.from_dict(raw)["/r"]["GET"]
+        return sorted(
+            case.meta.phase.data.description
+            for case in iter_coverage_cases(
+                operation=operation,
+                generation_modes=list(GenerationMode),
+                generate_duplicate_query_parameters=False,
+                unexpected_methods=set(),
+                generation_config=operation.schema.config.generation,
+            )
+        )
+
+    reference = {"$ref": "#/components/schemas/E"}
+    assert descriptions(
+        {"type": "object", "properties": {"t": reference}, "required": ["t"], "additionalProperties": False},
+        reference,
+    ) == descriptions(
+        {"type": "object", "properties": {"t": enum}, "required": ["t"], "additionalProperties": False},
+        enum,
+    )


### PR DESCRIPTION
Fixes #4499