### PR TITLE
fix: False positive `unsupported_method` when a templated path returns 404 instead of 405

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - Dropping the remaining wrong-type cases for a parameter once one type had no violation to send.
 - Generation hanging on a `maxLength` violation for a pattern whose repeated group spans two lengths.
 - Missing negative cases for parameter combinations when a parameter's schema uses `$ref`. [#4499](https://github.com/schemathesis/schemathesis/issues/4499)
+- False positive `unsupported_method` when a templated path returns 404 instead of 405. [#4503](https://github.com/schemathesis/schemathesis/issues/4503)
 
 #### Others
 

--- a/src/schemathesis/specs/openapi/checks.py
+++ b/src/schemathesis/specs/openapi/checks.py
@@ -824,6 +824,10 @@ def unsupported_method(ctx: CheckContext, response: Response, case: Case) -> boo
     data = meta.phase.data
     if data.scenario == CoverageScenario.UNSPECIFIED_HTTP_METHOD:
         if response.status_code != 405:
+            # Generated path parameters rarely point at an existing resource, and routing 404s before
+            # method dispatch. 405 is only guaranteed when the target resource exists.
+            if response.status_code == 404 and "{" in case.operation.path:
+                return None
             raise UnsupportedMethodResponse(
                 operation=case.operation.label,
                 method=cast(str, response.request.method),

--- a/test/cli/test_crash_handler.py
+++ b/test/cli/test_crash_handler.py
@@ -175,7 +175,7 @@ def test_crash_file_written_for_failures_in_errored_scenario(cli, ctx, tmp_path)
     checks = {
         check["name"] for f in crash_files for step in json.loads(f.read_text())["sequence"] for check in step["checks"]
     }
-    assert checks == {"status_code_conformance", "unsupported_method"}
+    assert checks == {"status_code_conformance"}
 
 
 def test_crash_file_uses_named_project_directory(cli, ctx, tmp_path):

--- a/test/specs/openapi/test_checks.py
+++ b/test/specs/openapi/test_checks.py
@@ -34,6 +34,7 @@ from schemathesis.specs.openapi.checks import (
     negative_data_rejection,
     positive_data_acceptance,
     response_schema_conformance,
+    unsupported_method,
     use_after_free,
 )
 from schemathesis.specs.openapi.negative.mutations import Mutation, MutationChannel
@@ -1654,3 +1655,55 @@ def test_use_after_free_skips_recreation_via_put(ctx, response_factory, put_stat
         response_checks=None,
     )
     assert use_after_free(check_context, put_response, put_case) is None
+
+
+@pytest.mark.parametrize(
+    ("path", "path_parameters", "status_code", "should_raise"),
+    [
+        ("/items/{item_id}", {"item_id": "42"}, 404, False),
+        ("/items/{item_id}", {"item_id": "42"}, 200, True),
+        ("/items", None, 404, True),
+    ],
+)
+def test_unsupported_method_404_on_templated_path(
+    ctx, response_factory, path, path_parameters, status_code, should_raise
+):
+    # A generated path parameter rarely points at an existing resource, so routing 404s before method dispatch.
+    parameters = (
+        [{"name": "item_id", "in": "path", "required": True, "schema": {"type": "string"}}] if path_parameters else []
+    )
+    schema = ctx.openapi.load_schema(
+        {path: {"get": {"parameters": parameters, "responses": {"200": {"description": "OK"}}}}}
+    )
+    operation = schema[path]["GET"]
+    case = operation.Case(
+        path_parameters=path_parameters,
+        _meta=CaseMetadata(
+            generation=GenerationInfo(time=0.1, mode=GenerationMode.NEGATIVE),
+            components={},
+            phase=PhaseInfo(
+                name=TestPhase.COVERAGE,
+                data=CoveragePhaseData(
+                    scenario=CoverageScenario.UNSPECIFIED_HTTP_METHOD,
+                    description="Unspecified HTTP method: POST",
+                    location=None,
+                    parameter=None,
+                    parameter_location=None,
+                ),
+            ),
+        ),
+    )
+    check_ctx = CheckContext(
+        override=None,
+        auth=None,
+        headers=None,
+        config=ChecksConfig(),
+        transport_kwargs=None,
+        response_checks=None,
+    )
+    response = response_factory.requests(status_code=status_code)
+    if should_raise:
+        with pytest.raises(Failure):
+            unsupported_method(check_ctx, response, case)
+    else:
+        assert unsupported_method(check_ctx, response, case) is None


### PR DESCRIPTION
Fixes #4503 