### PR TITLE
fix: Empty strings generated for query parameters declaring `allowEmptyValue: false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Coverage phase ignoring `prefixItems` when building array cases for OpenAPI 3.1 operations.
 - Coverage phase dropping a required name `properties` does not declare from generated array items.
 - Generation failing for an OpenAPI 3.0 `pattern` that names a capture group.
+- Empty strings generated for query parameters declaring `allowEmptyValue: false`. [#4574](https://github.com/schemathesis/schemathesis/issues/4574)
 
 ## [4.25.2](https://github.com/schemathesis/schemathesis/compare/v4.25.1...v4.25.2) - 2026-08-24
 

--- a/src/schemathesis/specs/openapi/adapter/parameters.py
+++ b/src/schemathesis/specs/openapi/adapter/parameters.py
@@ -1140,6 +1140,18 @@ class OpenApiParameter(OpenApiComponent):
             and schema.get("maxItems", 1) >= 1
         ):
             schema = {**schema, "minItems": 1}
+        # An explicit `allowEmptyValue: false` forbids sending the parameter with an empty value.
+        # The default is not applied — it would strip empty strings from every query parameter,
+        # and most schemas that omit the keyword do accept them.
+        if (
+            self.definition.get("allowEmptyValue") is False
+            and self.location is ParameterLocation.QUERY
+            and isinstance(schema, dict)
+            and schema.get("type") == "string"
+            and schema.get("minLength", 0) < 1
+            and schema.get("maxLength", 1) >= 1
+        ):
+            schema = {**schema, "minLength": 1}
         return schema
 
     def _get_raw_schema(self) -> JsonSchema:

--- a/test/specs/openapi/test_hypothesis.py
+++ b/test/specs/openapi/test_hypothesis.py
@@ -157,6 +157,35 @@ def test_required_array_parameter_is_non_empty(ctx, location):
     test()
 
 
+def test_allow_empty_value_false_excludes_empty_string(ctx):
+    # `allowEmptyValue: false` forbids sending `?name=`, so an empty string is not a positive value.
+    schema = ctx.openapi.load_schema(
+        {
+            "/data": {
+                "get": {
+                    "parameters": [
+                        {
+                            "in": "query",
+                            "name": "name",
+                            "required": True,
+                            "allowEmptyValue": False,
+                            "schema": {"type": "string"},
+                        }
+                    ],
+                    "responses": {"200": {"description": "OK"}},
+                }
+            }
+        }
+    )
+
+    @given(schema["/data"]["GET"].as_strategy(generation_mode=GenerationMode.POSITIVE))
+    @settings(max_examples=25)
+    def test(case):
+        assert case.query["name"] != "", "Empty value generated for `allowEmptyValue: false`"
+
+    test()
+
+
 def test_inlined_definitions(deeply_nested_schema):
     # See GH-1162
     # When not resolved references are present in the schema during constructing a strategy


### PR DESCRIPTION
Fixes #4574 