### PR TITLE
fix: False positive `negative_data_rejection` for non-numeric query and path parameters whose serialized value is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Coverage phase emitting properties whose names `propertyNames` rejects.
 - Coverage phase emitting a `multipleOf` value outside the float bound `minimum` and `maximum` pin.
 - Coverage phase emitting a single-item array that exceeds `maxContains`.
+- False positive `negative_data_rejection` for non-numeric query and path parameters whose serialized value is valid. [#4600](https://github.com/schemathesis/schemathesis/issues/4600)
 
 ## [4.25.2](https://github.com/schemathesis/schemathesis/compare/v4.25.1...v4.25.2) - 2026-08-24
 

--- a/src/schemathesis/specs/openapi/adapter/parameters.py
+++ b/src/schemathesis/specs/openapi/adapter/parameters.py
@@ -16,7 +16,6 @@ from schemathesis.core import NOT_SET, NotSet
 from schemathesis.core.adapter import OperationParameter
 from schemathesis.core.errors import InvalidSchema
 from schemathesis.core.jsonschema import (
-    FANCY_REGEX_OPTIONS,
     VALIDATED_FORMATS_BY_DRAFT,
     BundleError,
     Bundler,
@@ -1907,9 +1906,7 @@ class OpenApiParameterSet(ParameterSet):
 
     def get_strict_validator(self) -> jsonschema_rs.Validator:
         if isinstance(self._strict_validator, NotSet):
-            self._strict_validator = self.adapter.jsonschema_validator_cls(
-                self.schema, validate_formats=True, pattern_options=FANCY_REGEX_OPTIONS
-            )
+            self._strict_validator = make_validator(self.schema, self.adapter.jsonschema_validator_cls)
         return self._strict_validator
 
     @property

--- a/src/schemathesis/specs/openapi/checks.py
+++ b/src/schemathesis/specs/openapi/checks.py
@@ -13,7 +13,7 @@ import schemathesis
 from schemathesis.checks import CheckContext, CheckFunction
 from schemathesis.core import media_types, string_to_boolean
 from schemathesis.core.failures import AcceptedNegativeData, Failure
-from schemathesis.core.jsonschema import BUNDLE_STORAGE_KEY, FANCY_REGEX_OPTIONS, get_type, make_validator
+from schemathesis.core.jsonschema import BUNDLE_STORAGE_KEY, get_type, make_validator
 from schemathesis.core.jsonschema.types import JsonSchema
 from schemathesis.core.mutations import OperatorKind
 from schemathesis.core.parameters import ParameterLocation, plain_str_values
@@ -48,7 +48,7 @@ from schemathesis.transport.serialization import contains_binary
 if TYPE_CHECKING:
     from schemathesis.engine.recorder import RecordedScenario
     from schemathesis.schemas import APIOperation
-    from schemathesis.specs.openapi.adapter.parameters import OpenApiParameterSet
+    from schemathesis.specs.openapi.adapter.parameters import OpenApiParameter, OpenApiParameterSet
     from schemathesis.specs.openapi.schemas import OpenApiSchema
 
 
@@ -411,7 +411,7 @@ def _single_element_array_becomes_valid_after_serialization(case: Case) -> bool:
             # for the full original schema (including enum, minimum, pattern, etc.),
             # some frameworks may accept the request by picking that element.
             try:
-                validator = param.adapter.jsonschema_validator_cls(schema, pattern_options=FANCY_REGEX_OPTIONS)
+                validator = make_validator(schema, param.adapter.jsonschema_validator_cls)
             except Exception:
                 return True
             for element in param_value:
@@ -426,6 +426,18 @@ def _single_element_array_becomes_valid_after_serialization(case: Case) -> bool:
                         return True
 
     return False
+
+
+def _wire_value_matches_parameter(parameter: OpenApiParameter, expected_types: list[str], wire_value: str) -> bool:
+    """Check whether the text actually sent for `parameter` satisfies its original schema."""
+    if _coerce_string_to_numeric(wire_value, expected_types) is not None:
+        return True
+    try:
+        validator = make_validator(parameter.validation_schema, parameter.adapter.jsonschema_validator_cls)
+    except Exception:
+        # Schema rejected by jsonschema_rs - validity is unknown, so don't report a failure.
+        return True
+    return validator.is_valid(wire_value)
 
 
 def _string_type_mutation_becomes_valid_after_serialization(case: Case, location: ParameterLocation) -> bool:
@@ -488,15 +500,17 @@ def _string_type_mutation_becomes_valid_after_serialization(case: Case, location
             continue
         expected_types = get_type(parameter.definition.get("schema", {}))
 
-        if isinstance(value, str):
+        if isinstance(value, (str, int, float)):
+            wire_value = value if isinstance(value, str) else str(value)
             # Path parameters are URL-encoded; decode before parsing.
-            parsed_value = unquote(value) if location == ParameterLocation.PATH else value
-            if _coerce_string_to_numeric(parsed_value, expected_types) is not None:
+            if location == ParameterLocation.PATH:
+                wire_value = unquote(wire_value)
+            if _wire_value_matches_parameter(parameter, expected_types, wire_value):
                 return True
         elif location == ParameterLocation.QUERY and isinstance(value, dict):
             # urlencode(doseq=True) iterates over dict keys, producing one query value per key.
-            # e.g. {"5": "x"} becomes ?page_size=5, which is integer-parseable.
-            if any(_coerce_string_to_numeric(str(key), expected_types) is not None for key in value):
+            # e.g. {"5": "x"} becomes ?page_size=5, which the server sees as a valid integer.
+            if any(_wire_value_matches_parameter(parameter, expected_types, str(key)) for key in value):
                 return True
 
     return False
@@ -740,7 +754,7 @@ def _additional_properties_hint(case: Case) -> str | None:
         # `format: binary` fields hold raw bytes the JSON Schema validator cannot accept.
         if contains_binary(stripped):
             return None
-        if not validator_cls(alternative.optimized_schema, pattern_options=FANCY_REGEX_OPTIONS).is_valid(stripped):
+        if not make_validator(alternative.optimized_schema, validator_cls).is_valid(stripped):
             return None
 
         count = len(extra)
@@ -961,9 +975,7 @@ def has_only_additional_properties_in_non_body_parameters(case: Case) -> bool:
 
             value_without_additional_properties = {k: v for k, v in value.items() if k in container}
             try:
-                is_valid = validator_cls(schema, pattern_options=FANCY_REGEX_OPTIONS).is_valid(
-                    value_without_additional_properties
-                )
+                is_valid = make_validator(schema, validator_cls).is_valid(value_without_additional_properties)
             except Exception:
                 # Schema has an invalid pattern (e.g., valid Python regex but invalid ECMA 262)
                 # — can't determine validity, so skip this location

--- a/test/specs/openapi/test_checks.py
+++ b/test/specs/openapi/test_checks.py
@@ -1103,6 +1103,57 @@ def test_negative_data_rejection_query_object_mutation_with_numeric_key(ctx, res
     )
 
 
+@pytest.mark.parametrize(
+    ("value", "reported"),
+    [
+        ({"7": "x"}, False),
+        (7, False),
+        (True, False),
+        ({"a b": "x"}, True),
+    ],
+    ids=["object-collapse-valid", "scalar-valid", "boolean-valid", "object-collapse-invalid"],
+)
+def test_negative_data_rejection_query_string_parameter_wire_form(ctx, response_factory, value, reported):
+    # A wrong-typed query value can still reach the server as text that satisfies the declared schema.
+    schema = ctx.openapi.load_schema(
+        {
+            "/api/items": {
+                "get": {
+                    "parameters": [
+                        {
+                            "name": "kind",
+                            "in": "query",
+                            "required": True,
+                            "schema": {"type": "string", "minLength": 1, "maxLength": 100, "pattern": "^\\S+$"},
+                        }
+                    ],
+                    "responses": {"200": {"description": "Success"}, "400": {"description": "Bad Request"}},
+                }
+            }
+        }
+    )
+
+    operation = schema["/api/items"]["GET"]
+
+    case = operation.Case(
+        _meta=build_metadata(
+            query=GenerationMode.NEGATIVE,
+            generation_modes=[GenerationMode.NEGATIVE],
+            description="Invalid type object (expected string)",
+            parameter="kind",
+            parameter_location=ParameterLocation.QUERY,
+        ),
+        query={"kind": value},
+    )
+    response = response_factory.requests(status_code=200)
+
+    if reported:
+        with pytest.raises(AcceptedNegativeData):
+            negative_data_rejection(check_context(), response, case)
+    else:
+        assert negative_data_rejection(check_context(), response, case) is None
+
+
 def test_negative_data_rejection_path_string_numeric_serialization(ctx, response_factory):
     schema = ctx.openapi.load_schema(
         {


### PR DESCRIPTION
Fixes #4600 