### PR TITLE
perf: Coverage phase ~270x faster on strings declaring `format`, `pattern`, and a length bound together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 - `missing_test_data` warning tips reflect whether links reach the operation and whether stateful testing ran.
 - Reports record response bodies larger than 1 MiB as a prefix with the original size.
 
+### :racing_car: Performance
+
+- Coverage phase ~270x faster on strings declaring `format`, `pattern`, and a length bound together. [#4593](https://github.com/schemathesis/schemathesis/issues/4593)
+
 ### :bug: Fixed
 
 #### WFC authentication

--- a/benches/coverage_phase.py
+++ b/benches/coverage_phase.py
@@ -76,9 +76,15 @@ def test_string_constraints(benchmark, ctx, schema):
     benchmark(lambda: list(cover_schema_iter(ctx, schema)))
 
 
+EMAIL_PATTERN = (
+    r"^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*"
+    r"@(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$"
+)
+
 PATTERN_WITH_LENGTH_CONSTRAINTS = [
     {"type": "string", "pattern": "^[a-z]+$", "minLength": 3, "maxLength": 10},
     {"type": "string", "pattern": r"^\w{2,4}:\d{3,5}:[A-F]{1,2}$", "minLength": 10, "maxLength": 10},
+    {"type": "string", "format": "email", "pattern": EMAIL_PATTERN, "maxLength": 254},
 ]
 
 

--- a/src/schemathesis/specs/openapi/coverage/_schema.py
+++ b/src/schemathesis/specs/openapi/coverage/_schema.py
@@ -867,6 +867,7 @@ class CoverageContext:
                     raise Unsatisfiable
                 min_length = schema.get("minLength")
                 max_length = schema.get("maxLength")
+                length_is_pinned = False
                 if min_length is not None or max_length is not None:
                     pattern_min, pattern_max = pattern_length_bounds(pattern)
                     if max_length is not None and max_length < pattern_min:
@@ -887,16 +888,25 @@ class CoverageContext:
                         pinned = pin_pattern_length(pattern, min_length, max_length)
                         if pinned != pattern:
                             updated = pinned
+                            length_is_pinned = True
                     pattern = updated
                 if min_length is not None and min_length > MAX_GENERATED_PATTERN_LENGTH:
                     return self._long_string_matching(schema, min_length)
                 fmt = schema.get("format")
+                validated = fmt if fmt in VALIDATED_FORMATS else None
+                # Spelling the length into the pattern fixes the shape of every match, so a format the
+                # first match fails is one no redraw satisfies; checking once beats searching for it.
                 strategy = _pattern_strategy(
-                    self.session, pattern, min_length, max_length, fmt if fmt in VALIDATED_FORMATS else None
+                    self.session, pattern, min_length, max_length, None if length_is_pinned else validated
                 )
                 if strategy is None:
                     raise Unsatisfiable from None
-                return cached_draw(self.session, strategy)
+                value = cached_draw(self.session, strategy)
+                if length_is_pinned and validated is not None:
+                    validator = _get_format_validator(self.session, validated, self.validator_cls)
+                    if not validator.is_valid(value):
+                        raise Unsatisfiable
+                return value
             if (
                 isinstance(min_properties, int)
                 and min_properties > MAX_DRAWN_OBJECT_PROPERTIES


### PR DESCRIPTION
Resolves #4593